### PR TITLE
Fix #14: base-path aware links/static generation and prefix routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ bash examples/curl_examples.sh
 | `SOBS_BASIC_AUTH_USERNAME`  | _(empty)_      | Optional Basic Auth username for the Web UI      |
 | `SOBS_BASIC_AUTH_PASSWORD`  | _(empty)_      | Optional Basic Auth password for the Web UI      |
 | `SOBS_EXTERNAL_AUTH_URL`    | _(empty)_      | Optional external Bearer validator for the Web UI |
+| `SOBS_BASE_PATH`            | _(empty)_      | Optional URL prefix (for example `/sobs`) for UI/API routing and generated links |
 | `PORT`                      | `4317`         | Listen port                                      |
 | `FLASK_DEBUG`               | `0`            | Enable Flask debug mode                          |
 
@@ -106,6 +107,8 @@ The Web UI supports exactly one mode at a time:
 - external bearer validation (`SOBS_EXTERNAL_AUTH_URL`)
 
 Ingest API endpoints (`/v1/*`) use the separate `SOBS_API_KEY` mechanism.
+
+For reverse proxies, SOBS also honors `X-Forwarded-Prefix` for URL generation and prefixed routing.
 
 ## Kubernetes
 

--- a/app.py
+++ b/app.py
@@ -31,6 +31,67 @@ from flask import (
 # ---------------------------------------------------------------------------
 app = Flask(__name__)
 
+
+def _normalize_base_path(value: str) -> str:
+    """Normalize base path values to either '' or '/segment[/subsegment]'."""
+    if not value:
+        return ""
+    normalized = re.sub(r"/+", "/", str(value).strip())
+    if not normalized or normalized == "/":
+        return ""
+    if not normalized.startswith("/"):
+        normalized = "/" + normalized
+    normalized = normalized.rstrip("/")
+    return normalized if normalized != "/" else ""
+
+
+def _merge_script_name(script_name: str, base_path: str) -> str:
+    """Append base path to SCRIPT_NAME once."""
+    if not base_path:
+        return script_name or ""
+    current = script_name or ""
+    if current.endswith(base_path):
+        return current
+    if not current:
+        return base_path
+    return current.rstrip("/") + base_path
+
+
+BASE_PATH = _normalize_base_path(os.environ.get("SOBS_BASE_PATH", ""))
+app.config["APPLICATION_ROOT"] = BASE_PATH or "/"
+
+
+class BasePathMiddleware:
+    """Support deployment behind a path prefix and reverse-proxy prefix headers."""
+
+    def __init__(self, wrapped_app):
+        self.wrapped_app = wrapped_app
+
+    def __call__(self, environ, start_response):
+        forwarded = _normalize_base_path(environ.get("HTTP_X_FORWARDED_PREFIX", ""))
+        effective_base = forwarded or BASE_PATH
+
+        if effective_base:
+            path_info = environ.get("PATH_INFO", "") or "/"
+            script_name = environ.get("SCRIPT_NAME", "")
+
+            # Proxy kept the base path in PATH_INFO: strip it for route matching.
+            if path_info == effective_base:
+                environ["SCRIPT_NAME"] = _merge_script_name(script_name, effective_base)
+                environ["PATH_INFO"] = "/"
+            elif path_info.startswith(effective_base + "/"):
+                environ["SCRIPT_NAME"] = _merge_script_name(script_name, effective_base)
+                trimmed = path_info[len(effective_base) :]
+                environ["PATH_INFO"] = trimmed or "/"
+            else:
+                # Proxy already stripped prefix; still publish it for url_for generation.
+                environ["SCRIPT_NAME"] = _merge_script_name(script_name, effective_base)
+
+        return self.wrapped_app(environ, start_response)
+
+
+app.wsgi_app = BasePathMiddleware(app.wsgi_app)  # type: ignore[method-assign]
+
 DATA_DIR = os.environ.get("SOBS_DATA_DIR", os.path.join(os.path.dirname(__file__), "data"))
 DB_PATH = os.path.join(DATA_DIR, "sobs.db")
 API_KEY = os.environ.get("SOBS_API_KEY", "")  # empty = no auth required

--- a/templates/ai.html
+++ b/templates/ai.html
@@ -58,7 +58,7 @@
       </div>
       <div class="col-md-2 d-flex gap-1">
         <button type="submit" class="btn btn-primary btn-sm">Filter</button>
-        <a href="/ai" class="btn btn-outline-secondary btn-sm">Reset</a>
+        <a href="{{ url_for('view_ai') }}" class="btn btn-outline-secondary btn-sm">Reset</a>
       </div>
     </form>
   </div>
@@ -101,7 +101,7 @@
           <span><strong>Tokens out:</strong> {{ item.tokens_out }}</span>
           <span><strong>Duration:</strong> {{ item.duration_ms }}ms</span>
           {% if item.trace_id %}
-          <a href="/traces?trace_id={{ item.trace_id }}" class="trace-link">
+          <a href="{{ url_for('view_traces', trace_id=item.trace_id) }}" class="trace-link">
             Trace {{ item.trace_id[:12] }}…
           </a>
           {% endif %}
@@ -120,12 +120,12 @@
   <ul class="pagination pagination-sm mb-0">
     {% if offset > 0 %}
     <li class="page-item">
-      <a class="page-link" href="?service={{ service }}&model={{ model }}&limit={{ limit }}&offset={{ prev_offset }}">← Prev</a>
+      <a class="page-link" href="{{ url_for('view_ai', service=service, model=model, limit=limit, offset=prev_offset) }}">← Prev</a>
     </li>
     {% endif %}
     {% if next_offset < total %}
     <li class="page-item">
-      <a class="page-link" href="?service={{ service }}&model={{ model }}&limit={{ limit }}&offset={{ next_offset }}">Next →</a>
+      <a class="page-link" href="{{ url_for('view_ai', service=service, model=model, limit=limit, offset=next_offset) }}">Next →</a>
     </li>
     {% endif %}
   </ul>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}SOBS{% endblock %} — Simple Observe</title>
