### PR TITLE
chore(dependabot): improve triage with grouping and metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@ updates:
       interval: "daily"
       time: "06:00"
       timezone: "UTC"
+    assignees:
+      - "abartrim"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      python-version-updates:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -17,6 +26,15 @@ updates:
       interval: "daily"
       time: "06:15"
       timezone: "UTC"
+    assignees:
+      - "abartrim"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      npm-version-updates:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -28,6 +46,15 @@ updates:
       interval: "daily"
       time: "06:30"
       timezone: "UTC"
+    assignees:
+      - "abartrim"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      docker-version-updates:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -39,6 +66,15 @@ updates:
       interval: "daily"
       time: "06:45"
       timezone: "UTC"
+    assignees:
+      - "abartrim"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      github-actions-version-updates:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- add conservative Dependabot triage tuning in `.github/dependabot.yml`
- keep existing daily schedules and PR limits
- preserve security update behavior while improving PR organization

## Changes
- assign Dependabot PRs to `@abartrim`
- standardize commit message format with `chore(deps)` prefix and scope included
- group version update PRs by ecosystem to reduce PR noise:
  - `python-version-updates`
  - `npm-version-updates`
  - `docker-version-updates`
  - `github-actions-version-updates`

## Notes
- security alerts and automated security fix PRs remain enabled at repo level
- no auto-merge behavior added in this PR
