### PR TITLE
Harden hosted security controls (CSRF, headers, container, dependency audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,45 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            .github/workflows/ci.yml
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Audit Python dependencies
+        run: pip-audit -r requirements.txt --strict
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Audit npm dependencies
+        run: npm audit --omit=dev --audit-level=high
+
   rum-build:
     name: RUM JS Build & Type Check
     runs-on: ubuntu-latest
+    needs: dependency-audit
     permissions:
       contents: read
     steps:
@@ -51,6 +87,7 @@ jobs:
   lint:
     name: Code Style & Linting
     runs-on: ubuntu-latest
+    needs: dependency-audit
     permissions:
       contents: read
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ LABEL org.opencontainers.image.version="${SOBS_BUILD_VERSION}"
 
 WORKDIR /app
 
+# Run the app as an unprivileged user in production containers.
+RUN addgroup --system --gid 10001 sobs && adduser --system --uid 10001 --ingroup sobs --home /app sobs
+
 # Install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -20,11 +23,12 @@ COPY templates/ templates/
 COPY static/ static/
 
 # Data directory (mount a volume here for persistence)
-RUN mkdir -p /data
+RUN mkdir -p /data && chown -R sobs:sobs /app /data
 ENV SOBS_DATA_DIR=/data
 ENV PORT=4317
 ENV SOBS_BUILD_VERSION=${SOBS_BUILD_VERSION}
 RUN chmod +x /app/scripts/docker-entrypoint.sh
+USER sobs:sobs
 
 # Expose default port
 EXPOSE 4317

--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ The Work Items page is intended to make these decisions visible so operators can
 | `SOBS_BASE_PATH`            | _(empty)_      | Optional URL prefix (for example `/sobs`) for UI/API routing and generated links |
 | `SOBS_SECRET_KEY`           | `sobs-dev-secret-key` | Secret key used by Quart session handling (set explicitly in production) |
 | `SOBS_SESSION_COOKIE_NAME`  | `sobs_session` | Session cookie name for SOBS UI sessions (prevents collisions with management services using `session`) |
+| `SOBS_BEHIND_TLS`           | `0`            | Enable TLS-aware hardening (secure cookies + HSTS) when running behind HTTPS termination |
+| `SOBS_SESSION_COOKIE_SAMESITE` | `Lax`       | Session cookie SameSite policy (`Lax`, `Strict`, `None`) |
+| `SOBS_CSRF_ORIGIN_CHECK`    | `auto`         | Enforce same-origin checks on authenticated UI state-changing methods (defaults to enabled when `SOBS_BEHIND_TLS=1`) |
 | `PORT`                      | `44317`        | Listen port                                      |
 | `SOBS_WRITE_QUEUE_MAX`      | `5000`         | Max buffered write operations before ingest returns `503` |
 | `SOBS_WRITE_BATCH_MAX`      | `200`          | Max writes processed per DB batch |

--- a/app.py
+++ b/app.py
@@ -136,6 +136,27 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
+def _request_is_secure_context() -> bool:
+    if _BEHIND_TLS:
+        return True
+    forwarded_proto = str(request.headers.get("X-Forwarded-Proto") or "").split(",", 1)[0].strip().lower()
+    if forwarded_proto == "https":
+        return True
+    return str(request.scheme or "").lower() == "https"
+
+
+@app.after_request
+async def _apply_security_headers(response: Response):
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    response.headers.setdefault("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+    response.headers.setdefault("Content-Security-Policy", "frame-ancestors 'self'; object-src 'none'; base-uri 'self'")
+    if _request_is_secure_context():
+        response.headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+    return response
+
+
 def _env_flag(name: str, default: bool) -> bool:
     raw = os.environ.get(name)
     if raw is None:
@@ -173,6 +194,13 @@ app.config["APPLICATION_ROOT"] = BASE_PATH or "/"
 app.config["SECRET_KEY"] = os.environ.get("SOBS_SECRET_KEY", "sobs-dev-secret-key")
 app.config["SESSION_COOKIE_NAME"] = os.environ.get("SOBS_SESSION_COOKIE_NAME", "sobs_session")
 app.config["ENABLE_FIRST_RUN_TOUR"] = _env_flag("SOBS_ENABLE_FIRST_RUN_TOUR", True)
+_BEHIND_TLS = _env_flag("SOBS_BEHIND_TLS", False)
+_session_cookie_samesite = str(os.environ.get("SOBS_SESSION_COOKIE_SAMESITE", "Lax") or "Lax").strip().lower()
+if _session_cookie_samesite not in {"lax", "strict", "none"}:
+    _session_cookie_samesite = "lax"
+app.config["SESSION_COOKIE_SECURE"] = _BEHIND_TLS
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = _session_cookie_samesite.capitalize()
 
 _SETTINGS_ENCRYPTION_PREFIX = "enc:v1:"
 _SETTINGS_ENCRYPTION_KEY_ENV = "SOBS_SETTINGS_ENCRYPTION_KEY"
@@ -323,6 +351,7 @@ RUM_ASSET_MAX_BYTES = int(os.environ.get("SOBS_RUM_ASSET_MAX_BYTES", str(8 * 102
 RUM_CLIENT_AUTH_MODE = os.environ.get("SOBS_RUM_CLIENT_AUTH_MODE", "none").strip().lower()
 RUM_CLIENT_SIGNING_KEY = os.environ.get("SOBS_RUM_CLIENT_SIGNING_KEY", "")
 RUM_CLIENT_TOKEN_TTL_SEC = int(os.environ.get("SOBS_RUM_CLIENT_TOKEN_TTL_SEC", "900"))
+CSRF_ORIGIN_CHECK = _env_flag("SOBS_CSRF_ORIGIN_CHECK", _BEHIND_TLS)
 SOURCE_MAP_DIR = os.environ.get("SOBS_SOURCE_MAP_DIR", "").strip()
 SOURCE_MAP_ENABLE = _env_flag("SOBS_SOURCE_MAP_ENABLE", False)
 BUILD_VERSION = os.environ.get("SOBS_BUILD_VERSION", "").strip()
@@ -6654,7 +6683,7 @@ def require_api_key(f):
     @wraps(f)
     async def decorated(*args, **kwargs):
         if API_KEY:
-            key = request.headers.get("X-API-Key") or request.args.get("api_key")
+            key = request.headers.get("X-API-Key")
             if key != API_KEY:
                 return jsonify({"error": "Unauthorized"}), 401
         result = f(*args, **kwargs)
@@ -6798,6 +6827,25 @@ def _request_origin() -> str:
     return ""
 
 
+def _same_origin_request() -> bool:
+    origin = _normalize_origin(request.headers.get("Origin", ""))
+    referer = request.headers.get("Referer", "")
+    referer_origin = ""
+    if referer:
+        parsed = urllib.parse.urlparse(str(referer or "").strip())
+        if parsed.scheme and parsed.netloc:
+            referer_origin = f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+    forwarded_host = str(request.headers.get("X-Forwarded-Host") or "").split(",", 1)[0].strip().lower()
+    expected_host = forwarded_host or str(request.host or "").strip().lower()
+    forwarded_proto = str(request.headers.get("X-Forwarded-Proto") or "").split(",", 1)[0].strip().lower()
+    expected_scheme = forwarded_proto or str(request.scheme or "").strip().lower() or "http"
+    expected_origin = f"{expected_scheme}://{expected_host}" if expected_host else ""
+    if not expected_origin:
+        return False
+    return origin == expected_origin or referer_origin == expected_origin
+
+
 def _rum_client_sign(payload: str) -> str:
     return hmac.new(RUM_CLIENT_SIGNING_KEY.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
 
@@ -6892,6 +6940,9 @@ def require_basic_auth(f):
         mode = _auth_mode()
         if mode == "invalid":
             return jsonify({"error": "Server auth misconfiguration"}), 500
+        if mode != "none" and CSRF_ORIGIN_CHECK and request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            if not _same_origin_request():
+                return jsonify({"error": "CSRF origin check failed"}), 403
         if mode == "none":
             result = f(*args, **kwargs)
             if inspect.isawaitable(result):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     build: .
     image: ghcr.io/abartrim/sobs:latest
     container_name: sobs
+    user: "10001:10001"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     ports:
       - "44317:4317"
     volumes:
@@ -22,13 +27,21 @@ services:
       # -----------------------------------------------------------------------
       # Authentication (all optional – leave empty to disable)
       # -----------------------------------------------------------------------
-      # API key for ingest endpoints (send as X-API-Key header or ?api_key=).
+      # API key for ingest endpoints (send via X-API-Key header).
       - SOBS_API_KEY=
       # Basic Auth for the Web UI (set both or neither).
       # - SOBS_BASIC_AUTH_USERNAME=admin
       # - SOBS_BASIC_AUTH_PASSWORD=changeme
       # External Bearer token validator URL for the Web UI.
       # - SOBS_EXTERNAL_AUTH_URL=https://auth.example.com/validate
+      # Set when SOBS runs behind HTTPS/TLS termination.
+      # Enables secure cookies and HSTS.
+      # - SOBS_BEHIND_TLS=1
+      # Optional SameSite cookie mode: Lax | Strict | None
+      # - SOBS_SESSION_COOKIE_SAMESITE=Lax
+      # Optional CSRF same-origin guard override for authenticated UI POST/PUT/PATCH/DELETE.
+      # Defaults to enabled when SOBS_BEHIND_TLS=1.
+      # - SOBS_CSRF_ORIGIN_CHECK=1
 
       # -----------------------------------------------------------------------
       # AI assistant (configure in Settings → AI or via env/secret providers)

--- a/examples/README.md
+++ b/examples/README.md
@@ -342,6 +342,6 @@ Optional environment variable to extend the allowed table list:
 ## Authentication
 
 Set `SOBS_API_KEY` environment variable to enable API key auth.
-Send key in `X-API-Key` header or `?api_key=` query parameter.
+Send key in the `X-API-Key` header.
 
 For Web UI authentication options see the main [README.md](../README.md#authentication).


### PR DESCRIPTION
## Summary
This PR applies the security hardening items we agreed to implement for hosted deployments while preserving local-dev ergonomics.

### Implemented
1. CSRF same-origin protection for authenticated UI state-changing routes (`POST`/`PUT`/`PATCH`/`DELETE`) via `require_basic_auth`.
2. API key auth is now header-only (`X-API-Key`) to prevent query-string credential leakage.
3. TLS-aware web hardening:
   - secure cookie options (`SESSION_COOKIE_SECURE`, `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SAMESITE`)
   - response security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, minimal CSP)
   - HSTS when secure context is detected.
4. Container hardening:
   - run as non-root user (`uid/gid 10001`)
   - docker-compose hardening (`user`, `no-new-privileges`, `cap_drop: ALL`).
5. Dependency governance:
   - added CI dependency audit job (`pip-audit --strict`, `npm audit --omit=dev --audit-level=high`).

## Config behavior
- `SOBS_BEHIND_TLS=1` enables secure-cookie/HSTS posture.
- `SOBS_CSRF_ORIGIN_CHECK` defaults to enabled when `SOBS_BEHIND_TLS=1` (overridable).
- `SOBS_SESSION_COOKIE_SAMESITE` supports `Lax|Strict|None`.

## Docs
- Updated README config table for new hosted security env vars.
- Updated examples/docs to reflect header-only API key usage.
- Updated docker-compose comments for hosted hardening knobs.

## Validation
- `python -m pytest tests/test_app.py::TestBasicAuth::test_ui_requires_auth_when_configured -q` passed locally.
- Pre-commit checks passed during commit (isort/black/flake8/mypy).