### PR TITLE
feat(filters): support inline regex NOT clauses

### DIFF
--- a/app.py
+++ b/app.py
@@ -10341,6 +10341,62 @@ def _validate_re2_pattern(db: "ChDbConnection", pattern: str) -> str | None:
     return None
 
 
+_REGEX_FILTER_AND_SPLIT_RE = re.compile(r"\s*&&\s*")
+
+
+def _parse_regex_filter_expression(raw: str) -> tuple[list[str], list[str], str | None]:
+    """Parse `include && !exclude` style regex expressions from filter inputs."""
+    expression = str(raw or "").strip()
+    if not expression:
+        return [], [], None
+
+    parts = [part.strip() for part in _REGEX_FILTER_AND_SPLIT_RE.split(expression)]
+    if not parts or any(not part for part in parts):
+        return [], [], "Regex error: invalid expression around '&&'"
+
+    include_patterns: list[str] = []
+    exclude_patterns: list[str] = []
+    for part in parts:
+        negate = part.startswith("!")
+        token = part[1:].strip() if negate else part
+        if not token:
+            return [], [], "Regex error: expected a pattern after '!'"
+        try:
+            re.compile(token, re.IGNORECASE)
+        except re.error as exc:
+            return [], [], f"Regex error: {exc}"
+        if negate:
+            exclude_patterns.append(token)
+        else:
+            include_patterns.append(token)
+
+    return include_patterns, exclude_patterns, None
+
+
+def _validate_re2_patterns(db: "ChDbConnection", patterns: list[str]) -> str | None:
+    for pattern in patterns:
+        re2_error = _validate_re2_pattern(db, pattern)
+        if re2_error:
+            return re2_error
+    return None
+
+
+def _append_regex_expression_clauses(
+    *,
+    conditions: list[str],
+    params: list[Any],
+    column: str,
+    include_patterns: list[str],
+    exclude_patterns: list[str],
+) -> None:
+    for pattern in include_patterns:
+        conditions.append(f"match({column}, ?)")
+        params.append(pattern)
+    for pattern in exclude_patterns:
+        conditions.append(f"NOT match({column}, ?)")
+        params.append(pattern)
+
+
 @app.route("/logs")
 @require_basic_auth
 async def view_logs():
@@ -10377,17 +10433,18 @@ async def view_logs():
     stats_generated_age_s = 0
     where = ""
     params: list = []
+    include_patterns: list[str] = []
+    exclude_patterns: list[str] = []
 
     if time_error:
         error_msg = time_error
 
     if q:
-        try:
-            re.compile(q, re.IGNORECASE)
-        except re.error as exc:
-            error_msg = f"Regex error: {exc}"
+        include_patterns, exclude_patterns, parse_error = _parse_regex_filter_expression(q)
+        if parse_error:
+            error_msg = parse_error
         if not error_msg:
-            re2_error = _validate_re2_pattern(db, q)
+            re2_error = _validate_re2_patterns(db, [*include_patterns, *exclude_patterns])
             if re2_error:
                 error_msg = re2_error
 
@@ -10462,8 +10519,17 @@ async def view_logs():
             query_where = where
             query_params = list(params)
             if q:
-                query_where = f"{query_where} AND match(Body, ?)" if query_where else "WHERE match(Body, ?)"
-                query_params.append(q)
+                regex_conditions: list[str] = []
+                _append_regex_expression_clauses(
+                    conditions=regex_conditions,
+                    params=query_params,
+                    column="Body",
+                    include_patterns=include_patterns,
+                    exclude_patterns=exclude_patterns,
+                )
+                if regex_conditions:
+                    regex_sql = " AND ".join(regex_conditions)
+                    query_where = f"{query_where} AND {regex_sql}" if query_where else f"WHERE {regex_sql}"
 
             select_base = (
                 "SELECT Timestamp, SeverityText, ServiceName, Body, TraceId, SpanId " f"FROM otel_logs {query_where} "
@@ -12321,18 +12387,24 @@ async def view_metrics():
     rows: list[dict] = []
     total = 0
     error_msg = time_error
+    include_patterns: list[str] = []
+    exclude_patterns: list[str] = []
     if q and not error_msg:
-        try:
-            re.compile(q, re.IGNORECASE)
-        except re.error as exc:
-            error_msg = f"Regex error: {exc}"
+        include_patterns, exclude_patterns, parse_error = _parse_regex_filter_expression(q)
+        if parse_error:
+            error_msg = parse_error
         if not error_msg:
-            re2_error = _validate_re2_pattern(db, q)
+            re2_error = _validate_re2_patterns(db, [*include_patterns, *exclude_patterns])
             if re2_error:
                 error_msg = re2_error
             else:
-                where_parts.append("match(SignalName, ?)")
-                params.append(q)
+                _append_regex_expression_clauses(
+                    conditions=where_parts,
+                    params=params,
+                    column="SignalName",
+                    include_patterns=include_patterns,
+                    exclude_patterns=exclude_patterns,
+                )
 
     if hour_clause:
         params.append(hours)
@@ -13074,14 +13146,15 @@ async def view_errors():
             "Timestamp",
         )
     q = request.args.get("q", "").strip()
