### PR TITLE
ci: add automated GHCR cleanup job after docker push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,3 +256,27 @@ jobs:
             SOBS_BUILD_VERSION=${{ steps.build_version.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  cleanup-ghcr:
+    name: Cleanup Stale GHCR Versions
+    runs-on: ubuntu-latest
+    needs: docker
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    permissions:
+      packages: write
+    steps:
+      - name: Delete untagged GHCR versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: sobs
+          package-type: container
+          delete-only-untagged-versions: true
+
+      - name: Delete old SHA-tagged versions (keep latest + v* releases)
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: sobs
+          package-type: container
+          delete-only-untagged-versions: false
+          ignore-versions: '^(latest|v\d+\..*)$'
+          min-versions-to-keep: 0


### PR DESCRIPTION
Closes #214

## What
Adds a `cleanup-ghcr` job to CI that runs automatically after each successful `docker` job (main branch pushes only).

## How
Two steps using `actions/delete-package-versions@v5`:
1. **Untagged versions** — deletes all untagged layer manifests produced by multi-arch builds
2. **Stale SHA tags** — deletes SHA-tagged versions while ignoring `latest` and any `v*` release tags

## Validation
- Manually deleted ~460 stale versions today; this will prevent re-accumulation
- Only runs on push to main (same condition as the docker push job)
- `latest` and `v0.1.0-beta.1` (and future `v*` tags) are preserved by the ignore pattern `^(latest|v\d+\..*)$`