### PR TITLE
ci: disable GHCR cleanup job (issue #223)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
     name: Cleanup Stale GHCR Versions
     runs-on: ubuntu-latest
     needs: docker
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: false # Disabled: issue #223 - cleanup is too aggressive and removes the latest tag
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
The cleanup job is too aggressive and removes the latest tag, making Using default tag: latest latest: Pulling from abartrim/sobs fail with manifest unknown. Disabling until a safe cleanup strategy is identified.

Fixes #223