+    include_patterns: list[str] = []
+    exclude_patterns: list[str] = []
     error_msg = time_error or ""
     if q and not error_msg:
-        try:
-            re.compile(q, re.IGNORECASE)
-        except re.error as exc:
-            error_msg = f"Regex error: {exc}"
+        include_patterns, exclude_patterns, parse_error = _parse_regex_filter_expression(q)
+        if parse_error:
+            error_msg = parse_error
         if not error_msg:
-            re2_error = _validate_re2_pattern(db, q)
+            re2_error = _validate_re2_patterns(db, [*include_patterns, *exclude_patterns])
             if re2_error:
                 error_msg = re2_error
     resolved_ids = _get_resolved_error_ids(db)
@@ -13095,8 +13168,13 @@ async def view_errors():
     where_parts.extend(time_conditions)
     where_params.extend(time_params)
     if q and not error_msg:
-        where_parts.append("match(Body, ?)")
-        where_params.append(q)
+        _append_regex_expression_clauses(
+            conditions=where_parts,
+            params=where_params,
+            column="Body",
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+        )
     where_sql = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
 
     if grouped_mode:
@@ -14047,13 +14125,14 @@ async def view_traces():
     params = []
     q = request.args.get("q", "").strip()
     q_error = ""
+    include_patterns: list[str] = []
+    exclude_patterns: list[str] = []
     if q:
-        try:
-            re.compile(q, re.IGNORECASE)
-        except re.error as exc:
-            q_error = f"Regex error: {exc}"
+        include_patterns, exclude_patterns, parse_error = _parse_regex_filter_expression(q)
+        if parse_error:
+            q_error = parse_error
         if not q_error:
-            re2_error = _validate_re2_pattern(db, q)
+            re2_error = _validate_re2_patterns(db, [*include_patterns, *exclude_patterns])
             if re2_error:
                 q_error = re2_error
     if selected_services:
@@ -14067,8 +14146,13 @@ async def view_traces():
     conditions.extend(time_conditions)
     params.extend(time_params)
     if q and not q_error:
-        conditions.append("match(SpanName, ?)")
-        params.append(q)
+        _append_regex_expression_clauses(
+            conditions=conditions,
+            params=params,
+            column="SpanName",
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+        )
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
     if trace_id and not time_error:
         total = 0
@@ -15776,13 +15860,14 @@ async def view_rum():
 
     q = request.args.get("q", "").strip()
     q_error = ""
+    include_patterns: list[str] = []
+    exclude_patterns: list[str] = []
     if q:
-        try:
-            re.compile(q, re.IGNORECASE)
-        except re.error as exc:
-            q_error = f"Regex error: {exc}"
+        include_patterns, exclude_patterns, parse_error = _parse_regex_filter_expression(q)
+        if parse_error:
+            q_error = parse_error
         if not q_error:
-            re2_error = _validate_re2_pattern(db, q)
+            re2_error = _validate_re2_patterns(db, [*include_patterns, *exclude_patterns])
             if re2_error:
                 q_error = re2_error
 
@@ -15798,8 +15883,13 @@ async def view_rum():
     conditions.extend(time_conditions)
     params.extend(time_params)
     if q and not q_error:
-        conditions.append("match(Body, ?)")
-        params.append(q)
+        _append_regex_expression_clauses(
+            conditions=conditions,
+            params=params,
+            column="Body",
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+        )
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
     total = 0
     events: list[dict[str, Any]] = []