-  <link rel="stylesheet" href="/static/bootstrap.min.css">
-  <link rel="stylesheet" href="/static/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap-icons.min.css') }}">
   <style>
     body { font-size: .9rem; }
     .nav-link.active { font-weight: 600; }
@@ -33,38 +33,38 @@
 <div class="d-flex">
   <!-- Sidebar -->
   <nav class="sidebar d-flex flex-column p-3" style="width:220px;flex-shrink:0;">
-    <a href="/" class="text-decoration-none mb-4 d-flex align-items-center gap-2">
+    <a href="{{ url_for('dashboard') }}" class="text-decoration-none mb-4 d-flex align-items-center gap-2">
       <span style="font-size:1.4rem;">🔭</span>
       <span class="fw-bold fs-5 text-white">SOBS</span>
     </a>
     <ul class="nav flex-column gap-1">
       <li class="nav-item">
-        <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">
+        <a href="{{ url_for('dashboard') }}" class="nav-link {% if request.endpoint == 'dashboard' %}active{% endif %}">
           <i class="bi bi-speedometer2"></i> Dashboard
         </a>
       </li>
       <li class="nav-item">
-        <a href="/logs" class="nav-link {% if request.path == '/logs' %}active{% endif %}">
+        <a href="{{ url_for('view_logs') }}" class="nav-link {% if request.endpoint == 'view_logs' %}active{% endif %}">
           <i class="bi bi-journal-text"></i> Logs
         </a>
       </li>
       <li class="nav-item">
-        <a href="/errors" class="nav-link {% if request.path == '/errors' %}active{% endif %}">
+        <a href="{{ url_for('view_errors') }}" class="nav-link {% if request.endpoint == 'view_errors' %}active{% endif %}">
           <i class="bi bi-bug"></i> Errors
         </a>
       </li>
       <li class="nav-item">
