### PR TITLE
Enforce issue-branch-PR workflow and main branch governance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,16 @@
 # SOBS Copilot Instructions
 
+## Branch & PR Workflow (Mandatory)
+
+- Never commit directly to `main`.
+- Never push directly to `main`.
+- Every change must follow: Issue -> new branch -> pull request -> review -> merge.
+- Branch naming convention: `issue-<number>-<short-description>` (for example: `issue-321-fix-mcp-key-contrast`).
+- PRs must reference the issue number and include a short validation summary.
+- If work is started on `main` by mistake, stop and move changes to a new branch before continuing.
+
+These rules apply to humans and automated agents.
+
 ## Stack
 Flask/Jinja2, Bootstrap 5, chDB. Templates extend `base.html` via `{% block styles %}`, `{% block content %}`, `{% block scripts %}`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Branching Policy (Required)
+
+- Do not commit directly to `main`.
+- Do not push directly to `main`.
+- All work must use this flow: Issue -> new branch -> pull request -> review -> merge.
+- Use branch names like `issue-<number>-<short-description>`.
+- Every PR should reference its issue and include test/validation notes.
+
 ## Local Setup
 
 Use a virtual environment and install development dependencies:


### PR DESCRIPTION
## Summary
- add explicit no-direct-main workflow policy to repo agent instructions
- add matching branch policy section to contributor guide
- enforce Issue -> branch -> PR workflow in docs

## Validation
- updated docs only
- applied GitHub branch protection to main via API:
  - require pull request reviews (1 approval)
  - dismiss stale reviews
  - enforce for admins
  - require linear history
  - require conversation resolution
  - disable force pushes and deletions

## Notes
This PR exists to keep governance changes out of main direct commits.