@@ -22109,6 +22199,16 @@ def _regex_scope_time_conditions(scope: dict[str, Any], column: str) -> tuple[li
     return conditions, params
 
 
+def _parse_and_validate_regex_expression_for_api(db: Any, expression: str) -> tuple[list[str], list[str], str | None]:
+    include_patterns, exclude_patterns, parse_error = _parse_regex_filter_expression(expression)
+    if parse_error:
+        return [], [], parse_error.replace("Regex error: ", "", 1)
+    re2_error = _validate_re2_patterns(db, [*include_patterns, *exclude_patterns])
+    if re2_error:
+        return [], [], re2_error.replace("Regex error: ", "", 1)
+    return include_patterns, exclude_patterns, None
+
+
 def _regex_best_effort_sample(
     db: Any,
     *,
@@ -22149,14 +22249,13 @@ async def api_logs_validate_regex():
     if not pattern:
         return jsonify({"ok": True, "sample": None})
 
-    try:
-        re.compile(pattern, re.IGNORECASE)
-    except re.error as exc:
-        return jsonify({"ok": False, "error": str(exc), "sample": None})
+    db = get_db()
+    include_patterns, _exclude_patterns, expression_error = _parse_and_validate_regex_expression_for_api(db, pattern)
+    if expression_error:
+        return jsonify({"ok": False, "error": expression_error, "sample": None})
 
     # Attempt a cheap LIMIT 1 probe to surface a real sample match.
     try:
-        db = get_db()
         where_parts: list[str] = []
         where_params: list[Any] = []
 
@@ -22178,15 +22277,17 @@ async def api_logs_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = _regex_best_effort_sample(
-            db,
-            from_sql="otel_logs",
-            sample_column="Body",
-            order_column="Timestamp",
-            pattern=pattern,
-            where_parts=where_parts,
-            where_params=where_params,
-        )
+        sample = None
+        if include_patterns:
+            sample = _regex_best_effort_sample(
+                db,
+                from_sql="otel_logs",
+                sample_column="Body",
+                order_column="Timestamp",
+                pattern=include_patterns[0],
+                where_parts=where_parts,
+                where_params=where_params,
+            )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22208,13 +22309,12 @@ async def api_errors_validate_regex():
     if not pattern:
         return jsonify({"ok": True, "sample": None})
 
-    try:
-        re.compile(pattern, re.IGNORECASE)
-    except re.error as exc:
-        return jsonify({"ok": False, "error": str(exc), "sample": None})
+    db = get_db()
+    include_patterns, _exclude_patterns, expression_error = _parse_and_validate_regex_expression_for_api(db, pattern)
+    if expression_error:
+        return jsonify({"ok": False, "error": expression_error, "sample": None})
 
     try:
-        db = get_db()
         where_parts: list[str] = []
         where_params: list[Any] = []
 
@@ -22227,15 +22327,17 @@ async def api_errors_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = _regex_best_effort_sample(
-            db,
-            from_sql=f"({ERROR_SOURCES_SQL})",
-            sample_column="Body",
-            order_column="Timestamp",
-            pattern=pattern,
-            where_parts=where_parts,
-            where_params=where_params,
-        )
+        sample = None
+        if include_patterns:
+            sample = _regex_best_effort_sample(
+                db,
+                from_sql=f"({ERROR_SOURCES_SQL})",
+                sample_column="Body",
+                order_column="Timestamp",
+                pattern=include_patterns[0],
+                where_parts=where_parts,
+                where_params=where_params,
+            )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22257,13 +22359,12 @@ async def api_traces_validate_regex():
     if not pattern:
         return jsonify({"ok": True, "sample": None})
 
-    try:
-        re.compile(pattern, re.IGNORECASE)
-    except re.error as exc:
-        return jsonify({"ok": False, "error": str(exc), "sample": None})
+    db = get_db()
+    include_patterns, _exclude_patterns, expression_error = _parse_and_validate_regex_expression_for_api(db, pattern)
+    if expression_error:
+        return jsonify({"ok": False, "error": expression_error, "sample": None})
 
     try:
-        db = get_db()
         where_parts: list[str] = []
         where_params: list[Any] = []
 
@@ -22280,15 +22381,17 @@ async def api_traces_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = _regex_best_effort_sample(
-            db,
-            from_sql="otel_traces",
-            sample_column="SpanName",
-            order_column="Timestamp",
-            pattern=pattern,
-            where_parts=where_parts,
-            where_params=where_params,
-        )
+        sample = None
+        if include_patterns:
+            sample = _regex_best_effort_sample(
+                db,
+                from_sql="otel_traces",
+                sample_column="SpanName",
+                order_column="Timestamp",
+                pattern=include_patterns[0],
+                where_parts=where_parts,
+                where_params=where_params,
+            )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22310,13 +22413,12 @@ async def api_metrics_validate_regex():
     if not pattern:
         return jsonify({"ok": True, "sample": None})
 
-    try:
-        re.compile(pattern, re.IGNORECASE)
-    except re.error as exc:
-        return jsonify({"ok": False, "error": str(exc), "sample": None})
+    db = get_db()
+    include_patterns, _exclude_patterns, expression_error = _parse_and_validate_regex_expression_for_api(db, pattern)
+    if expression_error:
+        return jsonify({"ok": False, "error": expression_error, "sample": None})
 
     try:
-        db = get_db()
         where_parts: list[str] = []
         where_params: list[Any] = []
 
@@ -22341,15 +22443,17 @@ async def api_metrics_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = _regex_best_effort_sample(
-            db,
-            from_sql="v_derived_signals_anomaly",
-            sample_column="SignalName",
-            order_column="time",
-            pattern=pattern,
-            where_parts=where_parts,
-            where_params=where_params,
-        )
+        sample = None
+        if include_patterns:
+            sample = _regex_best_effort_sample(
+                db,
+                from_sql="v_derived_signals_anomaly",
+                sample_column="SignalName",
+                order_column="time",
+                pattern=include_patterns[0],
+                where_parts=where_parts,
+                where_params=where_params,
+            )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22371,13 +22475,12 @@ async def api_rum_validate_regex():
     if not pattern:
         return jsonify({"ok": True, "sample": None})
 
-    try:
-        re.compile(pattern, re.IGNORECASE)
-    except re.error as exc:
-        return jsonify({"ok": False, "error": str(exc), "sample": None})
+    db = get_db()
+    include_patterns, _exclude_patterns, expression_error = _parse_and_validate_regex_expression_for_api(db, pattern)
+    if expression_error:
+        return jsonify({"ok": False, "error": expression_error, "sample": None})
 
     try:
-        db = get_db()
         where_parts: list[str] = []
         where_params: list[Any] = []
 
@@ -22394,15 +22497,17 @@ async def api_rum_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = _regex_best_effort_sample(
-            db,
-            from_sql="hyperdx_sessions",
-            sample_column="Body",
-            order_column="Timestamp",
-            pattern=pattern,
-            where_parts=where_parts,
-            where_params=where_params,
-        )
+        sample = None
+        if include_patterns:
+            sample = _regex_best_effort_sample(
+                db,
+                from_sql="hyperdx_sessions",
+                sample_column="Body",
+                order_column="Timestamp",
+                pattern=include_patterns[0],
+                where_parts=where_parts,
+                where_params=where_params,
+            )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})

