### PR TITLE
Harden trace detail scaling and RE2 regex filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -13354,6 +13354,43 @@ def _build_span_tree(spans: list[dict]) -> list[dict]:
     return result
 
 
+def _slice_span_tree_with_ancestors(
+    full_span_tree: list[dict],
+    offset: int,
+    limit: int,
+) -> tuple[list[dict], int, int]:
+    """Return a paged span-tree slice plus required ancestors for context.
+
+    The returned tuple is ``(rows, page_end, context_rows)`` where:
+    - ``rows`` are in the original DFS order.
+    - ``page_end`` reflects the end index of the raw page window (without
+      ancestor expansion).
+    - ``context_rows`` is how many extra ancestor rows were prepended.
+    """
+    if not full_span_tree:
+        return [], 0, 0
+
+    total = len(full_span_tree)
+    page_start = max(0, min(offset, total))
+    page_end = min(page_start + max(1, limit), total)
+    page_rows = full_span_tree[page_start:page_end]
+    if not page_rows:
+        return [], page_end, 0
+
+    by_id = {str(row.get("span_id") or ""): row for row in full_span_tree}
+    included_ids = {str(row.get("span_id") or "") for row in page_rows}
+
+    for row in page_rows:
+        parent_id = str(row.get("parent_span_id") or "")
+        while parent_id and parent_id in by_id and parent_id not in included_ids:
+            included_ids.add(parent_id)
+            parent_id = str(by_id[parent_id].get("parent_span_id") or "")
+
+    rows = [row for row in full_span_tree if str(row.get("span_id") or "") in included_ids]
+    context_rows = max(0, len(rows) - len(page_rows))
+    return rows, page_end, context_rows
+
+
 def _compute_active_timeline_ms(spans: list[dict]) -> float:
     """Return merged active time across span intervals in milliseconds."""
     merged = _merge_span_intervals(spans)
