### PR TITLE
fix(docker): include masking module in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application
 COPY app.py .
+COPY masking.py .
 COPY scripts/docker-entrypoint.sh scripts/docker-entrypoint.sh
 COPY scripts/render_clickhouse_config.py scripts/render_clickhouse_config.py
 COPY templates/ templates/


### PR DESCRIPTION
## Summary
- Fix container startup failure: ModuleNotFoundError: No module named masking
- Update Docker build to copy masking.py into /app

## Root Cause
The image copied app.py but not masking.py, while app.py imports masking.

## Change
- Dockerfile: add `COPY masking.py .`

## Validation
- Confirmed diff only adds masking.py copy instruction
- Branch built specifically for this fix