--- a/app.py
+++ b/app.py
@@ -10341,7 +10341,33 @@ def _validate_re2_pattern(db: "ChDbConnection", pattern: str) -> str | None:
     return None
 
 
-_REGEX_FILTER_AND_SPLIT_RE = re.compile(r"\s*&&\s*")
+def _split_regex_filter_expression_terms(expression: str) -> list[str]:
+    """Split expression by unescaped && while preserving escaped literal \\&& tokens."""
+    parts: list[str] = []
+    buf: list[str] = []
+    i = 0
+    n = len(expression)
+    while i < n:
+        if i + 1 < n and expression[i] == "&" and expression[i + 1] == "&":
+            backslashes = 0
+            j = i - 1
+            while j >= 0 and expression[j] == "\\":
+                backslashes += 1
+                j -= 1
+            if backslashes % 2 == 0:
+                parts.append("".join(buf).strip())
+                buf = []
+                i += 2
+                continue
+        buf.append(expression[i])
+        i += 1
+    parts.append("".join(buf).strip())
+    return parts
+
+
+def _unescape_regex_filter_term(term: str) -> str:
+    """Interpret \\&& as literal && within a regex term."""
+    return term.replace(r"\&&", "&&")
 
 
 def _parse_regex_filter_expression(raw: str) -> tuple[list[str], list[str], str | None]:
