### PR TITLE
fix: make OTLP browser CORS configurable and include credentials header

### DIFF
--- a/app.py
+++ b/app.py
@@ -31198,8 +31198,7 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
     if metric_format == "prometheus":
         # --- Namespaces (kube-state-metrics Prometheus format) ---
         try:
-            namespace_rows = db.execute(
-                """
+            namespace_rows = db.execute("""
                 SELECT
                     Attributes['namespace'] AS name,
                     anyIf(Attributes['phase'], Value > 0) AS status,
@@ -31209,8 +31208,7 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
                 AND MetricName = 'kube_namespace_status_phase'
                 GROUP BY name
                 ORDER BY name
-                """
-            ).fetchall()
+                """).fetchall()
             result["namespaces"] = [
                 {
                     "name": str(row["name"]),
@@ -31224,8 +31222,7 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
             errors.append(f"namespaces: {exc}")
     else:
         try:
-            namespace_rows = db.execute(
-                """
+            namespace_rows = db.execute("""
                 SELECT
                     Attributes['k8s.namespace.name'] AS name,
                     max(TimeUnix) AS last_seen
@@ -31233,8 +31230,7 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
                 WHERE Attributes['k8s.namespace.name'] != ''
                 GROUP BY name
                 ORDER BY name
-                """
-            ).fetchall()
+                """).fetchall()
             result["namespaces"] = [
                 {
                     "name": str(row["name"]),

--- a/app.py
+++ b/app.py
@@ -364,6 +364,25 @@ _OTLP_CORS_ALLOWED_ORIGINS = tuple(
     if item.strip()
 )
 
+# Exact paths that are OTLP/RUM ingest endpoints exposed to browsers.
+# CORS is applied only to these paths, NOT to management API routes like
+# /v1/apps or /v1/releases which are not intended for browser cross-origin use.
+_OTLP_CORS_INGEST_PATHS = frozenset(
+    {
+        "/v1/logs",
+        "/v1/traces",
+        "/v1/metrics",
+        "/v1/rum",
+        "/v1/rum/assets",
+        "/v1/rum/client-token",
+        "/v1/errors",
+        "/v1/ai",
+    }
+)
+
+# Default ports per scheme – used to normalise origins for matching.
+_SCHEME_DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
+
 
 def _origin_allowed_for_otlp(origin: str) -> bool:
     parsed = urllib.parse.urlparse(origin)
@@ -374,11 +393,31 @@ def _origin_allowed_for_otlp(origin: str) -> bool:
         return False
 
     with_port = f"{scheme}://{netloc}"
-    without_port = f"{scheme}://{host}" if host else with_port
+    # Include the port-stripped form only when the origin carries no explicit
+    # port or uses the scheme default (e.g. https://example.com:443 →
+    # https://example.com).  Non-default ports must be matched explicitly so
+    # that a pattern like "https://example.com" does not accidentally allow
+    # "https://example.com:8443".
+    candidates: list[str] = [with_port]
+    if parsed.port is None or parsed.port == _SCHEME_DEFAULT_PORTS.get(scheme):
+        without_port = f"{scheme}://{host}" if host else with_port
+        if without_port != with_port:
+            candidates.append(without_port)
     for pattern in _OTLP_CORS_ALLOWED_ORIGINS:
         p = pattern.lower()
-        if fnmatch.fnmatch(with_port, p) or fnmatch.fnmatch(without_port, p):
+        if any(fnmatch.fnmatch(c, p) for c in candidates):
             return True
+    return False
+
+
+def _path_needs_otlp_cors(path: str) -> bool:
+    """Return True if *path* is an OTLP/RUM ingest endpoint that may receive
+    browser cross-origin requests."""
+    if path in _OTLP_CORS_INGEST_PATHS:
+        return True
+    # Dynamic sub-paths under /v1/rum/assets/ (individual asset downloads).
+    if path.startswith("/v1/rum/assets/"):
+        return True
     return False
 
 
@@ -388,7 +427,8 @@ def _append_vary_header(response: Response, value: str) -> None:
         response.headers["Vary"] = value
         return
     parts = [p.strip() for p in existing.split(",") if p.strip()]
-    if value not in parts:
+    # Vary tokens are case-insensitive; compare in lower-case to avoid dupes.
+    if value.lower() not in {p.lower() for p in parts}:
         response.headers["Vary"] = ", ".join(parts + [value])
 
 
@@ -402,7 +442,7 @@ async def _apply_security_headers(response: Response):
     if _request_is_secure_context():
         response.headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 
-    if request.path.startswith("/v1/"):
+    if _path_needs_otlp_cors(request.path):
         origin = str(request.headers.get("Origin") or "").strip()
         if origin and _origin_allowed_for_otlp(origin):
             response.headers["Access-Control-Allow-Origin"] = origin
@@ -411,7 +451,11 @@ async def _apply_security_headers(response: Response):
             response.headers.setdefault("Access-Control-Allow-Methods", "POST, OPTIONS")
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",
-                "Content-Type, Authorization, X-SOBS-RUM-Client, X-SOBS-RUM-Signature, X-SOBS-RUM-Timestamp",
+                (
+                    "Content-Type, Authorization, X-API-Key, "
+                    "X-SOBS-RUM-Client, X-SOBS-RUM-Signature, X-SOBS-RUM-Timestamp, "
+                    "X-SOBS-Asset-Timestamp, X-SOBS-Asset-Signature"
+                ),
             )
             response.headers.setdefault("Access-Control-Max-Age", "600")
 

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import atexit
 import base64
 import copy
 import difflib
+import fnmatch
 import hashlib
 import hmac
 import html
@@ -354,6 +355,43 @@ def _request_is_secure_context() -> bool:
     return str(request.scheme or "").lower() == "https"
 
 
+_OTLP_CORS_ALLOWED_ORIGINS = tuple(
+    item.strip()
+    for item in os.environ.get(
+        "SOBS_OTLP_CORS_ALLOWED_ORIGINS",
+        "http://localhost:*,https://localhost:*,http://127.0.0.1:*,https://127.0.0.1:*",
+    ).split(",")
+    if item.strip()
+)
+
+
+def _origin_allowed_for_otlp(origin: str) -> bool:
+    parsed = urllib.parse.urlparse(origin)
+    scheme = (parsed.scheme or "").lower()
+    host = (parsed.hostname or "").lower()
+    netloc = (parsed.netloc or "").lower()
+    if scheme not in {"http", "https"} or not netloc:
+        return False
+
+    with_port = f"{scheme}://{netloc}"
+    without_port = f"{scheme}://{host}" if host else with_port
+    for pattern in _OTLP_CORS_ALLOWED_ORIGINS:
+        p = pattern.lower()
+        if fnmatch.fnmatch(with_port, p) or fnmatch.fnmatch(without_port, p):
+            return True
+    return False
+
+
+def _append_vary_header(response: Response, value: str) -> None:
+    existing = str(response.headers.get("Vary") or "")
+    if not existing:
+        response.headers["Vary"] = value
+        return
+    parts = [p.strip() for p in existing.split(",") if p.strip()]
+    if value not in parts:
+        response.headers["Vary"] = ", ".join(parts + [value])
+
+
 @app.after_request
 async def _apply_security_headers(response: Response):
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
@@ -363,6 +401,19 @@ async def _apply_security_headers(response: Response):
     response.headers.setdefault("Content-Security-Policy", "frame-ancestors 'self'; object-src 'none'; base-uri 'self'")
     if _request_is_secure_context():
         response.headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+
+    if request.path.startswith("/v1/"):
+        origin = str(request.headers.get("Origin") or "").strip()
+        if origin and _origin_allowed_for_otlp(origin):
+            response.headers["Access-Control-Allow-Origin"] = origin
+            _append_vary_header(response, "Origin")
+            response.headers.setdefault("Access-Control-Allow-Methods", "POST, OPTIONS")
+            response.headers.setdefault(
+                "Access-Control-Allow-Headers",
+                "Content-Type, Authorization, X-SOBS-RUM-Client, X-SOBS-RUM-Signature, X-SOBS-RUM-Timestamp",
+            )
+            response.headers.setdefault("Access-Control-Max-Age", "600")
+
     return response
 
 
@@ -9429,6 +9480,14 @@ async def _parse_otlp_request(proto_class):
 # ---------------------------------------------------------------------------
 # OTLP Ingest – Logs  POST /v1/logs
 # ---------------------------------------------------------------------------
+@app.route("/v1/logs", methods=["OPTIONS"])
+@app.route("/v1/traces", methods=["OPTIONS"])
+@app.route("/v1/metrics", methods=["OPTIONS"])
+@app.route("/v1/rum/assets", methods=["OPTIONS"])
+async def ingest_preflight():
+    return "", 204
+
+
 @app.route("/v1/logs", methods=["POST"])
 @require_api_key
 async def ingest_logs():
@@ -24411,11 +24470,7 @@ async def _dispatch_browser_push_channel(config: dict, payload: dict) -> None:
     try:
         from cryptography.hazmat.backends import default_backend
         from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
-        from cryptography.hazmat.primitives.serialization import (
-            Encoding,
-            PublicFormat,
-            load_der_private_key,
-        )
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat, load_der_private_key
     except ImportError as exc:
         raise RuntimeError("The `cryptography` package is required for browser push notifications") from exc
 
@@ -24493,11 +24548,7 @@ def _encrypt_push_payload(
     plaintext: bytes, subscriber_pub_key_bytes: bytes, auth_bytes: bytes, backend: object
 ) -> tuple[bytes, bytes, bytes]:
     """Encrypt a Web Push payload using AES-128-GCM (RFC 8291 / RFC 8188)."""
-    from cryptography.hazmat.primitives.asymmetric.ec import (
-        ECDH,
-        SECP256R1,
-        generate_private_key,
-    )
+    from cryptography.hazmat.primitives.asymmetric.ec import ECDH, SECP256R1, generate_private_key
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
     from cryptography.hazmat.primitives.hashes import SHA256
     from cryptography.hazmat.primitives.hmac import HMAC as CryptoHMAC
@@ -24998,12 +25049,7 @@ def _generate_vapid_keys() -> tuple[str, str]:
     """Generate a new VAPID key pair. Returns (private_key_b64url, public_key_b64url)."""
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, generate_private_key
-    from cryptography.hazmat.primitives.serialization import (
-        Encoding,
-        NoEncryption,
-        PrivateFormat,
-        PublicFormat,
-    )
+    from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 
     private_key = generate_private_key(SECP256R1(), default_backend())
     private_bytes = private_key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
@@ -31151,7 +31197,8 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
     if metric_format == "prometheus":
         # --- Namespaces (kube-state-metrics Prometheus format) ---
         try:
-            namespace_rows = db.execute("""
+            namespace_rows = db.execute(
+                """
                 SELECT
                     Attributes['namespace'] AS name,
                     anyIf(Attributes['phase'], Value > 0) AS status,
@@ -31161,7 +31208,8 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
                 AND MetricName = 'kube_namespace_status_phase'
                 GROUP BY name
                 ORDER BY name
-                """).fetchall()
+                """
+            ).fetchall()
             result["namespaces"] = [
                 {
                     "name": str(row["name"]),
@@ -31175,7 +31223,8 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
             errors.append(f"namespaces: {exc}")
     else:
         try:
-            namespace_rows = db.execute("""
+            namespace_rows = db.execute(
+                """
                 SELECT
                     Attributes['k8s.namespace.name'] AS name,
                     max(TimeUnix) AS last_seen
@@ -31183,7 +31232,8 @@ def _fetch_k8s_from_otel(db: "ChDbConnection", query: dict[str, Any] | None = No
                 WHERE Attributes['k8s.namespace.name'] != ''
                 GROUP BY name
                 ORDER BY name
-                """).fetchall()
+                """
+            ).fetchall()
             result["namespaces"] = [
                 {
                     "name": str(row["name"]),

--- a/app.py
+++ b/app.py
@@ -407,6 +407,7 @@ async def _apply_security_headers(response: Response):
         if origin and _origin_allowed_for_otlp(origin):
             response.headers["Access-Control-Allow-Origin"] = origin
             _append_vary_header(response, "Origin")
+            response.headers.setdefault("Access-Control-Allow-Credentials", "true")
             response.headers.setdefault("Access-Control-Allow-Methods", "POST, OPTIONS")
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -631,7 +631,7 @@ class TestOtlpCors:
         return "https://evil.example.com"
 
     # ------------------------------------------------------------------ _origin_allowed_for_otlp unit tests
-    def test_allowed_origin_with_wildcard_port(self, monkeypatch):
+    def test_origin_allowed_for_otlp_with_wildcard_port(self, monkeypatch):
         monkeypatch.setattr(
             sobs_app,
             "_OTLP_CORS_ALLOWED_ORIGINS",
@@ -639,7 +639,7 @@ class TestOtlpCors:
         )
         assert sobs_app._origin_allowed_for_otlp("http://localhost:3000") is True
 
-    def test_disallowed_origin(self, monkeypatch):
+    def test_origin_allowed_for_otlp_rejects_disallowed_origin(self, monkeypatch):
         monkeypatch.setattr(
             sobs_app,
             "_OTLP_CORS_ALLOWED_ORIGINS",
@@ -673,7 +673,7 @@ class TestOtlpCors:
         )
         assert sobs_app._origin_allowed_for_otlp("https://example.com:443") is True
 
-    def test_invalid_origin_rejected(self, monkeypatch):
+    def test_origin_allowed_for_otlp_rejects_invalid_origin(self, monkeypatch):
         monkeypatch.setattr(
             sobs_app,
             "_OTLP_CORS_ALLOWED_ORIGINS",
@@ -684,20 +684,16 @@ class TestOtlpCors:
 
     # ------------------------------------------------------------------ _append_vary_header unit tests
     def test_append_vary_case_insensitive_dedup(self):
-        from quart import Quart
+        from quart.wrappers import Response as QuartResponse
 
-        _tmp = Quart(__name__)
-        with _tmp.test_request_context("/"):
-            from quart.wrappers import Response as QuartResponse
-
-            resp = QuartResponse("")
-            sobs_app._append_vary_header(resp, "Origin")
-            # Adding 'origin' (different case) should not duplicate.
-            sobs_app._append_vary_header(resp, "origin")
-            vary = resp.headers.get("Vary", "")
-            # There should be exactly one "Origin"-like token.
-            tokens = [t.strip() for t in vary.split(",") if t.strip()]
-            assert len(tokens) == 1
+        resp = QuartResponse("")
+        sobs_app._append_vary_header(resp, "Origin")
+        # Adding 'origin' (different case) should not duplicate.
+        sobs_app._append_vary_header(resp, "origin")
+        vary = resp.headers.get("Vary", "")
+        # There should be exactly one "Origin"-like token.
+        tokens = [t.strip() for t in vary.split(",") if t.strip()]
+        assert len(tokens) == 1
 
     # ------------------------------------------------------------------ CORS headers on ingest routes
     @pytest.mark.parametrize(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -617,6 +617,201 @@ class TestHealth:
         assert isinstance(data["write_queue_depth"], int)
 
 
+# ---------------------------------------------------------------------------
+# OTLP CORS behaviour
+# ---------------------------------------------------------------------------
+class TestOtlpCors:
+    """Tests for CORS header injection on OTLP/RUM ingest endpoints."""
+
+    # ------------------------------------------------------------------ helpers
+    def _allowed_origin(self):
+        return "http://localhost:3000"
+
+    def _disallowed_origin(self):
+        return "https://evil.example.com"
+
+    # ------------------------------------------------------------------ _origin_allowed_for_otlp unit tests
+    def test_allowed_origin_with_wildcard_port(self, monkeypatch):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("http://localhost:3000") is True
+
+    def test_disallowed_origin(self, monkeypatch):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("https://evil.example.com") is False
+
+    def test_pattern_without_port_does_not_match_origin_with_nondefault_port(self, monkeypatch):
+        """A pattern like 'https://example.com' must NOT match 'https://example.com:8443'."""
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("https://example.com",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("https://example.com:8443") is False
+
+    def test_pattern_without_port_matches_origin_without_port(self, monkeypatch):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("https://example.com",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("https://example.com") is True
+
+    def test_pattern_without_port_matches_origin_with_default_port(self, monkeypatch):
+        """https://example.com should match https://example.com:443 (default port)."""
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("https://example.com",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("https://example.com:443") is True
+
+    def test_invalid_origin_rejected(self, monkeypatch):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("not-an-origin") is False
+        assert sobs_app._origin_allowed_for_otlp("") is False
+
+    # ------------------------------------------------------------------ _append_vary_header unit tests
+    def test_append_vary_case_insensitive_dedup(self):
+        from quart import Quart
+
+        _tmp = Quart(__name__)
+        with _tmp.test_request_context("/"):
+            from quart.wrappers import Response as QuartResponse
+
+            resp = QuartResponse("")
+            sobs_app._append_vary_header(resp, "Origin")
+            # Adding 'origin' (different case) should not duplicate.
+            sobs_app._append_vary_header(resp, "origin")
+            vary = resp.headers.get("Vary", "")
+            # There should be exactly one "Origin"-like token.
+            tokens = [t.strip() for t in vary.split(",") if t.strip()]
+            assert len(tokens) == 1
+
+    # ------------------------------------------------------------------ CORS headers on ingest routes
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/logs",
+            "/v1/traces",
+            "/v1/metrics",
+            "/v1/rum",
+            "/v1/errors",
+            "/v1/ai",
+        ],
+    )
+    async def test_allowed_origin_gets_cors_headers(self, client, monkeypatch, path):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        r = await client.post(
+            path,
+            json={},
+            headers={"Origin": self._allowed_origin()},
+        )
+        assert r.headers.get("Access-Control-Allow-Origin") == self._allowed_origin()
+        assert r.headers.get("Access-Control-Allow-Credentials") == "true"
+        assert "Origin" in (r.headers.get("Vary") or "")
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/logs",
+            "/v1/traces",
+            "/v1/metrics",
+            "/v1/rum",
+        ],
+    )
+    async def test_disallowed_origin_gets_no_cors_headers(self, client, monkeypatch, path):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        r = await client.post(
+            path,
+            json={},
+            headers={"Origin": self._disallowed_origin()},
+        )
+        assert "Access-Control-Allow-Origin" not in r.headers
+        assert "Access-Control-Allow-Credentials" not in r.headers
+
+    async def test_options_preflight_with_api_key_header(self, client, monkeypatch):
+        """OPTIONS preflight including X-API-Key must succeed for an allowed origin."""
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        r = await client.options(
+            "/v1/logs",
+            headers={
+                "Origin": self._allowed_origin(),
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "Content-Type, X-API-Key",
+            },
+        )
+        assert r.status_code == 204
+        assert r.headers.get("Access-Control-Allow-Origin") == self._allowed_origin()
+        allow_headers = r.headers.get("Access-Control-Allow-Headers", "")
+        assert "X-API-Key" in allow_headers
+
+    async def test_options_preflight_with_asset_signature_headers(self, client, monkeypatch):
+        """OPTIONS preflight including asset signature headers must succeed for an allowed origin."""
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        r = await client.options(
+            "/v1/rum/assets",
+            headers={
+                "Origin": self._allowed_origin(),
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "Content-Type, X-SOBS-Asset-Timestamp, X-SOBS-Asset-Signature",
+            },
+        )
+        assert r.status_code == 204
+        assert r.headers.get("Access-Control-Allow-Origin") == self._allowed_origin()
+        allow_headers = r.headers.get("Access-Control-Allow-Headers", "")
+        assert "X-SOBS-Asset-Timestamp" in allow_headers
+        assert "X-SOBS-Asset-Signature" in allow_headers
+
+    # ------------------------------------------------------------------ CORS NOT applied to non-ingest routes
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/apps",
+            "/v1/releases/fake-id",
+        ],
+    )
+    async def test_non_ingest_routes_do_not_get_cors_headers(self, client, monkeypatch, path):
+        """Management API routes must not receive CORS headers even when the origin is allowed."""
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        r = await client.get(
+            path,
+            headers={"Origin": self._allowed_origin()},
+        )
+        assert "Access-Control-Allow-Origin" not in r.headers
+
+
 class TestWriteQueue:
     @pytest.mark.parametrize(
         ("path", "payload"),


### PR DESCRIPTION
## Summary
- make OTLP CORS allowed origins configurable via environment variable
- add `Access-Control-Allow-Credentials: true` for OTLP CORS responses when origin is allowed
- preserve least-privilege defaults unless explicitly overridden

## Why
Browser RUM requests from hosted signup/admin flows use credentials mode and were blocked by preflight checks without the credentials header.

## Validation
- local UI E2E in hosted environment now passes with browser console error checks enabled