### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1251,6 +1251,10 @@ class WriteQueueFullError(RuntimeError):
     """Raised when ingest cannot enqueue a write within timeout."""
 
 
+def _json_error(message: str, status_code: int):
+    return jsonify({"error": message}), status_code
+
+
 def get_db() -> ChDbConnection:
     global _global_db, _schema_ready
     if _global_db is None or not _schema_ready:
@@ -5544,11 +5548,11 @@ async def ingest_logs():
     wait = bool(app.config.get("TESTING", False))
     try:
         _queue_write(lambda db: _insert_log_events(db, events), wait=wait)
-    except WriteQueueFullError as exc:
-        return jsonify({"error": str(exc)}), 503
-    except Exception as exc:
+    except WriteQueueFullError:
+        return _json_error("write queue is full", 503)
+    except Exception:
         app.logger.exception("log ingest write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("log ingest write failed", 500)
     for event in events:
         await _sse_broadcast(
             {
@@ -5714,11 +5718,11 @@ async def ingest_traces():
 
     try:
         _queue_write(_op, wait=wait)
-    except WriteQueueFullError as exc:
-        return jsonify({"error": str(exc)}), 503
-    except Exception as exc:
+    except WriteQueueFullError:
+        return _json_error("write queue is full", 503)
+    except Exception:
         app.logger.exception("trace ingest write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("trace ingest write failed", 500)
     for event in span_events:
         await _sse_broadcast(
             {
@@ -5766,11 +5770,11 @@ async def ingest_metrics():
     wait = bool(app.config.get("TESTING", False))
     try:
         _queue_write(lambda db: _insert_metric_events(db, events), wait=wait)
-    except WriteQueueFullError as exc:
-        return jsonify({"error": str(exc)}), 503
-    except Exception as exc:
+    except WriteQueueFullError:
+        return _json_error("write queue is full", 503)
+    except Exception:
         app.logger.exception("metric ingest write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("metric ingest write failed", 500)
     count = len(events)
     return jsonify({"accepted": count}), 200
 
@@ -5928,11 +5932,11 @@ async def ingest_rum():
 
     try:
         _queue_write(_op, wait=wait)
-    except WriteQueueFullError as exc:
-        return jsonify({"error": str(exc)}), 503
-    except Exception as exc:
+    except WriteQueueFullError:
+        return _json_error("write queue is full", 503)
+    except Exception:
         app.logger.exception("rum ingest write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("rum ingest write failed", 500)
     return jsonify({"accepted": len(session_rows)}), 200
 
 
@@ -6004,11 +6008,11 @@ async def ingest_ai():
 
     try:
         _queue_write(_op, wait=wait)
-    except WriteQueueFullError as exc:
-        return jsonify({"error": str(exc)}), 503
-    except Exception as exc:
+    except WriteQueueFullError:
+        return _json_error("write queue is full", 503)
+    except Exception:
         app.logger.exception("ai ingest write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("ai ingest write failed", 500)
     await _sse_broadcast(
         {
             "source": "ai",
@@ -6070,11 +6074,11 @@ async def ingest_errors():
 
     try:
         _queue_write(_op, wait=wait)
-    except WriteQueueFullError as exc:
-        return jsonify({"error": str(exc)}), 503
-    except Exception as exc:
+    except WriteQueueFullError:
+        return _json_error("write queue is full", 503)
+    except Exception:
         app.logger.exception("error ingest write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("error ingest write failed", 500)
     return jsonify({"ok": True}), 200
 
 
@@ -8912,9 +8916,9 @@ async def resolve_error(error_id: str):
             db.execute("INSERT INTO sobs_error_resolutions(ErrorId) VALUES(?)", (error_id,))
 
         _queue_write(_op, wait=True)
-    except Exception as exc:
+    except Exception:
         app.logger.exception("resolve error write failed")
-        return jsonify({"error": str(exc)}), 500
+        return _json_error("resolve error write failed", 500)
     return jsonify({"ok": True})
 
 
@@ -15244,9 +15248,9 @@ async def check_notifications():
         try:
             result = await _check_notification_rule(db, rule, channels_by_id)
             results.append(result)
-        except Exception as exc:
+        except Exception:
             app.logger.exception("Error evaluating notification rule %s", rule.get("id"))
-            results.append({"rule_id": rule.get("id"), "fired": False, "error": str(exc)})
+            results.append({"rule_id": rule.get("id"), "fired": False, "error": "rule evaluation failed"})
 
     fired = [r for r in results if r.get("fired")]
 
@@ -15445,8 +15449,9 @@ async def generate_vapid_key():
                 ),
             }
         )
-    except Exception as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 500
+    except Exception:
+        app.logger.exception("VAPID key generation failed")
+        return jsonify({"ok": False, "error": "failed to generate VAPID keys"}), 500
 
 
 @app.route("/api/notifications/vapid-keys", methods=["DELETE"])
@@ -15489,14 +15494,14 @@ async def health_db():
     try:
         ensure_db_schema()
         get_db().execute("SELECT 1").fetchone()
-    except Exception as exc:
+    except Exception:
         app.logger.exception("DB readiness probe failed")
         return (
             jsonify(
                 {
                     "status": "degraded",
                     "db": "error",
-                    "error": str(exc),
+                    "error": "database unavailable",
                     "write_queue_depth": _write_queue_depth(),
                     "version": "1.0.0",
                 }

--- a/examples/python/rum_replay_test_app.py
+++ b/examples/python/rum_replay_test_app.py
@@ -10,12 +10,12 @@ import binascii
 import hashlib
 import hmac
 import json
+import logging
 import os
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import logging
 
 from flask import Flask, jsonify, render_template_string, request
 
@@ -378,8 +378,9 @@ def replay_upload():
         )
     except urllib.error.HTTPError as exc:
         return jsonify({"error": f"asset upload failed with HTTP {exc.code}"}), 502
-    except Exception as exc:
-        return jsonify({"error": f"asset upload failed: {exc}"}), 500
+    except Exception:
+        logger.exception("asset upload failed")
+        return jsonify({"error": "asset upload failed"}), 500
 
 
 @app.route("/api/fail", methods=["GET"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -116,30 +116,83 @@ class TestHealth:
         data = json.loads(await r.get_data())
         assert data["status"] == "degraded"
         assert data["db"] == "error"
-        assert "db timeout" in data["error"]
+        assert data["error"] == "database unavailable"
         assert isinstance(data["write_queue_depth"], int)
 
 
 class TestWriteQueue:
-    async def test_ingest_returns_503_when_write_queue_full(self, client, monkeypatch):
+    @pytest.mark.parametrize(
+        ("path", "payload"),
+        [
+            ("/v1/errors", {}),
+            ("/v1/logs", {}),
+            ("/v1/traces", {}),
+            ("/v1/metrics", {}),
+            ("/v1/rum", {}),
+            ("/v1/ai", {}),
+        ],
+    )
+    async def test_ingest_returns_503_when_write_queue_full(self, client, monkeypatch, path, payload):
         def _raise_queue_full(_op, wait=False):
             raise sobs_app.WriteQueueFullError("write queue is full")
 
         monkeypatch.setattr(sobs_app, "_queue_write", _raise_queue_full)
-        r = await client.post("/v1/errors", json={"service": "q-full", "message": "drop me"})
+        r = await client.post(path, json=payload)
         assert r.status_code == 503
         data = json.loads(await r.get_data())
-        assert "write queue is full" in data["error"]
+        assert data["error"] == "write queue is full"
 
-    async def test_ingest_returns_500_when_writer_op_fails(self, client, monkeypatch):
+    @pytest.mark.parametrize(
+        ("path", "payload", "expected_error"),
+        [
+            ("/v1/errors", {}, "error ingest write failed"),
+            ("/v1/logs", {}, "log ingest write failed"),
+            ("/v1/traces", {}, "trace ingest write failed"),
+            ("/v1/metrics", {}, "metric ingest write failed"),
+            ("/v1/rum", {}, "rum ingest write failed"),
+            ("/v1/ai", {}, "ai ingest write failed"),
+        ],
+    )
+    async def test_ingest_returns_500_when_writer_op_fails(self, client, monkeypatch, path, payload, expected_error):
         def _raise_write_failure(*_args, **_kwargs):
-            raise RuntimeError("write failed")
+            raise RuntimeError("write failed: secret internal details")
 
-        monkeypatch.setattr(sobs_app, "_insert_rows_json_each_row", _raise_write_failure)
-        r = await client.post("/v1/errors", json={"service": "q-fail", "message": "boom"})
+        monkeypatch.setattr(sobs_app, "_queue_write", _raise_write_failure)
+        r = await client.post(path, json=payload)
         assert r.status_code == 500
         data = json.loads(await r.get_data())
-        assert "write failed" in data["error"]
+        assert data["error"] == expected_error
+        assert "secret internal details" not in data["error"]
+
+    async def test_resolve_error_write_failure_is_sanitized(self, client, monkeypatch):
+        def _raise_write_failure(*_args, **_kwargs):
+            raise RuntimeError("resolve failed: secret internal details")
+
+        monkeypatch.setattr(sobs_app, "_queue_write", _raise_write_failure)
+        r = await client.post("/errors/deadbeefdeadbeefdeadbeefdeadbeef/resolve")
+        assert r.status_code == 500
+        data = json.loads(await r.get_data())
+        assert data["error"] == "resolve error write failed"
+        assert "secret internal details" not in data["error"]
+
+    async def test_notification_check_rule_failure_is_sanitized(self, client, monkeypatch):
+        monkeypatch.setattr(
+            sobs_app,
+            "_load_notification_rules",
+            lambda _db: [{"id": "rule-1", "is_enabled": True}],
+        )
+        monkeypatch.setattr(sobs_app, "_load_notification_channels", lambda _db: [])
+
+        async def _raise_rule_failure(_db, _rule, _channels_by_id):
+            raise RuntimeError("rule failed: secret internal details")
+
+        monkeypatch.setattr(sobs_app, "_check_notification_rule", _raise_rule_failure)
+
+        r = await client.post("/api/notifications/check")
+        assert r.status_code == 200
+        data = json.loads(await r.get_data())
+        assert data["results"][0]["error"] == "rule evaluation failed"
+        assert "secret internal details" not in data["results"][0]["error"]
 
     async def test_non_testing_mode_uses_async_queue_and_persists(self, monkeypatch):
         # In non-testing mode ingest should enqueue writes and return immediately.
@@ -7952,6 +8005,19 @@ class TestNotifications:
         assert r.status_code == 404
         data = json.loads(await r.get_data())
         assert data["ok"] is False
+
+    async def test_generate_vapid_keys_failure_is_sanitized(self, client, monkeypatch):
+        def _raise_keygen_failure():
+            raise RuntimeError("keygen failed: secret internal details")
+
+        monkeypatch.setattr(sobs_app, "_generate_vapid_keys", _raise_keygen_failure)
+
+        r = await client.post("/api/notifications/vapid-keygen")
+        assert r.status_code == 500
+        data = json.loads(await r.get_data())
+        assert data["ok"] is False
+        assert data["error"] == "failed to generate VAPID keys"
+        assert "secret internal details" not in data["error"]
 
     async def test_settings_page_shows_notification_counts(self, client):
         r = await client.get("/settings")


### PR DESCRIPTION
Potential fix for [https://github.com/abartrim/sobs/security/code-scanning/2](https://github.com/abartrim/sobs/security/code-scanning/2)

In general, to fix this issue you should avoid sending raw exception objects or stack traces back to clients. Instead, log the detailed exception server-side (to stdout, a logging framework, etc.) and return a generic, non-sensitive error message to the client, possibly with a coarse error code or ID.

For this specific code, the best fix is to change the generic `except Exception as exc:` block in `issue_rum_client_token` so that:
- It no longer embeds `exc` in the JSON response.
- It logs the exception details on the server, using Python’s `logging` module, with `logger.exception` or `logger.error(..., exc_info=True)`.
- It returns a generic error string, such as `"token request failed"` or `"internal error while requesting token"`.

Concretely:
- At the top of `examples/python/rum_replay_test_app.py`, add `import logging` and initialize a module-level logger, e.g. `logger = logging.getLogger(__name__)`.
- Around line 297–300, change the second `except` block to call `logger.exception("token request failed")` and return a sanitized message, e.g. `return jsonify({"error": "token request failed"}), 500`. This keeps behavior semantically similar (still 500 on unexpected failures) but no longer exposes exception details.

No other parts of the file need to change for this specific CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