-        <a href="/traces" class="nav-link {% if request.path == '/traces' %}active{% endif %}">
+        <a href="{{ url_for('view_traces') }}" class="nav-link {% if request.endpoint == 'view_traces' %}active{% endif %}">
           <i class="bi bi-diagram-3"></i> Traces
         </a>
       </li>
       <li class="nav-item">
-        <a href="/rum" class="nav-link {% if request.path == '/rum' %}active{% endif %}">
+        <a href="{{ url_for('view_rum') }}" class="nav-link {% if request.endpoint == 'view_rum' %}active{% endif %}">
           <i class="bi bi-globe"></i> RUM
         </a>
       </li>
       <li class="nav-item">
-        <a href="/ai" class="nav-link {% if request.path == '/ai' %}active{% endif %}">
+        <a href="{{ url_for('view_ai') }}" class="nav-link {% if request.endpoint == 'view_ai' %}active{% endif %}">
           <i class="bi bi-cpu"></i> AI
         </a>
       </li>
@@ -88,7 +88,7 @@
   </div>
 </div>
 
-<script src="/static/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='bootstrap.bundle.min.js') }}"></script>
 {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,7 +6,7 @@
 <!-- Stats row -->
 <div class="row g-3 mb-4">
   <div class="col-6 col-md-4 col-lg-2">
-    <a href="/logs" class="text-decoration-none">
+    <a href="{{ url_for('view_logs') }}" class="text-decoration-none">
       <div class="stat-card p-3 text-center">
         <div class="fs-2 fw-bold text-info">{{ stats.logs }}</div>
         <div class="text-secondary small">Logs</div>
@@ -14,7 +14,7 @@
     </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <a href="/errors" class="text-decoration-none">
+    <a href="{{ url_for('view_errors') }}" class="text-decoration-none">
       <div class="stat-card p-3 text-center">
         <div class="fs-2 fw-bold {% if stats.errors > 0 %}text-danger{% else %}text-success{% endif %}">{{ stats.errors }}</div>
         <div class="text-secondary small">Open Errors</div>
@@ -22,7 +22,7 @@
     </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <a href="/traces" class="text-decoration-none">
+    <a href="{{ url_for('view_traces') }}" class="text-decoration-none">
       <div class="stat-card p-3 text-center">
         <div class="fs-2 fw-bold text-warning">{{ stats.spans }}</div>
         <div class="text-secondary small">Spans</div>
@@ -30,7 +30,7 @@
     </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <a href="/rum" class="text-decoration-none">
+    <a href="{{ url_for('view_rum') }}" class="text-decoration-none">
       <div class="stat-card p-3 text-center">
         <div class="fs-2 fw-bold text-primary">{{ stats.rum }}</div>
         <div class="text-secondary small">RUM Events</div>
@@ -38,7 +38,7 @@
     </a>
   </div>
   <div class="col-6 col-md-4 col-lg-2">
-    <a href="/ai" class="text-decoration-none">
+    <a href="{{ url_for('view_ai') }}" class="text-decoration-none">
       <div class="stat-card p-3 text-center">
         <div class="fs-2 fw-bold text-success">{{ stats.ai }}</div>
         <div class="text-secondary small">AI Calls</div>
@@ -59,7 +59,7 @@
     <div class="card border-secondary">
       <div class="card-header d-flex justify-content-between align-items-center">
         <span><i class="bi bi-bug me-1 text-danger"></i>Recent Open Errors</span>
-        <a href="/errors" class="btn btn-sm btn-outline-secondary">View all</a>
+        <a href="{{ url_for('view_errors') }}" class="btn btn-sm btn-outline-secondary">View all</a>
       </div>
       <div class="card-body p-0">
         {% if recent_errors %}
@@ -87,7 +87,7 @@
     <div class="card border-secondary">
       <div class="card-header d-flex justify-content-between align-items-center">
         <span><i class="bi bi-journal-text me-1 text-info"></i>Recent Logs</span>
-        <a href="/logs" class="btn btn-sm btn-outline-secondary">View all</a>
+        <a href="{{ url_for('view_logs') }}" class="btn btn-sm btn-outline-secondary">View all</a>
       </div>
       <div class="card-body p-0">
         {% if recent_logs %}
@@ -123,7 +123,7 @@
           <tbody>
             {% for row in rum_summary %}
             <tr>
-              <td><a href="/rum?type={{ row[0] }}">{{ row[0] }}</a></td>
+              <td><a href="{{ url_for('view_rum', type=row[0]) }}">{{ row[0] }}</a></td>
               <td class="fw-semibold">{{ row[1] }}</td>
             </tr>
             {% endfor %}

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -29,7 +29,7 @@
       </div>
       <div class="col-md-2 d-flex gap-1">
         <button type="submit" class="btn btn-primary btn-sm">Filter</button>
-        <a href="/errors" class="btn btn-outline-secondary btn-sm">Reset</a>
+        <a href="{{ url_for('view_errors') }}" class="btn btn-outline-secondary btn-sm">Reset</a>
       </div>
     </form>
   </div>
@@ -60,12 +60,12 @@
         {% endif %}
         <div class="d-flex gap-2 mt-2">
           {% if err.trace_id %}
-          <a href="/traces?trace_id={{ err.trace_id }}" class="btn btn-sm btn-outline-info">
+          <a href="{{ url_for('view_traces', trace_id=err.trace_id) }}" class="btn btn-sm btn-outline-info">
             <i class="bi bi-diagram-3 me-1"></i>Trace
           </a>
           {% endif %}
           {% if not err.resolved %}
-          <button class="btn btn-sm btn-outline-success resolve-btn" data-id="{{ err.id }}">
+          <button class="btn btn-sm btn-outline-success resolve-btn" data-resolve-url="{{ url_for('resolve_error', error_id=err.id) }}">
             <i class="bi bi-check2 me-1"></i>Resolve
           </button>
           {% endif %}
@@ -84,12 +84,12 @@
   <ul class="pagination pagination-sm mb-0">
     {% if offset > 0 %}
     <li class="page-item">
-      <a class="page-link" href="?service={{ service }}&resolved={{ resolved }}&limit={{ limit }}&offset={{ prev_offset }}">← Prev</a>
+      <a class="page-link" href="{{ url_for('view_errors', service=service, resolved=resolved, limit=limit, offset=prev_offset) }}">← Prev</a>
     </li>
     {% endif %}
     {% if next_offset < total %}
     <li class="page-item">
-      <a class="page-link" href="?service={{ service }}&resolved={{ resolved }}&limit={{ limit }}&offset={{ next_offset }}">Next →</a>
+      <a class="page-link" href="{{ url_for('view_errors', service=service, resolved=resolved, limit=limit, offset=next_offset) }}">Next →</a>
     </li>
     {% endif %}
   </ul>
@@ -105,8 +105,7 @@
 <script>
 document.querySelectorAll('.resolve-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
-    const id = btn.dataset.id;
-    const res = await fetch(`/errors/${id}/resolve`, {method: 'POST'});
+    const res = await fetch(btn.dataset.resolveUrl, {method: 'POST'});
     if (res.ok) {
       btn.closest('.accordion-item').querySelectorAll('.badge').forEach(b => {
         if (b.classList.contains('bg-danger')) { b.classList.replace('bg-danger', 'bg-success'); b.textContent = 'Resolved'; }

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -41,7 +41,7 @@
         <button type="submit" class="btn btn-primary btn-sm flex-grow-1">
           <i class="bi bi-search"></i>
         </button>
-        <a href="/logs" class="btn btn-outline-secondary btn-sm"><i class="bi bi-x"></i></a>
+        <a href="{{ url_for('view_logs') }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-x"></i></a>
       </div>
     </form>
     {% if error_msg %}
@@ -71,7 +71,7 @@
         <td class="log-body">{{ log.body }}</td>
         <td>
           {% if log.trace_id %}
-          <a href="/traces?trace_id={{ log.trace_id }}" class="trace-link text-truncate d-inline-block" style="max-width:110px;" title="{{ log.trace_id }}">
+          <a href="{{ url_for('view_traces', trace_id=log.trace_id) }}" class="trace-link text-truncate d-inline-block" style="max-width:110px;" title="{{ log.trace_id }}">
             {{ log.trace_id[:12] }}…
           </a>
           {% endif %}
@@ -90,12 +90,12 @@
   <ul class="pagination pagination-sm mb-0">
     {% if offset > 0 %}
     <li class="page-item">
-      <a class="page-link" href="?q={{ q }}&level={{ level }}&service={{ service }}&sql={{ sql_where }}&limit={{ limit }}&offset={{ prev_offset }}">← Prev</a>
+      <a class="page-link" href="{{ url_for('view_logs', q=q, level=level, service=service, sql=sql_where, limit=limit, offset=prev_offset) }}">← Prev</a>
     </li>
     {% endif %}
     {% if next_offset < total %}
     <li class="page-item">
-      <a class="page-link" href="?q={{ q }}&level={{ level }}&service={{ service }}&sql={{ sql_where }}&limit={{ limit }}&offset={{ next_offset }}">Next →</a>
+      <a class="page-link" href="{{ url_for('view_logs', q=q, level=level, service=service, sql=sql_where, limit=limit, offset=next_offset) }}">Next →</a>
     </li>
     {% endif %}
   </ul>

--- a/templates/rum.html
+++ b/templates/rum.html
@@ -40,7 +40,7 @@
       </div>
       <div class="col-md-2 d-flex gap-1">
         <button type="submit" class="btn btn-primary btn-sm">Filter</button>
-        <a href="/rum" class="btn btn-outline-secondary btn-sm">Reset</a>
+        <a href="{{ url_for('view_rum') }}" class="btn btn-outline-secondary btn-sm">Reset</a>
       </div>
     </form>
   </div>
@@ -92,12 +92,12 @@
   <ul class="pagination pagination-sm mb-0">
     {% if offset > 0 %}
     <li class="page-item">
-      <a class="page-link" href="?type={{ event_type }}&limit={{ limit }}&offset={{ prev_offset }}">← Prev</a>
+      <a class="page-link" href="{{ url_for('view_rum', type=event_type, limit=limit, offset=prev_offset) }}">← Prev</a>
     </li>
     {% endif %}
     {% if next_offset < total %}
     <li class="page-item">
-      <a class="page-link" href="?type={{ event_type }}&limit={{ limit }}&offset={{ next_offset }}">Next →</a>
+      <a class="page-link" href="{{ url_for('view_rum', type=event_type, limit=limit, offset=next_offset) }}">Next →</a>
     </li>
     {% endif %}
   </ul>
@@ -105,7 +105,7 @@
 {% else %}
 <div class="text-center py-5 text-secondary">
   <i class="bi bi-globe" style="font-size:2rem;"></i>
-  <p class="mt-2">No RUM events yet. Embed the <a href="/static/rum.js">rum.js</a> snippet in your app.</p>
+  <p class="mt-2">No RUM events yet. Embed the <a href="{{ url_for('static', filename='rum.js') }}">rum.js</a> snippet in your app.</p>
 </div>
 {% endif %}
 

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -26,7 +26,7 @@
       </div>
       <div class="col-md-2 d-flex gap-1">
         <button type="submit" class="btn btn-primary btn-sm">Filter</button>
-        <a href="/traces" class="btn btn-outline-secondary btn-sm">Reset</a>
+        <a href="{{ url_for('view_traces') }}" class="btn btn-outline-secondary btn-sm">Reset</a>
       </div>
     </form>
   </div>
@@ -70,7 +70,7 @@
         <td class="small text-secondary">{{ span.http_method }}</td>
         <td class="small">{% if span.http_status %}<span class="badge {% if span.http_status|string >= '500' %}bg-danger{% elif span.http_status|string >= '400' %}bg-warning text-dark{% else %}bg-success{% endif %}">{{ span.http_status }}</span>{% endif %}</td>
         <td>
-          <a href="/traces?trace_id={{ span.trace_id }}" class="trace-link text-truncate d-inline-block" style="max-width:120px;" title="{{ span.trace_id }}">
+          <a href="{{ url_for('view_traces', trace_id=span.trace_id) }}" class="trace-link text-truncate d-inline-block" style="max-width:120px;" title="{{ span.trace_id }}">
             {{ span.trace_id[:12] if span.trace_id else '—' }}{% if span.trace_id %}…{% endif %}
           </a>
         </td>
@@ -88,12 +88,12 @@
   <ul class="pagination pagination-sm mb-0">
     {% if offset > 0 %}
     <li class="page-item">
-      <a class="page-link" href="?service={{ service }}&trace_id={{ trace_id }}&limit={{ limit }}&offset={{ prev_offset }}">← Prev</a>
+      <a class="page-link" href="{{ url_for('view_traces', service=service, trace_id=trace_id, limit=limit, offset=prev_offset) }}">← Prev</a>
     </li>
     {% endif %}
     {% if next_offset < total %}
     <li class="page-item">
-      <a class="page-link" href="?service={{ service }}&trace_id={{ trace_id }}&limit={{ limit }}&offset={{ next_offset }}">Next →</a>
+      <a class="page-link" href="{{ url_for('view_traces', service=service, trace_id=trace_id, limit=limit, offset=next_offset) }}">Next →</a>
     </li>
     {% endif %}
   </ul>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -418,6 +418,44 @@ class TestUIPages:
         assert r.status_code == 200
         assert b"SQL error" in r.data
 
+    def test_root_mode_uses_root_relative_links(self, client):
+        """Default deployment should generate links/assets without a path prefix."""
+        r = client.get("/")
+        assert r.status_code == 200
+        assert b'href="/logs"' in r.data
+        assert b'href="/errors"' in r.data
+        assert b'src="/static/bootstrap.bundle.min.js"' in r.data
+
+
+class TestBasePathSupport:
+    def test_prefixed_mode_routes_and_generates_prefixed_links(self, monkeypatch):
+        """When SOBS base path is configured, both routing and generated links should honor it."""
+        import app as app_module
+
+        monkeypatch.setattr(app_module, "BASE_PATH", "/sobs")
+        app.config["TESTING"] = True
+
+        with app.test_client() as c:
+            dashboard = c.get("/sobs/")
+            assert dashboard.status_code == 200
+            assert b'href="/sobs/logs"' in dashboard.data
+            assert b'href="/sobs/errors"' in dashboard.data
+            assert b'src="/sobs/static/bootstrap.bundle.min.js"' in dashboard.data
+
+            logs_ingest = c.post("/sobs/v1/logs", json={})
+            assert logs_ingest.status_code == 200
+
+            rum_script = c.get("/sobs/static/rum.js")
+            assert rum_script.status_code == 200
+
+    def test_forwarded_prefix_generates_prefixed_links(self, client):
+        """X-Forwarded-Prefix should influence generated links even when backend paths are unprefixed."""
+        r = client.get("/", headers={"X-Forwarded-Prefix": "/sobs"})
+        assert r.status_code == 200
+        assert b'href="/sobs/logs"' in r.data
+        assert b'href="/sobs/errors"' in r.data
+        assert b'src="/sobs/static/bootstrap.bundle.min.js"' in r.data
+
 
 # ---------------------------------------------------------------------------
 # Basic Auth


### PR DESCRIPTION
## Summary
- switch UI/static link generation to Flask `url_for(...)` across templates to avoid hardcoded root paths
- add base-path aware middleware supporting `SOBS_BASE_PATH` and `X-Forwarded-Prefix`
- keep routing working for both stripped and non-stripped proxy prefix forwarding
- document new `SOBS_BASE_PATH` configuration in README

## Testing
- `/Users/abartrim/Documents/dev/sobs/.venv/bin/python -m pytest tests/test_app.py -q`
- added tests for:
  - default root mode link/static generation
  - configured `/sobs` prefixed routing + generated links
  - `X-Forwarded-Prefix: /sobs` generated link behavior

Closes #14
