### PR TITLE
Fix light-mode contrast issues on Errors and related pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,32 @@
     .badge-level-DEBUG { background-color: #6c757d !important; }
     .badge-level-METRIC { background-color: #0dcaf0 !important; color: #000 !important; }
     .log-body { font-family: "SFMono-Regular", Menlo, monospace; font-size: .78rem; word-break: break-all; }
-    .stack-trace { font-family: monospace; font-size: .78rem; white-space: pre-wrap; max-height: 200px; overflow-y: auto; }
+    .stack-trace {
+      font-family: monospace;
+      font-size: .78rem;
+      white-space: pre-wrap;
+      max-height: 200px;
+      overflow-y: auto;
+      color: var(--bs-danger-text-emphasis);
+      background: var(--bs-danger-bg-subtle);
+      border: 1px solid var(--bs-danger-border-subtle);
+    }
+    .theme-panel {
+      color: var(--bs-body-color);
+      background: var(--bs-tertiary-bg);
+      border: 1px solid var(--bs-border-color);
+    }
+    [data-bs-theme='light'] .table-dark {
+      --bs-table-color: var(--bs-body-color);
+      --bs-table-bg: var(--bs-body-bg);
+      --bs-table-border-color: var(--bs-border-color);
+      --bs-table-striped-bg: var(--bs-tertiary-bg);
+      --bs-table-striped-color: var(--bs-body-color);
+      --bs-table-active-bg: var(--bs-secondary-bg);
+      --bs-table-active-color: var(--bs-body-color);
+      --bs-table-hover-bg: var(--bs-secondary-bg);
+      --bs-table-hover-color: var(--bs-body-color);
+    }
     .stat-card { border: 1px solid var(--bs-border-color); border-radius: 10px; }
     .vitals-good  { color: #198754; }
     .vitals-needs { color: #ffc107; }

--- a/templates/chart_editor_help.html
+++ b/templates/chart_editor_help.html
@@ -64,7 +64,7 @@
     <div class="row g-3">
       <div class="col-lg-4">
         <h6 class="small text-uppercase text-secondary">Raw SQL</h6>
-<pre class="small p-2 bg-dark rounded mb-0"><code>SELECT
+<pre class="small p-2 theme-panel rounded mb-0"><code>SELECT
   toStartOfMinute(Timestamp) AS ts,
   quantile(0.95)(Duration) AS p95_ms
 FROM otel_traces
@@ -75,7 +75,7 @@ LIMIT 240</code></pre>
       </div>
       <div class="col-lg-4">
         <h6 class="small text-uppercase text-secondary">Mapping JSON</h6>
-<pre class="small p-2 bg-dark rounded mb-0"><code>{
+<pre class="small p-2 theme-panel rounded mb-0"><code>{
   "points": { "from": "rows" },
   "_drilldown": {
     "target": "traces",
@@ -86,7 +86,7 @@ LIMIT 240</code></pre>
       </div>
       <div class="col-lg-4">
         <h6 class="small text-uppercase text-secondary">Option JSON</h6>
-<pre class="small p-2 bg-dark rounded mb-0"><code>{
+<pre class="small p-2 theme-panel rounded mb-0"><code>{
   "xAxis": { "type": "time" },
   "yAxis": { "type": "value" },
   "series": [

--- a/templates/custom_dashboard_view.html
+++ b/templates/custom_dashboard_view.html
@@ -115,7 +115,7 @@
         </div>
         <details class="mt-2">
           <summary class="text-secondary small" style="cursor:pointer;">SQL Query</summary>
-          <pre class="small mt-1 p-2 bg-dark rounded text-secondary" style="max-height:120px;overflow:auto;">{{ chart.query }}</pre>
+          <pre class="small mt-1 p-2 theme-panel rounded text-body-secondary" style="max-height:120px;overflow:auto;">{{ chart.query }}</pre>
         </details>
       </div>
     </div>
@@ -305,7 +305,7 @@
                       </button>
                     </div>
                   </div>
-                  <pre id="compiledSql" class="small mt-1 p-2 bg-dark rounded text-secondary" style="max-height:170px;overflow:auto;white-space:pre-wrap;"></pre>
+                  <pre id="compiledSql" class="small mt-1 p-2 theme-panel rounded text-body-secondary" style="max-height:170px;overflow:auto;white-space:pre-wrap;"></pre>
                   <div id="specValidationMsg" class="small text-secondary"></div>
                   <div id="dryRunMeta" class="small text-secondary mt-2"></div>
                   <div class="table-responsive mt-2" id="dryRunTableWrap" style="display:none;max-height:160px;overflow:auto;">

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -88,7 +88,7 @@
     <div id="err{{ err.id }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}">
       <div class="accordion-body py-2">
         {% if err.stack %}
-        <pre id="stack-{{ err.id }}" class="stack-trace text-danger-emphasis bg-dark rounded p-2">{{ err.stack }}</pre>
+        <pre id="stack-{{ err.id }}" class="stack-trace rounded p-2">{{ err.stack }}</pre>
         {% endif %}
         <div class="d-flex gap-2 mt-2">
           {% if err.trace_id %}

--- a/templates/metrics_rules.html
+++ b/templates/metrics_rules.html
@@ -9,9 +9,9 @@
 </div>
 
 <div class="accordion mb-3" id="metricsRulesAutoAccordion">
-  <div class="accordion-item bg-dark border border-secondary">
+  <div class="accordion-item bg-body-tertiary border border-secondary">
     <h2 class="accordion-header" id="autoRulesHeading">
-      <button class="accordion-button collapsed bg-dark text-light" type="button" data-bs-toggle="collapse" data-bs-target="#autoRulesCollapse" aria-expanded="false" aria-controls="autoRulesCollapse">
+      <button class="accordion-button collapsed bg-body-tertiary text-body" type="button" data-bs-toggle="collapse" data-bs-target="#autoRulesCollapse" aria-expanded="false" aria-controls="autoRulesCollapse">
         Auto Make Metric Rules
       </button>
     </h2>
@@ -106,9 +106,9 @@
     </div>
   </div>
 
-  <div class="accordion-item bg-dark border border-secondary border-top-0">
+  <div class="accordion-item bg-body-tertiary border border-secondary border-top-0">
     <h2 class="accordion-header" id="autoDashboardHeading">
-      <button class="accordion-button collapsed bg-dark text-light" type="button" data-bs-toggle="collapse" data-bs-target="#autoDashboardCollapse" aria-expanded="false" aria-controls="autoDashboardCollapse">
+      <button class="accordion-button collapsed bg-body-tertiary text-body" type="button" data-bs-toggle="collapse" data-bs-target="#autoDashboardCollapse" aria-expanded="false" aria-controls="autoDashboardCollapse">
         Auto Generate Dashboard from Active Rules
       </button>
     </h2>

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -192,7 +192,7 @@
         <div id="terr{{ loop.index }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}">
           <div class="accordion-body py-2">
             {% if err.stack %}
-            <pre class="stack-trace text-danger-emphasis bg-dark rounded p-2">{{ err.stack }}</pre>
+            <pre class="stack-trace rounded p-2">{{ err.stack }}</pre>
             {% endif %}
             {% if err.span_id %}
             <a href="{{ url_for('view_logs', trace_id=err.trace_id, from_ts=from_ts, to_ts=to_ts) }}" class="btn btn-sm btn-outline-info mt-1">


### PR DESCRIPTION
# Issue: Errors page content is unreadable in light mode

## Summary
In light theme, stack trace content on the Errors page was rendered with a forced dark background and danger-emphasis text. This produced poor contrast and made the content difficult to read.

## Affected Areas
- `templates/errors.html`
- `templates/traces.html` (same stack trace panel pattern)
- `templates/chart_editor_help.html` (code examples forced dark background)
- `templates/custom_dashboard_view.html` (SQL preview panels forced dark background)
- `templates/metrics_rules.html` (forced dark accordion surfaces)
- Global dark table surfaces in light mode (`table table-dark` usage across pages)

## Root Cause
UI markup used hard-coded dark presentation classes (`bg-dark`, `text-light`, dark panel/table variants) without considering active theme, causing low contrast or visually inconsistent rendering in light mode.

## Fix Implemented
- Added theme-aware shared styles in `templates/base.html`:
  - `.stack-trace` now uses Bootstrap theme variables (`--bs-danger-bg-subtle`, `--bs-danger-text-emphasis`, `--bs-danger-border-subtle`).
  - `.theme-panel` for reusable code/query panel surfaces.
  - Light-mode override for `.table-dark` so table text/background remain readable and consistent.
- Updated affected templates to use theme-aware classes instead of hard-coded dark classes.

## Acceptance Criteria
- Errors stack traces are readable in both light and dark themes.
- Related stack traces in Traces page are readable in both themes.
- Help/code/query panels are readable in both themes.
- Metrics Rules accordion no longer forces dark-only surface styling.
- Legacy `table-dark` tables remain readable in light mode.

## Verification Checklist
- [ ] Toggle light/dark in the app and verify `Errors` stack trace readability.
- [ ] Open trace detail with related errors and verify stack traces.
- [ ] Check `Chart Editor Help` code samples in light mode.
- [ ] Check `Custom Dashboard` SQL preview panels in light mode.
- [ ] Check `Metrics Rules` auto panels and all dark table views in light mode.
