### PR TITLE
Fix JSON serialization crash on Undefined payloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,33 @@ from quart import (
 # ---------------------------------------------------------------------------
 app = Quart(__name__)
 
+_base_jsonify = jsonify
+
+
+def _coerce_undefined_for_json(value: Any, depth: int = 0, max_depth: int = 12) -> Any:
+    """Replace Undefined sentinels with None so JSON encoding can proceed."""
+    if depth > max_depth:
+        return value
+
+    if type(value).__name__ == "Undefined":
+        return None
+
+    if isinstance(value, dict):
+        return {key: _coerce_undefined_for_json(item, depth + 1, max_depth) for key, item in value.items()}
+
+    if isinstance(value, (list, tuple)):
+        return [_coerce_undefined_for_json(item, depth + 1, max_depth) for item in value]
+
+    return value
+
+
+def jsonify(*args: Any, **kwargs: Any):  # type: ignore[no-redef]
+    """Wrap Quart jsonify to guard against leaked Undefined values in payloads."""
+    safe_args = tuple(_coerce_undefined_for_json(arg) for arg in args)
+    safe_kwargs = {key: _coerce_undefined_for_json(value) for key, value in kwargs.items()}
+    return _base_jsonify(*safe_args, **safe_kwargs)
+
+
 _ASYNC_HTTP_CLIENT: httpx.AsyncClient | None = None
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -59,6 +59,27 @@ class TestCompression:
         assert decompress_json(None) == {}
 
 
+class TestJsonSanitizer:
+    async def test_coerce_undefined_values_to_none(self):
+        class Undefined:
+            pass
+
+        payload = {
+            "top": Undefined(),
+            "nested": {"value": Undefined()},
+            "items": [1, Undefined(), {"x": Undefined()}],
+            "ok": "value",
+        }
+
+        sanitized = sobs_app._coerce_undefined_for_json(payload)
+
+        assert sanitized["top"] is None
+        assert sanitized["nested"]["value"] is None
+        assert sanitized["items"][1] is None
+        assert sanitized["items"][2]["x"] is None
+        assert sanitized["ok"] == "value"
+
+
 # ---------------------------------------------------------------------------
 # Health check
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- wrap JSON responses with a sanitizer that coerces leaked Undefined sentinels to null-safe values
- add a regression test that validates nested Undefined values are converted recursively

## Problem
In the spark-cluster tenant flow, JSON response encoding could fail with:
TypeError: Object of type Undefined is not JSON serializable

## Validation
- isort *.py tests/ scripts
- black *.py tests/ scripts
- flake8 *.py tests/ scripts
- mypy app.py tests scripts
- pytest

## Notes
- change is centralized through the module-level jsonify wrapper to cover existing API routes consistently