@@ -10350,7 +10376,7 @@ def _parse_regex_filter_expression(raw: str) -> tuple[list[str], list[str], str 
     if not expression:
         return [], [], None
 
-    parts = [part.strip() for part in _REGEX_FILTER_AND_SPLIT_RE.split(expression)]
+    parts = _split_regex_filter_expression_terms(expression)
     if not parts or any(not part for part in parts):
         return [], [], "Regex error: invalid expression around '&&'"
 
@@ -10359,6 +10385,7 @@ def _parse_regex_filter_expression(raw: str) -> tuple[list[str], list[str], str 
     for part in parts:
         negate = part.startswith("!")
         token = part[1:].strip() if negate else part
+        token = _unescape_regex_filter_term(token)
         if not token:
             return [], [], "Regex error: expected a pattern after '!'"
         try:
@@ -22215,20 +22242,31 @@ def _regex_best_effort_sample(
     from_sql: str,
     sample_column: str,
     order_column: str,
-    pattern: str,
+    include_patterns: list[str],
+    exclude_patterns: list[str],
     where_parts: list[str],
     where_params: list[Any],
 ) -> str | None:
     """Return a bounded sample match by probing only recent candidate rows."""
     where_sql = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+    regex_conditions: list[str] = []
+    regex_params: list[Any] = []
+    _append_regex_expression_clauses(
+        conditions=regex_conditions,
+        params=regex_params,
+        column="sample_value",
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+    )
+    regex_where_sql = ("WHERE " + " AND ".join(regex_conditions)) if regex_conditions else ""
     sql = (
-        f"SELECT {sample_column} FROM ("
-        f"SELECT {sample_column} FROM {from_sql} "
+        "SELECT sample_value FROM ("
+        f"SELECT {sample_column} AS sample_value FROM {from_sql} "
         f"{where_sql} ORDER BY {order_column} DESC LIMIT ?"
         ") "
-        f"WHERE match({sample_column}, ?) LIMIT 1"
+        f"{regex_where_sql} LIMIT 1"
     )
-    params = [*where_params, _REGEX_VALIDATE_CANDIDATE_LIMIT, pattern]
+    params = [*where_params, _REGEX_VALIDATE_CANDIDATE_LIMIT, *regex_params]
     row = db.execute(sql, params).fetchone()
     return _truncate_sample(row[0] if row else None)
 
@@ -22277,17 +22315,16 @@ async def api_logs_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = None
-        if include_patterns:
-            sample = _regex_best_effort_sample(
-                db,
-                from_sql="otel_logs",
-                sample_column="Body",
-                order_column="Timestamp",
-                pattern=include_patterns[0],
-                where_parts=where_parts,
-                where_params=where_params,
-            )
+        sample = _regex_best_effort_sample(
+            db,
+            from_sql="otel_logs",
+            sample_column="Body",
+            order_column="Timestamp",
+            include_patterns=include_patterns,
+            exclude_patterns=_exclude_patterns,
+            where_parts=where_parts,
+            where_params=where_params,
+        )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22327,17 +22364,16 @@ async def api_errors_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = None
-        if include_patterns:
-            sample = _regex_best_effort_sample(
-                db,
-                from_sql=f"({ERROR_SOURCES_SQL})",
-                sample_column="Body",
-                order_column="Timestamp",
-                pattern=include_patterns[0],
-                where_parts=where_parts,
-                where_params=where_params,
-            )
+        sample = _regex_best_effort_sample(
+            db,
+            from_sql=f"({ERROR_SOURCES_SQL})",
+            sample_column="Body",
+            order_column="Timestamp",
+            include_patterns=include_patterns,
+            exclude_patterns=_exclude_patterns,
+            where_parts=where_parts,
+            where_params=where_params,
+        )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22381,17 +22417,16 @@ async def api_traces_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = None
-        if include_patterns:
-            sample = _regex_best_effort_sample(
-                db,
-                from_sql="otel_traces",
-                sample_column="SpanName",
-                order_column="Timestamp",
-                pattern=include_patterns[0],
-                where_parts=where_parts,
-                where_params=where_params,
-            )
+        sample = _regex_best_effort_sample(
+            db,
+            from_sql="otel_traces",
+            sample_column="SpanName",
+            order_column="Timestamp",
+            include_patterns=include_patterns,
+            exclude_patterns=_exclude_patterns,
+            where_parts=where_parts,
+            where_params=where_params,
+        )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22443,17 +22478,16 @@ async def api_metrics_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = None
-        if include_patterns:
-            sample = _regex_best_effort_sample(
-                db,
-                from_sql="v_derived_signals_anomaly",
-                sample_column="SignalName",
-                order_column="time",
-                pattern=include_patterns[0],
-                where_parts=where_parts,
-                where_params=where_params,
-            )
+        sample = _regex_best_effort_sample(
+            db,
+            from_sql="v_derived_signals_anomaly",
+            sample_column="SignalName",
+            order_column="time",
+            include_patterns=include_patterns,
+            exclude_patterns=_exclude_patterns,
+            where_parts=where_parts,
+            where_params=where_params,
+        )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})
@@ -22497,17 +22531,16 @@ async def api_rum_validate_regex():
         where_parts.extend(time_parts)
         where_params.extend(time_params)
 
-        sample = None
-        if include_patterns:
-            sample = _regex_best_effort_sample(
-                db,
-                from_sql="hyperdx_sessions",
-                sample_column="Body",
-                order_column="Timestamp",
-                pattern=include_patterns[0],
-                where_parts=where_parts,
-                where_params=where_params,
-            )
+        sample = _regex_best_effort_sample(
+            db,
+            from_sql="hyperdx_sessions",
+            sample_column="Body",
+            order_column="Timestamp",
+            include_patterns=include_patterns,
+            exclude_patterns=_exclude_patterns,
+            where_parts=where_parts,
+            where_params=where_params,
+        )
         return masked_jsonify({"ok": True, "sample": sample})
     except Exception:
         return masked_jsonify({"ok": True, "sample": None})

--- a/templates/_filter_macros.html
+++ b/templates/_filter_macros.html
@@ -46,7 +46,7 @@ if (!{{ fn_name }}()) {
 }
 {%- endmacro %}
 
