### PR TITLE
fix: rename session cookie to avoid collision with management service

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,6 +89,7 @@ def _merge_script_name(script_name: str, base_path: str) -> str:
 BASE_PATH = _normalize_base_path(os.environ.get("SOBS_BASE_PATH", ""))
 app.config["APPLICATION_ROOT"] = BASE_PATH or "/"
 app.config["SECRET_KEY"] = os.environ.get("SOBS_SECRET_KEY", "sobs-dev-secret-key")
+app.config["SESSION_COOKIE_NAME"] = os.environ.get("SOBS_SESSION_COOKIE_NAME", "sobs_session")
 app.config["ENABLE_FIRST_RUN_TOUR"] = _env_flag("SOBS_ENABLE_FIRST_RUN_TOUR", True)
 
 


### PR DESCRIPTION
## Problem

When sobs is deployed with `SOBS_BASE_PATH=/sobs`, the app sets `APPLICATION_ROOT` to `/sobs`. Quart's session interface reads `APPLICATION_ROOT` to determine the cookie path, so any session cookie sobs writes gets scoped to `/sobs`.

Both sobs and the email-assistant management service use the default Quart/Flask cookie name `session`. This creates a collision:

- Management service sets: `session=<auth-token>` (path `/`)
- Sobs sets: `session=<sobs-junk>` (path `/sobs`)

Per RFC 6265 path-specificity, the browser sends the more specific `/sobs`-scoped cookie **first** when the browser is visiting a `/sobs/*` path. So `request.cookies.get("session")` in `require_basic_auth` returns sobs's own meaningless session value — not the management service's auth token. This gets forwarded to the external auth validator, which rejects it (wrong HMAC signature), returning **401 Unauthorized**.

## Root Cause Chain

```
app.config["APPLICATION_ROOT"] = "/sobs"  # sobs app.py line 90
  └─> get_cookie_path() returns "/sobs"   # Quart session interface
  └─> sobs session cookie gets path /sobs
  └─> browser sends /sobs cookie first for /sobs/* requests
  └─> require_basic_auth reads wrong cookie
  └─> external auth rejects it → 401
```

## Fix

Add one line to configure a distinct `SESSION_COOKIE_NAME`:

```python
app.config["SESSION_COOKIE_NAME"] = os.environ.get("SOBS_SESSION_COOKIE_NAME", "sobs_session")
```

This renames sobs's own session cookie from `session` to `sobs_session`, eliminating the collision. The `require_basic_auth` decorator still calls `request.cookies.get("session")` to find the management service's auth cookie — that's now unambiguous because sobs's own cookie no longer pollutes the `session` name.

The env var `SOBS_SESSION_COOKIE_NAME` allows overriding if needed.

## Existing tests

No changes needed to existing tests — the external-auth session cookie tests (`test_session_cookie_used_as_bearer_fallback_when_valid`, etc.) correctly set a cookie named `"session"` to simulate the management service's auth cookie, which is what `require_basic_auth` looks for. This behavior is unchanged.