@@ -14262,8 +14299,11 @@ async def view_traces():
             capped_total_spans = len(full_span_tree)
             if trace_span_offset >= capped_total_spans and capped_total_spans > 0:
                 trace_span_offset = max(0, ((capped_total_spans - 1) // trace_span_limit) * trace_span_limit)
-            trace_page_spans = full_span_tree[trace_span_offset : trace_span_offset + trace_span_limit]
-            trace_page_end = min(trace_span_offset + len(trace_page_spans), capped_total_spans)
+            trace_page_spans, trace_page_end, trace_context_rows = _slice_span_tree_with_ancestors(
+                full_span_tree,
+                trace_span_offset,
+                trace_span_limit,
+            )
             detail_prev_offset = max(0, trace_span_offset - trace_span_limit)
             detail_next_offset = trace_span_offset + trace_span_limit
             detail_hard_capped = trace_total_spans > _TRACE_DETAIL_HARD_CAP
@@ -14299,6 +14339,7 @@ async def view_traces():
                 "page_limit": trace_span_limit,
                 "page_offset": trace_span_offset,
                 "page_end": trace_page_end,
+                "context_rows": trace_context_rows,
                 "prev_offset": detail_prev_offset,
                 "next_offset": detail_next_offset,
                 "has_prev_page": trace_span_offset > 0,

--- a/app.py
+++ b/app.py
@@ -10326,6 +10326,21 @@ def _compute_advanced_log_analysis(rows: list[dict], level_stats: dict, service_
 # ---------------------------------------------------------------------------
 # Web UI – Logs
 # ---------------------------------------------------------------------------
+def _validate_re2_pattern(db: "ChDbConnection", pattern: str) -> str | None:
+    value = str(pattern or "").strip()
+    if not value:
+        return None
+    try:
+        # chDB uses RE2 for match(), which is stricter than Python's re.
+        db.execute("SELECT match('', ?)", [value]).fetchone()
+    except Exception as exc:
+        msg = str(exc).strip()
+        if ": while executing function" in msg:
+            msg = msg.split(": while executing function", 1)[0].strip()
+        return f"Regex error: {msg}"
+    return None
+
+
 @app.route("/logs")
 @require_basic_auth
 async def view_logs():
@@ -10371,6 +10386,10 @@ async def view_logs():
             re.compile(q, re.IGNORECASE)
         except re.error as exc:
             error_msg = f"Regex error: {exc}"
+        if not error_msg:
+            re2_error = _validate_re2_pattern(db, q)
+            if re2_error:
+                error_msg = re2_error
 
     if error_msg:
         pass
@@ -12305,10 +12324,15 @@ async def view_metrics():
     if q and not error_msg:
         try:
             re.compile(q, re.IGNORECASE)
-            where_parts.append("match(SignalName, ?)")
-            params.append(q)
         except re.error as exc:
             error_msg = f"Regex error: {exc}"
+        if not error_msg:
+            re2_error = _validate_re2_pattern(db, q)
+            if re2_error:
+                error_msg = re2_error
+            else:
+                where_parts.append("match(SignalName, ?)")
+                params.append(q)
 
     if hour_clause:
         params.append(hours)
@@ -13056,6 +13080,10 @@ async def view_errors():
             re.compile(q, re.IGNORECASE)
         except re.error as exc:
             error_msg = f"Regex error: {exc}"
+        if not error_msg:
+            re2_error = _validate_re2_pattern(db, q)
+            if re2_error:
+                error_msg = re2_error
     resolved_ids = _get_resolved_error_ids(db)
     where_parts = []
     where_params = []
@@ -13420,6 +13448,12 @@ def _build_trace_timeline_segments(
             )
 
     return segments
+
+
+_TRACE_DETAIL_HARD_CAP = 5000
+_TRACE_DETAIL_DEFAULT_LIMIT = 200
+_TRACE_DETAIL_MAX_LIMIT = 1000
+_TRACE_DETAIL_COLLAPSE_THRESHOLD = 300
 
 
 def _build_trace_window_overlay_segments(
@@ -13954,6 +13988,13 @@ async def view_traces():
     from_ts, to_ts, time_error = _parse_time_window_args()
     limit = _parse_limit(100)
     offset = _parse_offset()
+    trace_span_limit = _coerce_positive_int(
+        request.args.get("trace_span_limit"),
+        _TRACE_DETAIL_DEFAULT_LIMIT,
+        1,
+        _TRACE_DETAIL_MAX_LIMIT,
+    )
+    trace_span_offset = _coerce_positive_int(request.args.get("trace_span_offset"), 0, 0, _TRACE_DETAIL_HARD_CAP)
     sort_by, sort_col, sort_dir = _parse_sort(
         {
             "Timestamp": "Timestamp",
@@ -13974,6 +14015,10 @@ async def view_traces():
             re.compile(q, re.IGNORECASE)
         except re.error as exc:
             q_error = f"Regex error: {exc}"
+        if not q_error:
+            re2_error = _validate_re2_pattern(db, q)
+            if re2_error:
+                q_error = re2_error
     if selected_services:
         placeholders = ",".join(["?"] * len(selected_services))
         conditions.append(f"ServiceName IN ({placeholders})")
@@ -13988,15 +14033,22 @@ async def view_traces():
         conditions.append("match(SpanName, ?)")
         params.append(q)
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
-    if not where:
-        total = _active_part_rows(db, "otel_traces")
+    if trace_id and not time_error:
+        total = 0
+        rows = []
     else:
-        total = db.execute(f"SELECT COUNT(*) FROM otel_traces {where}", params).fetchone()[0]
-    rows = db.execute(
-        f"SELECT Timestamp, TraceId, SpanId, ParentSpanId, SpanName, ServiceName, Duration, StatusCode, SpanAttributes "
-        f"FROM otel_traces {where} {order_clause} LIMIT ? OFFSET ?",
-        params + [limit, offset],
-    ).fetchall()
+        if not where:
+            total = _active_part_rows(db, "otel_traces")
+        else:
+            total = db.execute(f"SELECT COUNT(*) FROM otel_traces {where}", params).fetchone()[0]
+        rows = db.execute(
+            (
+                "SELECT Timestamp, TraceId, SpanId, ParentSpanId, "
+                "SpanName, ServiceName, Duration, StatusCode, SpanAttributes "
+                f"FROM otel_traces {where} {order_clause} LIMIT ? OFFSET ?"
+            ),
+            params + [limit, offset],
+        ).fetchall()
 
     spans = []
     for r in rows:
@@ -14027,11 +14079,15 @@ async def view_traces():
     # When a specific trace is selected build an enriched detail view.
     trace_detail: dict | None = None
     if trace_id and not time_error:
+        trace_total_spans = int(
+            db.execute("SELECT COUNT(*) FROM otel_traces WHERE TraceId=?", [trace_id]).fetchone()[0] or 0
+        )
+        detail_fetch_limit = min(trace_total_spans, _TRACE_DETAIL_HARD_CAP)
         detail_rows = db.execute(
             "SELECT Timestamp, TraceId, SpanId, ParentSpanId, SpanName, ServiceName, "
             "Duration, StatusCode, SpanAttributes "
-            "FROM otel_traces WHERE TraceId=? ORDER BY Timestamp ASC",
-            [trace_id],
+            "FROM otel_traces WHERE TraceId=? ORDER BY Timestamp ASC, SpanId ASC LIMIT ?",
+            [trace_id, detail_fetch_limit],
         ).fetchall()
         if detail_rows:
             all_trace_spans = []
@@ -14202,8 +14258,21 @@ async def view_traces():
 
             trace_window_segments = _build_trace_window_overlay_segments(all_trace_spans, trace_windows)
 
+            full_span_tree = _build_span_tree(all_trace_spans)
+            capped_total_spans = len(full_span_tree)
+            if trace_span_offset >= capped_total_spans and capped_total_spans > 0:
+                trace_span_offset = max(0, ((capped_total_spans - 1) // trace_span_limit) * trace_span_limit)
+            trace_page_spans = full_span_tree[trace_span_offset : trace_span_offset + trace_span_limit]
+            trace_page_end = min(trace_span_offset + len(trace_page_spans), capped_total_spans)
+            detail_prev_offset = max(0, trace_span_offset - trace_span_limit)
+            detail_next_offset = trace_span_offset + trace_span_limit
+            detail_hard_capped = trace_total_spans > _TRACE_DETAIL_HARD_CAP
+            default_collapsed = capped_total_spans > _TRACE_DETAIL_COLLAPSE_THRESHOLD
+
+            total = trace_total_spans
+
             trace_detail = {
-                "span_tree": _build_span_tree(all_trace_spans),
+                "span_tree": trace_page_spans,
                 "trace_start_ts": str(all_trace_spans[0]["ts"]),
                 "trace_end_ts": str(all_trace_spans[-1]["ts"]),
                 "trace_start_ms": round(trace_start_ms),
@@ -14222,6 +14291,18 @@ async def view_traces():
                 "raw_windows": trace_windows,
                 "raw_window_segments": trace_window_segments,
                 "metrics_context": trace_metrics_context,
+                "total_spans": trace_total_spans,
+                "capped_total_spans": capped_total_spans,
+                "hard_cap": _TRACE_DETAIL_HARD_CAP,
+                "hard_capped": detail_hard_capped,
+                "default_collapsed": default_collapsed,
+                "page_limit": trace_span_limit,
+                "page_offset": trace_span_offset,
+                "page_end": trace_page_end,
+                "prev_offset": detail_prev_offset,
+                "next_offset": detail_next_offset,
+                "has_prev_page": trace_span_offset > 0,
+                "has_next_page": detail_next_offset < capped_total_spans,
             }
 
     # Build work-item pre-check map for trace-detail errors so "Raise issue" shows as
@@ -15659,6 +15740,10 @@ async def view_rum():
             re.compile(q, re.IGNORECASE)
         except re.error as exc:
             q_error = f"Regex error: {exc}"
+        if not q_error:
+            re2_error = _validate_re2_pattern(db, q)
+            if re2_error:
+                q_error = re2_error
 
     conditions = []
     params = []

--- a/templates/_filter_macros.html
+++ b/templates/_filter_macros.html
@@ -45,3 +45,17 @@ if (!{{ fn_name }}()) {
   window.addEventListener('load', {{ fn_name }}, { once: true });
 }
 {%- endmacro %}
+
+{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search…', flex_style='flex: 2 0 200px') -%}
+<div style="{{ flex_style }}">
+  <label class="form-label small text-secondary">{{ label }}</label>
+  <div class="position-relative">
+    <input type="text" name="{{ name }}" id="{{ input_id }}" class="form-control form-control-sm font-monospace"
+           placeholder="{{ placeholder }}" value="{{ value }}"
+           autocomplete="off" aria-autocomplete="list" aria-haspopup="listbox">
+    <ul id="{{ dropdown_id }}" role="listbox"
+        class="dropdown-menu p-0 font-monospace small"
+        style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
+  </div>
+</div>
+{%- endmacro %}

--- a/templates/_regex_filter_script.js
+++ b/templates/_regex_filter_script.js
@@ -8,7 +8,7 @@ function _sobsInitRegexFilter(opts) {
 
   const validateUrl = opts.validateUrl;
   const noMatchMessage = opts.noMatchMessage || "Valid regex — no matching records found.";
-  const hintMessage = opts.hintMessage || "Enter a regex pattern to filter records.";
+  const hintMessage = opts.hintMessage || "Enter an RE2 regex pattern to filter records.";
   const scope = (opts.scope && typeof opts.scope === "object") ? opts.scope : null;
   const suggestionLimit = Number.isFinite(opts.suggestionLimit) ? Math.max(5, Number(opts.suggestionLimit)) : 30;
 
@@ -34,6 +34,14 @@ function _sobsInitRegexFilter(opts) {
     { label: "\\n",     hint: "newline",                    insert: "\\n",     ctx: ["\\"] },
     { label: "\\t",     hint: "tab",                        insert: "\\t",     ctx: ["\\"] },
     { label: "\\b",     hint: "word boundary",              insert: "\\b",     ctx: ["\\"] },
+    { label: "\\A",     hint: "start of text",              insert: "\\A",     ctx: ["\\"] },
+    { label: "\\z",     hint: "end of text",                insert: "\\z",     ctx: ["\\"] },
+    { label: "\\.",     hint: "literal dot",                insert: "\\.",     ctx: ["\\", "general"] },
+    { label: "\\/",     hint: "literal slash",              insert: "\\/",     ctx: ["\\", "general"] },
+    { label: "[[:digit:]]+", hint: "POSIX digits",            insert: "[[:digit:]]+", ctx: ["[", "general"] },
+    { label: "[[:alpha:]]+", hint: "POSIX letters",           insert: "[[:alpha:]]+", ctx: ["[", "general"] },
+    { label: "[[:alnum:]_]+", hint: "POSIX word-like",        insert: "[[:alnum:]_]+", ctx: ["[", "general"] },
+    { label: "[[:space:]]+", hint: "POSIX whitespace",        insert: "[[:space:]]+", ctx: ["[", "general"] },
     { label: "[a-z]",   hint: "lowercase letters",          insert: "[a-z]",   ctx: ["[", "general"] },
     { label: "[A-Z]",   hint: "uppercase letters",          insert: "[A-Z]",   ctx: ["["] },
     { label: "[0-9]",   hint: "digits (explicit)",          insert: "[0-9]",   ctx: ["["] },
@@ -41,20 +49,28 @@ function _sobsInitRegexFilter(opts) {
     { label: "[^...]",  hint: "any char except ...",        insert: "[^",      ctx: ["["] },
     { label: "(?:...)", hint: "non-capturing group",        insert: "(?:",     ctx: ["(", "general"] },
     { label: "(?i)...", hint: "case-insensitive prefix",    insert: "(?i)",    ctx: ["("] },
-    { label: "(?=...)", hint: "positive lookahead",         insert: "(?=",     ctx: ["("] },
-    { label: "(?!...)", hint: "negative lookahead",         insert: "(?!",     ctx: ["("] },
     { label: "(a|b)",   hint: "alternation",                insert: "(",       ctx: ["("] },
     { label: "{n}",     hint: "exactly n times",            insert: "{",       ctx: ["{"] },
     { label: "{n,}",    hint: "at least n times",           insert: "{",       ctx: ["{"] },
     { label: "{n,m}",   hint: "between n and m times",      insert: "{",       ctx: ["{"] },
+    { label: "*?",      hint: "lazy zero or more",           insert: "*?",      ctx: ["general"] },
+    { label: "+?",      hint: "lazy one or more",            insert: "+?",      ctx: ["general"] },
+    { label: "??",      hint: "lazy optional",               insert: "??",      ctx: ["general"] },
     { label: "^",       hint: "start of string",            insert: "^",       ctx: ["^"] },
     { label: "$",       hint: "end of string",              insert: "$",       ctx: ["$"] },
     { label: ".*",      hint: "any chars (greedy)",         insert: ".*",      ctx: ["general"] },
+    { label: ".*?",     hint: "any chars (lazy)",           insert: ".*?",     ctx: ["general"] },
     { label: ".+",      hint: "one or more any chars",      insert: ".+",      ctx: ["general"] },
+    { label: ".+?",     hint: "one or more any chars (lazy)", insert: ".+?",   ctx: ["general"] },
+    { label: "(?:error|warn|fatal)", hint: "grouped alternation", insert: "(?:error|warn|fatal)", ctx: ["general"] },
+    { label: "(?m)^ERROR", hint: "multiline line-start match", insert: "(?m)^ERROR", ctx: ["general", "("] },
     { label: "error|warn", hint: "error/warn terms",        insert: "error|warn", ctx: ["general"] },
     { label: "exception|error|fatal", hint: "error type terms", insert: "exception|error|fatal", ctx: ["general"] },
     { label: "\\d{4}-\\d{2}-\\d{2}", hint: "date YYYY-MM-DD", insert: "\\d{4}-\\d{2}-\\d{2}", ctx: ["general"] },
     { label: "\\d+\\.\\d+", hint: "decimal number", insert: "\\d+\\.\\d+", ctx: ["general"] },
+    { label: "(?:GET|POST|PUT|DELETE)", hint: "HTTP methods", insert: "(?:GET|POST|PUT|DELETE)", ctx: ["general"] },
+    { label: "\\b(?:5\\d\\d|4\\d\\d)\\b", hint: "HTTP 4xx/5xx status", insert: "\\b(?:5\\d\\d|4\\d\\d)\\b", ctx: ["general"] },
+    { label: "(?:timeout|timed\\s*out|deadline)", hint: "timeout variants", insert: "(?:timeout|timed\\s*out|deadline)", ctx: ["general"] },
     { label: "https?://\\S+", hint: "URL",                  insert: "https?://\\S+", ctx: ["general"] },
     { label: "\\b\\d{1,3}(\\.\\d{1,3}){3}\\b", hint: "IPv4 address", insert: "\\b\\d{1,3}(\\.\\d{1,3}){3}\\b", ctx: ["general"] },
   ];

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_filter_macros.html" import render_filter_accordion, render_tz_init_script %}
+{% from "_filter_macros.html" import render_filter_accordion, render_regex_filter, render_tz_init_script %}
 {% from "_error_panels.html" import render_error_accordion, render_error_panel_styles %}
 {% from "_multi_select_filter.html" import render_multi_select, render_single_select %}
 {% block title %}Errors{% endblock %}
@@ -28,17 +28,7 @@
 <!-- Filter bar -->
 {% call render_filter_accordion('errorsFiltersAccordion', 'errorsFiltersHeading', 'errorsFiltersPanel', 'text-danger', 'errors-tz-badge-btn', 'errors-tz-badge-label') %}
     <form method="get" class="d-flex flex-wrap gap-2 align-items-end sobs-filter-form">
-      <div style="flex: 2 0 200px">
-        <label class="form-label small text-secondary">Search</label>
-        <div class="position-relative">
-          <input type="text" name="q" id="errors-regex-filter-input" class="form-control form-control-sm font-monospace"
-                 placeholder="regex search…" value="{{ q }}"
-                 autocomplete="off" aria-autocomplete="list" aria-haspopup="listbox">
-          <ul id="errors-regex-ac-dropdown" role="listbox"
-              class="dropdown-menu p-0 font-monospace small"
-              style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
-        </div>
-      </div>
+      {{ render_regex_filter(input_id='errors-regex-filter-input', dropdown_id='errors-regex-ac-dropdown', value=q) }}
       {{ render_multi_select('service', 'Service', services, selected_services, '140px') }}
       {{ render_single_select('resolved', 'Status', [
         {'value': '0', 'label': 'Open'},
@@ -242,7 +232,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching errors found.",
-  hintMessage: "Enter a regex pattern to search error messages."
+  hintMessage: "Enter a regex pattern to search error messages. Use RE2 syntax."
 });
 
 // ── Saved Reports: errors page ────────────────────────────────────────────

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from '_multi_select_filter.html' import render_multi_select %}
-{% from '_filter_macros.html' import render_filter_accordion %}
+{% from '_filter_macros.html' import render_filter_accordion, render_regex_filter %}
 {% block title %}Logs{% endblock %}
 {% block content %}
 {% set live = request.args.get('live', '') %}
@@ -65,17 +65,7 @@
       <input type="hidden" name="analyze" value="{{ analyze }}">
       <input type="hidden" name="stats" value="{{ '1' if stats_open else '' }}">
       <input type="hidden" name="trace_ids" value="{{ trace_ids_csv }}">
-      <div style="flex: 2 0 200px">
-        <label class="form-label small text-secondary">Grep pattern</label>
-        <div class="position-relative">
-          <input type="text" name="q" id="regex-filter-input" class="form-control form-control-sm font-monospace"
-                 placeholder="regex search…" value="{{ q }}"
-                 autocomplete="off" aria-autocomplete="list" aria-haspopup="listbox">
-          <ul id="regex-ac-dropdown" role="listbox"
-              class="dropdown-menu p-0 font-monospace small"
-              style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
-        </div>
-      </div>
+      {{ render_regex_filter(label='Grep pattern', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value=q) }}
       {{ render_multi_select('level', 'Level', levels, selected_levels, '120px') }}
       {{ render_multi_select('service', 'Service', services, selected_services, '140px') }}
       <div style="flex: 1 0 220px">
@@ -917,7 +907,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching log entries found.",
-  hintMessage: "Enter a regex pattern to filter log messages."
+  hintMessage: "Enter a regex pattern to filter log messages. Use RE2 syntax."
 });
 </script>
 

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "_multi_select_filter.html" import render_multi_select %}
-{% from "_filter_macros.html" import render_filter_accordion, render_tz_init_script %}
+{% from "_filter_macros.html" import render_filter_accordion, render_regex_filter, render_tz_init_script %}
 {% block title %}Metrics{% endblock %}
 {% block content %}
 <div class="d-flex align-items-center justify-content-between mb-3">
@@ -16,17 +16,7 @@
 
 {% call render_filter_accordion('metricsFiltersAccordion', 'metricsFiltersHeading', 'metricsFiltersPanel', 'text-info', 'metrics-tz-badge-btn', 'metrics-tz-badge-label', body_class='py-2') %}
     <form method="get" class="d-flex flex-wrap gap-2 align-items-end sobs-filter-form">
-      <div style="flex: 2 0 200px">
-        <label class="form-label small text-secondary">Search</label>
-        <div class="position-relative">
-          <input type="text" name="q" id="metrics-regex-filter-input" class="form-control form-control-sm font-monospace"
-                 placeholder="regex search…" value="{{ q }}"
-                 autocomplete="off" aria-autocomplete="list" aria-haspopup="listbox">
-          <ul id="metrics-regex-ac-dropdown" role="listbox"
-              class="dropdown-menu p-0 font-monospace small"
-              style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
-        </div>
-      </div>
+      {{ render_regex_filter(input_id='metrics-regex-filter-input', dropdown_id='metrics-regex-ac-dropdown', value=q) }}
       {{ render_multi_select('source', 'Source', sources, selected_sources, '120px') }}
       {{ render_multi_select('service', 'Service', services, selected_services, '140px') }}
       {{ render_multi_select('signal', 'Signal', signals, selected_signals, '140px') }}
@@ -208,7 +198,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching signal names found.",
-  hintMessage: "Enter a regex pattern to search signal names."
+  hintMessage: "Enter a regex pattern to search signal names. Use RE2 syntax."
 });
 
 // ── Saved Reports: metrics page ───────────────────────────────────────────

--- a/templates/rum.html
+++ b/templates/rum.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "_multi_select_filter.html" import render_single_select %}
-{% from "_filter_macros.html" import render_filter_accordion %}
+{% from "_filter_macros.html" import render_filter_accordion, render_regex_filter %}
 {% block title %}RUM{% endblock %}
 {% block content %}
 {% set from_ts = from_ts or request.args.get('from_ts', '') %}
@@ -753,15 +753,7 @@
 {% call render_filter_accordion('rumFiltersAccordion', 'rumFiltersHeading', 'rumFiltersPanel', 'text-primary', 'rum-tz-badge-btn', 'rum-tz-badge-label', body_class='py-3 rum-filters-panel') %}
     <form method="get" class="d-flex flex-wrap align-items-end rum-filters-form sobs-filter-form">
       <div class="rum-filter-field rum-filter-search">
-        <label class="form-label small text-secondary">Search</label>
-        <div class="position-relative">
-          <input type="text" name="q" id="rum-regex-filter-input" class="form-control form-control-sm font-monospace"
-                 placeholder="regex search…" value="{{ q }}"
-                 autocomplete="off" aria-autocomplete="list" aria-haspopup="listbox">
-          <ul id="rum-regex-ac-dropdown" role="listbox"
-              class="dropdown-menu p-0 font-monospace small"
-              style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
-        </div>
+        {{ render_regex_filter(input_id='rum-regex-filter-input', dropdown_id='rum-regex-ac-dropdown', value=q, flex_style='flex: 1 1 auto;') }}
       </div>
       {{ render_single_select('type', 'Event type', ([{'value': '', 'label': 'All types'}] + event_types), event_type, '140px') }}
       {{ render_single_select('error_source', 'Error source', ([{'value': '', 'label': 'All sources'}] + error_sources), error_source, '160px') }}
@@ -1665,7 +1657,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching RUM events found.",
-  hintMessage: "Enter a regex pattern to search RUM event data."
+  hintMessage: "Enter a regex pattern to search RUM event data. Use RE2 syntax."
 });
 
 // ── Saved Reports: RUM page ───────────────────────────────────────────────

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -518,6 +518,9 @@
   <!-- Span tree rows -->
   <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
     <small class="text-secondary">Visible rows {{ trace_detail.page_offset + 1 }}-{{ trace_detail.page_end }} of {{ trace_detail.capped_total_spans }}{% if trace_detail.hard_capped %} (first {{ trace_detail.hard_cap }} only){% endif %}</small>
+    {% if trace_detail.context_rows %}
+    <small class="text-secondary">+{{ trace_detail.context_rows }} ancestor context row(s)</small>
+    {% endif %}
     <div class="d-flex align-items-center gap-2">
       <select class="form-select form-select-sm" style="width:auto;" onchange="window.location.href=this.value" aria-label="Trace rows per page">
         {% for n in [100, 200, 500, 1000] %}

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_filter_macros.html" import render_filter_accordion %}
+{% from "_filter_macros.html" import render_filter_accordion, render_regex_filter %}
 {% from "_error_panels.html" import render_error_accordion, render_error_panel_styles %}
 {% from "_multi_select_filter.html" import render_multi_select %}
 {% block title %}Traces{% endblock %}
@@ -18,17 +18,7 @@
 <!-- Filter bar -->
 {% call render_filter_accordion('tracesFiltersAccordion', 'tracesFiltersHeading', 'tracesFiltersPanel', 'text-warning', 'traces-tz-badge-btn', 'traces-tz-badge-label') %}
     <form method="get" class="d-flex flex-wrap gap-2 align-items-end sobs-filter-form">
-      <div style="flex: 2 0 200px">
-        <label class="form-label small text-secondary">Search</label>
-        <div class="position-relative">
-          <input type="text" name="q" id="traces-regex-filter-input" class="form-control form-control-sm font-monospace"
-                 placeholder="regex search…" value="{{ q }}"
-                 autocomplete="off" aria-autocomplete="list" aria-haspopup="listbox">
-          <ul id="traces-regex-ac-dropdown" role="listbox"
-              class="dropdown-menu p-0 font-monospace small"
-              style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
-        </div>
-      </div>
+      {{ render_regex_filter(input_id='traces-regex-filter-input', dropdown_id='traces-regex-ac-dropdown', value=q) }}
       {{ render_multi_select('service', 'Service', services, selected_services, '140px') }}
       <div style="flex: 2 0 200px">
         <label class="form-label small text-secondary">Trace ID</label>
@@ -234,7 +224,11 @@
     <span class="badge bg-secondary-subtle text-secondary-emphasis" title="Actual trace timestamps">
       <i class="bi bi-clock-history me-1"></i>{{ trace_detail.trace_start_ts }} to {{ trace_detail.trace_end_ts }}
     </span>
-    <span class="badge bg-secondary">{{ trace_detail.span_tree | length }} span(s)</span>
+    <span class="badge bg-secondary">{{ trace_detail.total_spans }} span(s)</span>
+    <span class="badge bg-light text-dark border">showing {{ trace_detail.page_offset + 1 }}-{{ trace_detail.page_end }} of {{ trace_detail.capped_total_spans }}</span>
+    {% if trace_detail.hard_capped %}
+    <span class="badge bg-warning text-dark" title="Trace detail view is capped for safety">capped at {{ trace_detail.hard_cap }}</span>
+    {% endif %}
     <span class="badge bg-info text-dark">{{ fmt_ms(trace_detail.total_ms) }} total</span>
     <span class="badge bg-primary-subtle text-primary-emphasis"
           title="Active span coverage across the full trace window (merged non-overlapping span intervals)">
@@ -259,6 +253,18 @@
       <i class="bi bi-shield-exclamation me-1"></i>Incident View
     </a>
   </div>
+
+  {% if trace_detail.hard_capped %}
+  <div class="alert alert-warning py-2 px-3 small">
+    Showing the first {{ trace_detail.hard_cap }} spans for this trace to keep the page responsive. Narrow the trace timeframe or use paging below to inspect the capped timeline view.
+  </div>
+  {% endif %}
+
+  {% if trace_detail.default_collapsed %}
+  <div class="alert alert-secondary py-2 px-3 small">
+    Large trace detected. Child spans start collapsed by default to reduce initial render cost.
+  </div>
+  {% endif %}
 
   {% set mc = trace_detail.metrics_context or {} %}
   {% set ts_data = mc.timeseries or {'ticks_ms': [], 'by_metric': {}} %}
@@ -510,12 +516,34 @@
   </div>
 
   <!-- Span tree rows -->
-  <div id="traceTree">
+  <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
+    <small class="text-secondary">Visible rows {{ trace_detail.page_offset + 1 }}-{{ trace_detail.page_end }} of {{ trace_detail.capped_total_spans }}{% if trace_detail.hard_capped %} (first {{ trace_detail.hard_cap }} only){% endif %}</small>
+    <div class="d-flex align-items-center gap-2">
+      <select class="form-select form-select-sm" style="width:auto;" onchange="window.location.href=this.value" aria-label="Trace rows per page">
+        {% for n in [100, 200, 500, 1000] %}
+        <option value="{{ url_for('view_traces', service=service, trace_id=trace_id, from_ts=from_ts, to_ts=to_ts, sort_by=sort_by, sort_dir=sort_dir, limit=limit, offset=offset, q=q, trace_span_limit=n, trace_span_offset=0) }}" {% if trace_detail.page_limit == n %}selected{% endif %}>{{ n }} rows</option>
+        {% endfor %}
+      </select>
+      <ul class="pagination pagination-sm mb-0">
+        {% if trace_detail.has_prev_page %}
+        <li class="page-item">
+          <a class="page-link" href="{{ url_for('view_traces', service=service, trace_id=trace_id, from_ts=from_ts, to_ts=to_ts, sort_by=sort_by, sort_dir=sort_dir, limit=limit, offset=offset, q=q, trace_span_limit=trace_detail.page_limit, trace_span_offset=trace_detail.prev_offset) }}">← Prev</a>
+        </li>
+        {% endif %}
+        {% if trace_detail.has_next_page %}
+        <li class="page-item">
+          <a class="page-link" href="{{ url_for('view_traces', service=service, trace_id=trace_id, from_ts=from_ts, to_ts=to_ts, sort_by=sort_by, sort_dir=sort_dir, limit=limit, offset=offset, q=q, trace_span_limit=trace_detail.page_limit, trace_span_offset=trace_detail.next_offset) }}">Next →</a>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+
+  <div id="traceTree" data-default-collapsed="{{ '1' if trace_detail.default_collapsed else '0' }}">
     {% for span in trace_detail.span_tree %}
     {% set is_error = span.status and 'ERROR' in span.status %}
     {% set has_span_error = span.span_id in trace_detail.error_span_ids %}
     {% set log_count = trace_detail.log_counts.get(span.span_id, 0) %}
-    {% set row_id = 'span-' ~ loop.index %}
     <div class="trace-tree-row d-flex align-items-center py-1 border-bottom"
          data-depth="{{ span.depth }}"
          data-span-id="{{ span.span_id }}"
@@ -589,23 +617,22 @@
               title="View raw span record"
               data-span-id="{{ span.span_id }}"
               data-trace-id="{{ span.trace_id }}"
-              data-raw-target="raw-span-{{ loop.index }}"
               aria-label="Toggle raw span record"
               aria-expanded="false">
         <i class="bi bi-braces" style="font-size:.8rem;"></i>
       </button>
     </div>
-    <!-- Raw span accordion panel (lazy-loaded) -->
-    <div id="raw-span-{{ loop.index }}"
-         class="raw-span-panel d-none border-bottom"
-         data-span-id="{{ span.span_id }}"
-         data-loaded="0"
-         style="padding-left:{{ span.depth * 20 + 8 }}px; background:var(--bs-tertiary-bg);">
-      <div class="raw-span-body p-2">
-        <div class="raw-span-loading text-secondary small"><span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Loading…</div>
-      </div>
-    </div>
     {% endfor %}
+  </div>
+
+  <div id="trace-shared-raw-panel"
+       class="raw-span-panel d-none border-bottom"
+       data-open="0"
+       data-span-id=""
+       style="background:var(--bs-tertiary-bg);">
+    <div class="raw-span-body p-2">
+      <div class="raw-span-loading text-secondary small"><span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Loading…</div>
+    </div>
   </div>
 
   {% if trace_detail.errors %}
@@ -763,6 +790,41 @@ if (window.sobsTimezone && typeof window.sobsTimezone.initPage === 'function') {
   style.textContent = '.trace-tree-row.tree-hidden { display: none !important; }';
   document.head.appendChild(style);
 
+  var traceTree = document.getElementById('traceTree');
+  var sharedRawPanel = document.getElementById('trace-shared-raw-panel');
+  var activeRawRow = null;
+
+  function hideSharedRawPanel() {
+    if (!sharedRawPanel) return;
+    sharedRawPanel.classList.add('d-none');
+    sharedRawPanel.dataset.open = '0';
+    sharedRawPanel.dataset.spanId = '';
+    if (activeRawRow) {
+      var activeBtn = activeRawRow.querySelector('.span-raw-toggle');
+      if (activeBtn) {
+        activeBtn.setAttribute('aria-expanded', 'false');
+        var activeIcon = activeBtn.querySelector('i');
+        if (activeIcon) activeIcon.classList.remove('text-warning');
+      }
+    }
+    activeRawRow = null;
+  }
+
+  function setActiveRawRow(row) {
+    activeRawRow = row || null;
+  }
+
+  if (traceTree && traceTree.dataset.defaultCollapsed === '1') {
+    traceTree.querySelectorAll('.trace-tree-row').forEach(function (row) {
+      var depth = parseInt(row.dataset.depth || '0', 10);
+      if (depth > 0) row.classList.add('tree-hidden');
+    });
+    traceTree.querySelectorAll('.tree-toggle i').forEach(function (icon) {
+      icon.classList.remove('bi-chevron-down');
+      icon.classList.add('bi-chevron-right');
+    });
+  }
+
   document.querySelectorAll('.tree-toggle').forEach(function (btn) {
     btn.addEventListener('click', function () {
       var row = btn.closest('.trace-tree-row');
@@ -782,19 +844,7 @@ if (window.sobsTimezone && typeof window.sobsTimezone.initPage === 'function') {
           if (isExpanded) {
             // Collapsing: hide ALL descendants.
             next.classList.add('tree-hidden');
-            // Also close any open raw payload panel for the hidden row.
-            var rawToggle = next.querySelector('.span-raw-toggle');
-            if (rawToggle) {
-              var rawPanelId = rawToggle.dataset.rawTarget;
-              var rawPanel = rawPanelId ? document.getElementById(rawPanelId) : null;
-              if (rawPanel) {
-                rawPanel.classList.add('d-none');
-                rawPanel.dataset.open = '0';
-              }
-              rawToggle.setAttribute('aria-expanded', 'false');
-              var rawIcon = rawToggle.querySelector('i');
-              if (rawIcon) rawIcon.classList.remove('text-warning');
-            }
+            if (activeRawRow === next) hideSharedRawPanel();
           } else {
             // Expanding: only reveal direct children; leave deeper rows as-is
             // so their own collapsed state is preserved.
@@ -802,45 +852,124 @@ if (window.sobsTimezone && typeof window.sobsTimezone.initPage === 'function') {
               next.classList.remove('tree-hidden');
             }
           }
-        } else if (isExpanded && next.classList.contains('raw-span-panel')) {
-          // Ensure stray visible raw panels are hidden when collapsing a parent.
-          next.classList.add('d-none');
-          next.dataset.open = '0';
         }
         next = next.nextElementSibling;
       }
+
+      if (isExpanded && activeRawRow) {
+        var activeDepth = parseInt(activeRawRow.dataset.depth || '0', 10);
+        if (activeDepth > depth) {
+          var cursor = activeRawRow.previousElementSibling;
+          while (cursor) {
+            if (!cursor.classList.contains('trace-tree-row')) {
+              cursor = cursor.previousElementSibling;
+              continue;
+            }
+            var cursorDepth = parseInt(cursor.dataset.depth || '0', 10);
+            if (cursorDepth < activeDepth && cursor === row) {
+              hideSharedRawPanel();
+              break;
+            }
+            if (cursorDepth <= depth) break;
+            cursor = cursor.previousElementSibling;
+          }
+        }
+      }
     });
   });
+
+  window._traceTreeHideSharedRawPanel = hideSharedRawPanel;
+  window._traceTreeSetActiveRawRow = setActiveRawRow;
 }());
 
-/* Raw span accordion – lazy-load and copy-to-clipboard */
+/* Raw span panel – lazy-load and copy-to-clipboard */
 (function () {
+  var sharedPanel = document.getElementById('trace-shared-raw-panel');
+  if (!sharedPanel) return;
+
+  var sharedBody = sharedPanel.querySelector('.raw-span-body');
+  var rawSpanCache = Object.create(null);
+
+  function renderLoading() {
+    sharedBody.innerHTML = '<div class="raw-span-loading text-secondary small"><span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Loading…</div>';
+  }
+
+  function renderRawBody(payload) {
+    if (payload.error) {
+      sharedBody.innerHTML = '<span class="text-danger small">' + _escHtml(payload.error) + '</span>';
+      return;
+    }
+    var truncNote = payload.truncated
+      ? '<div class="alert alert-warning py-1 px-2 mb-2 small">Large payload – attribute values truncated to 512 characters.</div>'
+      : '';
+    sharedBody.innerHTML =
+      truncNote +
+      '<div class="d-flex align-items-center gap-2 mb-1">' +
+      '<span class="small text-secondary fw-semibold">Raw Span Record</span>' +
+      '<button class="btn btn-outline-secondary btn-sm py-0 px-2 span-raw-copy-btn" ' +
+      '  style="font-size:.7rem;" title="Copy JSON to clipboard">' +
+      '  <i class="bi bi-clipboard me-1"></i>Copy' +
+      '</button>' +
+      '</div>' +
+      '<pre class="mb-0 p-2 rounded small font-monospace" ' +
+      '  style="white-space:pre-wrap; word-break:break-all; max-height:400px; overflow-y:auto; ' +
+      '         background:var(--bs-tertiary-bg); color:var(--bs-body-color); border:1px solid var(--bs-border-color);">' +
+      _escHtml(payload.raw) +
+      '</pre>';
+
+    var copyBtn = sharedBody.querySelector('.span-raw-copy-btn');
+    if (copyBtn) {
+      copyBtn.addEventListener('click', function () {
+        navigator.clipboard.writeText(payload.raw).then(function () {
+          var orig = copyBtn.innerHTML;
+          copyBtn.innerHTML = '<i class="bi bi-check2 me-1"></i>Copied';
+          copyBtn.classList.replace('btn-outline-secondary', 'btn-secondary');
+          setTimeout(function () {
+            copyBtn.innerHTML = orig;
+            copyBtn.classList.replace('btn-secondary', 'btn-outline-secondary');
+          }, 1800);
+        }).catch(function (e) {
+          window.SOBS.notify('Could not copy: ' + e.message, { level: 'danger', title: 'Clipboard' });
+        });
+      });
+    }
+  }
+
   document.querySelectorAll('.span-raw-toggle').forEach(function (btn) {
     btn.addEventListener('click', function () {
-      var panelId = btn.dataset.rawTarget;
-      var panel = document.getElementById(panelId);
-      if (!panel) return;
+      var row = btn.closest('.trace-tree-row');
+      if (!row) return;
+      var hidePanel = window._traceTreeHideSharedRawPanel;
 
-      var isOpen = panel.dataset.open === '1';
-      if (isOpen) {
-        panel.classList.add('d-none');
-        panel.dataset.open = '0';
-        btn.setAttribute('aria-expanded', 'false');
-        btn.querySelector('i').classList.remove('text-warning');
+      var sameRowOpen = sharedPanel.dataset.open === '1' && sharedPanel.dataset.spanId === btn.dataset.spanId;
+      if (sameRowOpen) {
+        if (typeof hidePanel === 'function') hidePanel();
         return;
       }
 
-      // Show the panel first so the user sees the spinner immediately.
-      panel.classList.remove('d-none');
-      panel.dataset.open = '1';
+      if (typeof hidePanel === 'function') hidePanel();
+
+      row.insertAdjacentElement('afterend', sharedPanel);
+      sharedPanel.style.paddingLeft = row.style.paddingLeft;
+      sharedPanel.classList.remove('d-none');
+      sharedPanel.dataset.open = '1';
+      sharedPanel.dataset.spanId = btn.dataset.spanId || '';
+      if (typeof window._traceTreeSetActiveRawRow === 'function') {
+        window._traceTreeSetActiveRawRow(row);
+      }
       btn.setAttribute('aria-expanded', 'true');
       btn.querySelector('i').classList.add('text-warning');
-
-      // Only fetch once; subsequent opens reuse the cached DOM.
-      if (panel.dataset.loaded === '1') return;
+      renderLoading();
 
       var spanId = btn.dataset.spanId;
       var traceId = btn.dataset.traceId || '';
+      if (!spanId) return;
+
+      if (rawSpanCache[spanId]) {
+        renderRawBody(rawSpanCache[spanId]);
+        return;
+      }
+
       var rawSpanUrl = {{ url_for('api_raw_span', span_id='') | tojson }} + encodeURIComponent(spanId);
       if (traceId) {
         rawSpanUrl += '?trace_id=' + encodeURIComponent(traceId);
@@ -848,53 +977,15 @@ if (window.sobsTimezone && typeof window.sobsTimezone.initPage === 'function') {
       fetch(rawSpanUrl)
         .then(function (res) { return res.json(); })
         .then(function (data) {
-          panel.dataset.loaded = '1';
-          var body = panel.querySelector('.raw-span-body');
-          if (data.error) {
-            body.innerHTML = '<span class="text-danger small">' + _escHtml(data.error) + '</span>';
+          rawSpanCache[spanId] = data;
+          if (sharedPanel.dataset.spanId !== spanId) {
             return;
           }
-          var truncNote = data.truncated
-            ? '<div class="alert alert-warning py-1 px-2 mb-2 small">Large payload – attribute values truncated to 512 characters.</div>'
-            : '';
-          var copyId = 'raw-copy-' + panelId;
-          body.innerHTML =
-            truncNote +
-            '<div class="d-flex align-items-center gap-2 mb-1">' +
-            '<span class="small text-secondary fw-semibold">Raw Span Record</span>' +
-            '<button class="btn btn-outline-secondary btn-sm py-0 px-2 span-raw-copy-btn" ' +
-            '  id="' + _escAttr(copyId) + '" ' +
-            '  style="font-size:.7rem;" title="Copy JSON to clipboard">' +
-            '  <i class="bi bi-clipboard me-1"></i>Copy' +
-            '</button>' +
-            '</div>' +
-            '<pre class="mb-0 p-2 rounded small font-monospace" ' +
-            '  style="white-space:pre-wrap; word-break:break-all; max-height:400px; overflow-y:auto; ' +
-            '         background:var(--bs-tertiary-bg); color:var(--bs-body-color); border:1px solid var(--bs-border-color);">' +
-            _escHtml(data.raw) +
-            '</pre>';
-
-          var copyBtn = body.querySelector('.span-raw-copy-btn');
-          if (copyBtn) {
-            copyBtn.addEventListener('click', function () {
-              navigator.clipboard.writeText(data.raw).then(function () {
-                var orig = copyBtn.innerHTML;
-                copyBtn.innerHTML = '<i class="bi bi-check2 me-1"></i>Copied';
-                copyBtn.classList.replace('btn-outline-secondary', 'btn-secondary');
-                setTimeout(function () {
-                  copyBtn.innerHTML = orig;
-                  copyBtn.classList.replace('btn-secondary', 'btn-outline-secondary');
-                }, 1800);
-              }).catch(function (e) {
-                window.SOBS.notify('Could not copy: ' + e.message, { level: 'danger', title: 'Clipboard' });
-              });
-            });
-          }
+          renderRawBody(data);
         })
         .catch(function (err) {
-          panel.dataset.loaded = '0';
-          var body = panel.querySelector('.raw-span-body');
-          body.innerHTML = '<span class="text-danger small">Failed to load: ' + _escHtml(String(err)) + '</span>';
+          if (sharedPanel.dataset.spanId !== spanId) return;
+          sharedBody.innerHTML = '<span class="text-danger small">Failed to load: ' + _escHtml(String(err)) + '</span>';
         });
     });
   });
@@ -905,9 +996,6 @@ if (window.sobsTimezone && typeof window.sobsTimezone.initPage === 'function') {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
-  }
-  function _escAttr(s) {
-    return String(s).replace(/"/g, '&quot;');
   }
 }());
 
@@ -943,7 +1031,7 @@ window.SOBS.initRaiseIssueModal({
       to_ts: {{ to_ts | tojson }}
     },
     noMatchMessage: "Valid regex — no matching span names found.",
-    hintMessage: "Enter a regex pattern to search span names."
+    hintMessage: "Enter a regex pattern to search span names. Use RE2 syntax."
   });
 
   // ── Saved Reports: traces page ────────────────────────────────────────────

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4375,7 +4375,7 @@ class TestUIPages:
         assert data_b["span"]["service"] == "raw-disambiguate-b"
 
     async def test_trace_detail_includes_raw_span_toggle(self, client):
-        """Trace detail view includes the raw span toggle button and panel markup."""
+        """Trace detail view includes the raw span toggle button and shared lazy-load panel markup."""
         from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
         from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
         from opentelemetry.proto.resource.v1.resource_pb2 import Resource
@@ -4406,11 +4406,12 @@ class TestUIPages:
         r = await client.get(f"/traces?trace_id={trace_id_hex}")
         assert r.status_code == 200
         body = await r.get_data(as_text=True)
-        # Raw toggle button and lazy-load panel present
+        # Raw toggle button and shared lazy-load panel present.
         assert "span-raw-toggle" in body
         assert "raw-span-panel" in body
         assert "raw-span-loading" in body
-        assert 'data-loaded="0"' in body
+        assert 'id="trace-shared-raw-panel"' in body
+        assert 'data-open="0"' in body
         assert "data-trace-id=" in body
         # JavaScript for lazy loading present
         assert "/api/traces/span/" in body

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4416,6 +4416,53 @@ class TestUIPages:
         # JavaScript for lazy loading present
         assert "/api/traces/span/" in body
 
+    async def test_trace_detail_pagination_includes_ancestor_context(self, client):
+        """Paged trace detail includes ancestor rows so child-only orphan pages are avoided."""
+        from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+        from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+        from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+        from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span, Status
+
+        trace_id_bytes = bytes.fromhex("1234567811223344aabbccddeeff0011")
+        root_span_id = bytes.fromhex("1111111122222222")
+        child_span_id = bytes.fromhex("3333333344444444")
+        start_ns = 1704067200_000_000_000
+
+        root_span = Span(
+            trace_id=trace_id_bytes,
+            span_id=root_span_id,
+            name="ancestor-root-span",
+            start_time_unix_nano=start_ns,
+            end_time_unix_nano=start_ns + 2_000_000_000,
+            status=Status(code=1),
+        )
+        child_span = Span(
+            trace_id=trace_id_bytes,
+            span_id=child_span_id,
+            parent_span_id=root_span_id,
+            name="descendant-child-span",
+            start_time_unix_nano=start_ns + 500_000_000,
+            end_time_unix_nano=start_ns + 1_000_000_000,
+            status=Status(code=1),
+        )
+        resource = Resource(attributes=[KeyValue(key="service.name", value=AnyValue(string_value="paging-svc"))])
+        msg = ExportTraceServiceRequest(
+            resource_spans=[ResourceSpans(resource=resource, scope_spans=[ScopeSpans(spans=[root_span, child_span])])]
+        )
+        r = await client.post(
+            "/v1/traces", data=msg.SerializeToString(), headers={"Content-Type": "application/x-protobuf"}
+        )
+        assert r.status_code == 200
+
+        trace_id_hex = trace_id_bytes.hex()
+        r = await client.get(f"/traces?trace_id={trace_id_hex}&trace_span_limit=1&trace_span_offset=1")
+        assert r.status_code == 200
+        body = await r.get_data(as_text=True)
+
+        assert "ancestor-root-span" in body
+        assert "descendant-child-span" in body
+        assert "+1 ancestor context row" in body
+
     async def test_rum_sort_by_type(self, client):
         r = await client.get("/rum?sort_by=EventName&sort_dir=asc")
         assert r.status_code == 200


### PR DESCRIPTION
## Summary
This PR hardens trace detail rendering for very large traces and aligns regex-backed filtering with chDB/ClickHouse RE2 behavior.

## Changes
- add shared RE2 validation before executing `match()`-backed filters
- refactor the regex filter input markup into a shared template macro
- improve shared regex helper guidance and RE2-safe suggestions
- cap and page trace detail tree rows for large traces
- default-collapse large trace trees
- replace per-row hidden raw panels with a single shared lazy-loaded raw span panel
- skip the wasted flat-list trace query when trace detail is selected
- update trace detail UI coverage test for the shared raw panel

## Validation
- `for f ("app.py" "masking.py" "echarts_chart_types.py" "examples/python" "tests" "scripts" "examples/notifications"); do isort $f && black $f && flake8 $f && mypy $f; done`
- `$PWD/.venv/bin/python -m pytest -q`

Closes #191