-{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (use && and !)…', flex_style='flex: 2 0 200px') -%}
+{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (&&, !, \\&&)…', flex_style='flex: 2 0 200px') -%}
 <div style="{{ flex_style }}">
   <label class="form-label small text-secondary">{{ label }}</label>
   <div class="position-relative">

--- a/templates/_filter_macros.html
+++ b/templates/_filter_macros.html
@@ -46,7 +46,7 @@ if (!{{ fn_name }}()) {
 }
 {%- endmacro %}
 
-{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (use && and !)…', flex_style='flex: 2 0 200px') -%}
+{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (use && and !)…', flex_style='flex: 2 0 200px', helper_text='Use RE2 with && and !. Example: error && !healthcheck') -%}
 <div style="{{ flex_style }}">
   <label class="form-label small text-secondary">{{ label }}</label>
   <div class="position-relative">
@@ -57,5 +57,6 @@ if (!{{ fn_name }}()) {
         class="dropdown-menu p-0 font-monospace small"
         style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
   </div>
+  <div class="form-text small" style="line-height:1.15;">{{ helper_text }}</div>
 </div>
 {%- endmacro %}

--- a/templates/_filter_macros.html
+++ b/templates/_filter_macros.html
@@ -46,7 +46,7 @@ if (!{{ fn_name }}()) {
 }
 {%- endmacro %}
 
-{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (use && and !)…', flex_style='flex: 2 0 200px', helper_text='Use RE2 with && and !. Example: error && !healthcheck') -%}
+{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (use && and !)…', flex_style='flex: 2 0 200px') -%}
 <div style="{{ flex_style }}">
   <label class="form-label small text-secondary">{{ label }}</label>
   <div class="position-relative">
@@ -57,6 +57,5 @@ if (!{{ fn_name }}()) {
         class="dropdown-menu p-0 font-monospace small"
         style="display:none;position:absolute;top:100%;left:0;z-index:1060;min-width:100%;max-width:600px;max-height:min(400px,60vh);overflow-y:auto;"></ul>
   </div>
-  <div class="form-text small" style="line-height:1.15;">{{ helper_text }}</div>
 </div>
 {%- endmacro %}

--- a/templates/_filter_macros.html
+++ b/templates/_filter_macros.html
@@ -46,7 +46,7 @@ if (!{{ fn_name }}()) {
 }
 {%- endmacro %}
 
-{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search…', flex_style='flex: 2 0 200px') -%}
+{% macro render_regex_filter(label='Search', name='q', input_id='regex-filter-input', dropdown_id='regex-ac-dropdown', value='', placeholder='regex search (use && and !)…', flex_style='flex: 2 0 200px') -%}
 <div style="{{ flex_style }}">
   <label class="form-label small text-secondary">{{ label }}</label>
   <div class="position-relative">

--- a/templates/_regex_filter_script.js
+++ b/templates/_regex_filter_script.js
@@ -8,7 +8,7 @@ function _sobsInitRegexFilter(opts) {
 
   const validateUrl = opts.validateUrl;
   const noMatchMessage = opts.noMatchMessage || "Valid regex — no matching records found.";
-  const hintMessage = opts.hintMessage || "Enter an RE2 regex pattern to filter records.";
+  const hintMessage = opts.hintMessage || "Enter RE2 regex terms. Combine with && and negate with !.";
   const scope = (opts.scope && typeof opts.scope === "object") ? opts.scope : null;
   const suggestionLimit = Number.isFinite(opts.suggestionLimit) ? Math.max(5, Number(opts.suggestionLimit)) : 30;
 
@@ -100,12 +100,39 @@ function _sobsInitRegexFilter(opts) {
     if (dropdown.style.display !== "none") renderStatusRow();
   }
 
+  function parseRegexExpression(value) {
+    const expr = String(value || "").trim();
+    if (!expr) return { include: [], exclude: [], error: null };
+    const parts = expr.split(/\s*&&\s*/).map((part) => part.trim());
+    if (!parts.length || parts.some((part) => !part)) {
+      return { include: [], exclude: [], error: "Invalid expression around '&&'." };
+    }
+    const include = [];
+    const exclude = [];
+    for (const part of parts) {
+      const negate = part.startsWith("!");
+      const token = negate ? part.slice(1).trim() : part;
+      if (!token) {
+        return { include: [], exclude: [], error: "Expected a pattern after '!'." };
+      }
+      if (negate) exclude.push(token);
+      else include.push(token);
+    }
+    return { include, exclude, error: null };
+  }
+
   function clientValidate(value) {
     const v = String(value || "").trim();
     if (!v) return { ok: true, level: "info", message: hintMessage };
+    const parsed = parseRegexExpression(v);
+    if (parsed.error) {
+      return { ok: false, level: "error", message: `Invalid regex expression: ${parsed.error}` };
+    }
     try {
-      new RegExp(v, "i");
-      return { ok: true, level: "success", message: "Valid regex pattern." };
+      [...parsed.include, ...parsed.exclude].forEach((token) => {
+        new RegExp(token, "i");
+      });
+      return { ok: true, level: "success", message: "Valid regex expression." };
     } catch (err) {
       return { ok: false, level: "error", message: `Invalid regex: ${err.message}` };
     }

--- a/templates/_regex_filter_script.js
+++ b/templates/_regex_filter_script.js
@@ -8,7 +8,7 @@ function _sobsInitRegexFilter(opts) {
 
   const validateUrl = opts.validateUrl;
   const noMatchMessage = opts.noMatchMessage || "Valid regex — no matching records found.";
-  const hintMessage = opts.hintMessage || "Enter RE2 regex terms. Combine with && and negate with !.";
+  const hintMessage = opts.hintMessage || "Enter RE2 regex terms. Combine with &&, negate with !, and use \\&& for literal &&.";
   const scope = (opts.scope && typeof opts.scope === "object") ? opts.scope : null;
   const suggestionLimit = Number.isFinite(opts.suggestionLimit) ? Math.max(5, Number(opts.suggestionLimit)) : 30;
 
@@ -100,10 +100,36 @@ function _sobsInitRegexFilter(opts) {
     if (dropdown.style.display !== "none") renderStatusRow();
   }
 
+  function splitRegexExpressionTerms(expr) {
+    const parts = [];
+    let buf = "";
+    for (let i = 0; i < expr.length; i += 1) {
+      if (expr[i] === "&" && expr[i + 1] === "&") {
+        let backslashes = 0;
+        for (let j = i - 1; j >= 0 && expr[j] === "\\"; j -= 1) {
+          backslashes += 1;
+        }
+        if (backslashes % 2 === 0) {
+          parts.push(buf.trim());
+          buf = "";
+          i += 1;
+          continue;
+        }
+      }
+      buf += expr[i];
+    }
+    parts.push(buf.trim());
+    return parts;
+  }
+
+  function unescapeRegexExpressionTerm(term) {
+    return String(term || "").replace(/\\&&/g, "&&");
+  }
+
   function parseRegexExpression(value) {
     const expr = String(value || "").trim();
     if (!expr) return { include: [], exclude: [], error: null };
-    const parts = expr.split(/\s*&&\s*/).map((part) => part.trim());
+    const parts = splitRegexExpressionTerms(expr);
     if (!parts.length || parts.some((part) => !part)) {
       return { include: [], exclude: [], error: "Invalid expression around '&&'." };
     }
@@ -111,7 +137,7 @@ function _sobsInitRegexFilter(opts) {
     const exclude = [];
     for (const part of parts) {
       const negate = part.startsWith("!");
-      const token = negate ? part.slice(1).trim() : part;
+      const token = unescapeRegexExpressionTerm(negate ? part.slice(1).trim() : part);
       if (!token) {
         return { include: [], exclude: [], error: "Expected a pattern after '!'." };
       }

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -232,7 +232,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching errors found.",
-  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: timeout && !known benign)."
+  hintMessage: "Enter RE2 regex terms. Combine with &&, negate with !, and use \\&& for literal && (example: timeout && !known benign)."
 });
 
 // ── Saved Reports: errors page ────────────────────────────────────────────

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -232,7 +232,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching errors found.",
-  hintMessage: "Enter a regex pattern to search error messages. Use RE2 syntax."
+  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: timeout && !known benign)."
 });
 
 // ── Saved Reports: errors page ────────────────────────────────────────────

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -907,7 +907,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching log entries found.",
-  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: error && !healthcheck)."
+  hintMessage: "Enter RE2 regex terms. Combine with &&, negate with !, and use \\&& for literal && (example: error && !healthcheck)."
 });
 </script>
 

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -907,7 +907,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching log entries found.",
-  hintMessage: "Enter a regex pattern to filter log messages. Use RE2 syntax."
+  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: error && !healthcheck)."
 });
 </script>
 

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -198,7 +198,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching signal names found.",
-  hintMessage: "Enter a regex pattern to search signal names. Use RE2 syntax."
+  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: latency && !p95)."
 });
 
 // ── Saved Reports: metrics page ───────────────────────────────────────────

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -198,7 +198,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching signal names found.",
-  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: latency && !p95)."
+  hintMessage: "Enter RE2 regex terms. Combine with &&, negate with !, and use \\&& for literal && (example: latency && !p95)."
 });
 
 // ── Saved Reports: metrics page ───────────────────────────────────────────

