### PR TITLE
fix: follow-up hardening for OTLP CORS origin parsing and method headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -399,7 +399,11 @@ def _origin_allowed_for_otlp(origin: str) -> bool:
     # that a pattern like "https://example.com" does not accidentally allow
     # "https://example.com:8443".
     candidates: list[str] = [with_port]
-    if parsed.port is None or parsed.port == _SCHEME_DEFAULT_PORTS.get(scheme):
+    try:
+        parsed_port = parsed.port
+    except ValueError:
+        return False
+    if parsed_port is None or parsed_port == _SCHEME_DEFAULT_PORTS.get(scheme):
         without_port = f"{scheme}://{host}" if host else with_port
         if without_port != with_port:
             candidates.append(without_port)
@@ -419,6 +423,13 @@ def _path_needs_otlp_cors(path: str) -> bool:
     if path.startswith("/v1/rum/assets/"):
         return True
     return False
+
+
+def _otlp_cors_allow_methods(path: str) -> str:
+    """Return allowed methods for CORS preflight on OTLP/RUM endpoints."""
+    if path.startswith("/v1/rum/assets/"):
+        return "GET, HEAD, OPTIONS"
+    return "POST, OPTIONS"
 
 
 def _append_vary_header(response: Response, value: str) -> None:
@@ -448,7 +459,7 @@ async def _apply_security_headers(response: Response):
             response.headers["Access-Control-Allow-Origin"] = origin
             _append_vary_header(response, "Origin")
             response.headers.setdefault("Access-Control-Allow-Credentials", "true")
-            response.headers.setdefault("Access-Control-Allow-Methods", "POST, OPTIONS")
+            response.headers.setdefault("Access-Control-Allow-Methods", _otlp_cors_allow_methods(request.path))
             response.headers.setdefault(
                 "Access-Control-Allow-Headers",
                 (

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -682,6 +682,14 @@ class TestOtlpCors:
         assert sobs_app._origin_allowed_for_otlp("not-an-origin") is False
         assert sobs_app._origin_allowed_for_otlp("") is False
 
+    def test_origin_allowed_for_otlp_rejects_invalid_port(self, monkeypatch):
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("https://example.com",),
+        )
+        assert sobs_app._origin_allowed_for_otlp("https://example.com:abc") is False
+
     # ------------------------------------------------------------------ _append_vary_header unit tests
     def test_append_vary_case_insensitive_dedup(self):
         from quart.wrappers import Response as QuartResponse
@@ -785,6 +793,27 @@ class TestOtlpCors:
         allow_headers = r.headers.get("Access-Control-Allow-Headers", "")
         assert "X-SOBS-Asset-Timestamp" in allow_headers
         assert "X-SOBS-Asset-Signature" in allow_headers
+
+    async def test_options_preflight_for_dynamic_asset_get(self, client, monkeypatch):
+        """Dynamic asset GET preflight should advertise GET/HEAD support."""
+        monkeypatch.setattr(
+            sobs_app,
+            "_OTLP_CORS_ALLOWED_ORIGINS",
+            ("http://localhost:*",),
+        )
+        r = await client.options(
+            "/v1/rum/assets/test-id",
+            headers={
+                "Origin": self._allowed_origin(),
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "Authorization",
+            },
+        )
+        assert r.status_code in {200, 204}
+        assert r.headers.get("Access-Control-Allow-Origin") == self._allowed_origin()
+        allow_methods = r.headers.get("Access-Control-Allow-Methods", "")
+        assert "GET" in allow_methods
+        assert "OPTIONS" in allow_methods
 
     # ------------------------------------------------------------------ CORS NOT applied to non-ingest routes
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- harden OTLP CORS origin parsing to safely reject malformed Origin ports (avoid ValueError path)
- return path-appropriate `Access-Control-Allow-Methods` for OTLP CORS responses
  - dynamic RUM asset downloads now advertise `GET, HEAD, OPTIONS`
  - ingest endpoints continue to advertise `POST, OPTIONS`
- add regression tests for malformed origin port handling and dynamic asset GET preflight

## Why
PR #235 was merged, but these follow-up hardening commits remained on the old branch after merge. This PR cleanly replays the missing changes onto `main`.

## Validation
- `python -m isort *.py tests/ scripts`
- `python -m black *.py tests/ scripts`
- `python -m flake8 *.py tests/ scripts`
- `python -m mypy app.py tests scripts`
- `python -m pytest`

Local result: 1086 passed, 4 skipped.