### PR TITLE
Harden chdb pytest crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt pytest pytest-asyncio pytest-forked
+        run: pip install -r requirements.txt pytest pytest-asyncio
 
       - name: Run unit tests
-        run: pytest tests/test_app.py -v --forked
+        run: pytest tests/test_app.py -v
 
   integration:
     name: Integration Tests

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ RUM, Logs, Errors, Traces, and AI transparency.
 
 import ast
 import asyncio
+import atexit
 import base64
 import copy
 import hashlib
@@ -109,6 +110,7 @@ async def _shutdown_async_http_client() -> None:
     if _ASYNC_HTTP_CLIENT is not None:
         await _ASYNC_HTTP_CLIENT.aclose()
         _ASYNC_HTTP_CLIENT = None
+    _shutdown_db_resources()
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -1092,6 +1094,9 @@ class _WriteTask:
     op: Callable[[ChDbConnection], None]
     done: threading.Event | None = None
     error: Exception | None = None
+
+
+_WRITE_STOP = cast(_WriteTask, object())
 
 
 class WriteQueueFullError(RuntimeError):
@@ -3671,6 +3676,8 @@ def _write_worker_main() -> None:
     assert _write_queue is not None
     while True:
         first = _write_queue.get()
+        if first is _WRITE_STOP:
+            return
         batch = [first]
         deadline = time.monotonic() + (max(1, WRITE_BATCH_WAIT_MS) / 1000.0)
         while len(batch) < max(1, WRITE_BATCH_MAX):
@@ -3678,7 +3685,11 @@ def _write_worker_main() -> None:
             if remaining <= 0:
                 break
             try:
-                batch.append(_write_queue.get(timeout=remaining))
+                queued = _write_queue.get(timeout=remaining)
+                if queued is _WRITE_STOP:
+                    _run_write_batch(batch)
+                    return
+                batch.append(queued)
             except queue.Empty:
                 break
         _run_write_batch(batch)
@@ -3716,6 +3727,38 @@ def _queue_write(op: Callable[[ChDbConnection], None], wait: bool = False) -> No
 
 def _write_queue_depth() -> int:
     return _write_queue.qsize() if _write_queue is not None else 0
+
+
+def _shutdown_db_resources() -> None:
+    global _global_db, _schema_ready, _write_queue, _write_thread
+
+    thread_to_join: threading.Thread | None = None
+    with _write_worker_lock:
+        if _write_queue is not None and _write_thread is not None and _write_thread.is_alive():
+            try:
+                _write_queue.put(_WRITE_STOP, timeout=1)
+            except queue.Full:
+                pass
+            thread_to_join = _write_thread
+
+    if thread_to_join is not None:
+        thread_to_join.join(timeout=5)
+
+    with _write_worker_lock:
+        _write_thread = None
+        _write_queue = None
+
+    with _db_init_lock:
+        if _global_db is not None:
+            try:
+                _global_db.close()
+            except Exception:
+                pass
+        _global_db = None
+        _schema_ready = False
+
+
+atexit.register(_shutdown_db_resources)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,6 +27,8 @@ from app import app, compress, compress_json, decompress, decompress_json, init_
 @pytest.fixture(scope="session", autouse=True)
 def setup_db():
     init_db()
+    yield
+    sobs_app._shutdown_db_resources()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- fix `/ai` template rendering for sparse message payloads that omit `content`
- add explicit chDB cleanup for process shutdown and test session teardown
- remove the blanket `pytest --forked` CI workaround

## Problems Addressed
1. `/ai` could 500 in production when message objects were missing `content`, causing Jinja `Undefined` to be passed into `tojson`.
2. intermittent end-of-run instability in tests was likely tied to teardown/lifecycle of shared chDB resources and the background write worker.
3. the broad CI forked-mode workaround added overhead and did not target the underlying teardown behavior.

## Changes
### 1) AI page rendering hardening
- Added a message rendering helper in `templates/ai.html` to normalize message `content` safely before `tojson`.
- Replaced direct `msg.content ... | tojson` render sites with the safe helper.
- Added regression test in `tests/test_app.py` for sparse input/output message payloads.

### 2) Explicit chDB and writer shutdown
- Added `_shutdown_db_resources()` in `app.py` to:
  - stop/join the background write worker via a sentinel
  - close and reset the global chDB connection
  - reset shared DB/write globals for clean lifecycle boundaries
- Hooked shutdown into:
  - Quart app shutdown (`@app.after_serving`)
  - process exit (`atexit.register(...)`)
- Updated session test fixture to call `sobs_app._shutdown_db_resources()` after tests complete.

### 3) CI adjustment
- Removed `pytest-forked` install from the unit test job.
- Removed `--forked` from the unit test command.

## Production Root Cause (validated on cluster)
Tenant/pod: `email-assistant-ajba` / `email-unified-cbdc94b65-mzh9c` (`sobs` container)

Observed traceback:
- `GET /ai` failed in `templates/ai.html`
- template line attempted `msg.content ... | tojson`
- `msg.content` was `Undefined` for sparse payloads
- raised `TypeError: Object of type Undefined is not JSON serializable`

## Validation
- Targeted AI regression run:
  - `/Users/abartrim/Documents/dev/sobs/.venv/bin/python -m pytest tests/test_app.py -k 'messages_missing_content or view_ai or ai' -q`
- Full local suite repeated 5 times:
  - `for i in 1 2 3 4 5; do /Users/abartrim/Documents/dev/sobs/.venv/bin/python -m pytest -q || exit $?; done`
  - Result: all 5 runs passed (`435 passed` each run), no hang/segfault reproduced.
- Pre-commit checks on commits (`isort`, `black`, `flake8`, `mypy`) passed.