--- a/templates/rum.html
+++ b/templates/rum.html
@@ -1657,7 +1657,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching RUM events found.",
-  hintMessage: "Enter a regex pattern to search RUM event data. Use RE2 syntax."
+  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: error && !ResizeObserver)."
 });
 
 // ── Saved Reports: RUM page ───────────────────────────────────────────────

--- a/templates/rum.html
+++ b/templates/rum.html
@@ -1657,7 +1657,7 @@ _sobsInitRegexFilter({
     to_ts: {{ to_ts | tojson }}
   },
   noMatchMessage: "Valid regex — no matching RUM events found.",
-  hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: error && !ResizeObserver)."
+  hintMessage: "Enter RE2 regex terms. Combine with &&, negate with !, and use \\&& for literal && (example: error && !ResizeObserver)."
 });
 
 // ── Saved Reports: RUM page ───────────────────────────────────────────────

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -1034,7 +1034,7 @@ window.SOBS.initRaiseIssueModal({
       to_ts: {{ to_ts | tojson }}
     },
     noMatchMessage: "Valid regex — no matching span names found.",
-    hintMessage: "Enter a regex pattern to search span names. Use RE2 syntax."
+    hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: db|redis && !healthcheck)."
   });
 
   // ── Saved Reports: traces page ────────────────────────────────────────────

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -1034,7 +1034,7 @@ window.SOBS.initRaiseIssueModal({
       to_ts: {{ to_ts | tojson }}
     },
     noMatchMessage: "Valid regex — no matching span names found.",
-    hintMessage: "Enter RE2 regex terms. Combine with && and negate with ! (example: db|redis && !healthcheck)."
+    hintMessage: "Enter RE2 regex terms. Combine with &&, negate with !, and use \\&& for literal && (example: db|redis && !healthcheck)."
   });
 
   // ── Saved Reports: traces page ────────────────────────────────────────────

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2424,6 +2424,63 @@ class TestUIPages:
         assert empty_data["ok"] is True
         assert empty_data.get("sample") is None
 
