### PR TITLE
Fix container startup by copying mcp.py into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application
 COPY app.py .
 COPY masking.py .
+COPY mcp.py .
 COPY scripts/docker-entrypoint.sh scripts/docker-entrypoint.sh
 COPY scripts/render_clickhouse_config.py scripts/render_clickhouse_config.py
 COPY templates/ templates/


### PR DESCRIPTION
Closes #226.

## What changed
- Updated `Dockerfile` to include `COPY mcp.py .` alongside other application modules.

## Why
Container startup failed because `app.py` imports `mcp` but `mcp.py` was not copied into `/app` during image build.

## Validation summary
- Built image successfully.
- Verified in-container import works:
  - `python -c "import mcp; print('mcp import ok')"`
- Confirmed import exits with code 0.