+        # Escaped literal && should be treated as text, not an expression separator.
+        scoped_service = f"regex-validate-logs-{time.time_ns()}"
+        await client.post(
+            "/v1/logs",
+            json={
+                "resourceLogs": [
+                    {
+                        "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": scoped_service}}]},
+                        "scopeLogs": [
+                            {
+                                "logRecords": [
+                                    {
+                                        "timeUnixNano": str(int(time.time() * 1_000_000_000)),
+                                        "severityText": "INFO",
+                                        "body": {"stringValue": "literal && marker"},
+                                    },
+                                    {
+                                        "timeUnixNano": str(int(time.time() * 1_000_000_000) + 1),
+                                        "severityText": "INFO",
+                                        "body": {"stringValue": "known-noise-marker"},
+                                    },
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+
+        r_literal = await client.post(
+            "/api/logs/validate-regex",
+            json={"pattern": r"literal \&& marker", "scope": {"service": scoped_service}},
+        )
+        assert r_literal.status_code == 200
+        literal_data = await r_literal.get_json()
+        assert literal_data["ok"] is True
+        assert literal_data.get("sample") == "literal && marker"
+
+        # Negative-only expressions should still return a sample that satisfies exclusions.
+        r_negative = await client.post(
+            "/api/logs/validate-regex",
+            json={"pattern": "!known-noise-marker", "scope": {"service": scoped_service}},
+        )
+        assert r_negative.status_code == 200
+        negative_data = await r_negative.get_json()
+        assert negative_data["ok"] is True
+        assert negative_data.get("sample") is not None
+        assert "known-noise-marker" not in str(negative_data.get("sample"))
+
+    def test_parse_regex_filter_expression_escaped_and(self):
+        from app import _parse_regex_filter_expression
+
+        include_patterns, exclude_patterns, error = _parse_regex_filter_expression(r"foo\&&bar&&baz&&!qux\&&z")
+        assert error is None
+        assert include_patterns == ["foo&&bar", "baz"]
+        assert exclude_patterns == ["qux&&z"]
+
     async def test_logs_attr_keys_catalog_and_hints(self, client):
         import time as _time
 


### PR DESCRIPTION
## Summary
Add inline include/exclude expression support to regex filters using RE2-backed matching.

Examples:
- `error && !healthcheck`
- `timeout|deadline && !known benign`
- `!noise1 && !noise2`

## What changed
- Added shared backend parser for regex expressions:
  - split by `&&` (with or without spaces)
  - `!term` means exclusion
- Added shared helper to append SQL predicates:
  - include -> `match(column, ?)`
  - exclude -> `NOT match(column, ?)`
- Wired expression handling into:
  - Logs (`Body`)
  - Errors (`Body`)
  - Traces (`SpanName`)
  - Metrics (`SignalName`)
  - RUM (`Body`)
- Updated regex validation APIs to parse/validate expression terms and return sample matches from first include term when present.
- Updated shared client-side regex validation in the filter autocomplete script to validate expression terms instead of treating the whole input as one JS regex.
- Updated regex filter hints/placeholders to document `&&` and `!` syntax.

## Validation
- `python -m py_compile app.py`
- Pre-commit hooks ran successfully in commit (isort/black/flake8/mypy)

Closes #193
