### PR TITLE
Fix Sobs polling fallback for CI release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,6 @@ jobs:
           fi
 
       - uses: actions/checkout@v6
-        if: steps.sobs_gate.outputs.enabled == 'true'
 
       - name: Set up Python
         if: steps.sobs_gate.outputs.enabled == 'true'
@@ -304,11 +303,9 @@ jobs:
           python-version: "3.14"
 
       - name: Set up QEMU for cross-platform image inspection
-        if: steps.sobs_gate.outputs.enabled == 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Log in to GitHub Container Registry
-        if: steps.sobs_gate.outputs.enabled == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -316,7 +313,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve release version
-        if: steps.sobs_gate.outputs.enabled == 'true'
         id: release_version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
@@ -326,7 +322,6 @@ jobs:
           fi
 
       - name: Resolve deterministic release id
-        if: steps.sobs_gate.outputs.enabled == 'true'
         id: release_id
         run: |
           release_key="${GITHUB_REPOSITORY}|${{ steps.release_version.outputs.value }}|${GITHUB_SHA}|${GITHUB_RUN_ID}|production"
@@ -334,14 +329,12 @@ jobs:
           echo "value=${release_id}" >> "$GITHUB_OUTPUT"
 
       - name: Download rum.min.js.map artifact
-        if: steps.sobs_gate.outputs.enabled == 'true'
         uses: actions/download-artifact@v6
         with:
           name: rum-min-js-sourcemap
           path: static
 
       - name: Extract resolved dependency snapshots from published image (per arch)
-        if: steps.sobs_gate.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           mkdir -p .sobs-release
@@ -357,7 +350,6 @@ jobs:
           done
 
       - name: Upload per-arch dependency snapshots
-        if: steps.sobs_gate.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: sobs-release-dependency-snapshots

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 import html
 import inspect
+import io
 import ipaddress as _ipaddress
 import json
 import logging
@@ -28,6 +29,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
+import zipfile
 import zlib
 from collections import Counter, OrderedDict
 from collections.abc import AsyncIterator
@@ -319,7 +321,7 @@ async def _startup_async_http_client() -> None:
 
 @app.after_serving
 async def _shutdown_async_http_client() -> None:
-    global _ASYNC_HTTP_CLIENT, _CVE_SCAN_TASK, _RAW_WINDOW_COPY_TASK
+    global _ASYNC_HTTP_CLIENT, _CVE_SCAN_TASK, _RAW_WINDOW_COPY_TASK, _GITHUB_REPO_HEALTH_TASK
     if _ASYNC_HTTP_CLIENT is not None:
         await _ASYNC_HTTP_CLIENT.aclose()
         _ASYNC_HTTP_CLIENT = None
@@ -337,6 +339,13 @@ async def _shutdown_async_http_client() -> None:
         except asyncio.CancelledError:
             pass
         _RAW_WINDOW_COPY_TASK = None
+    if _GITHUB_REPO_HEALTH_TASK is not None and not _GITHUB_REPO_HEALTH_TASK.done():
+        _GITHUB_REPO_HEALTH_TASK.cancel()
+        try:
+            await _GITHUB_REPO_HEALTH_TASK
+        except asyncio.CancelledError:
+            pass
+        _GITHUB_REPO_HEALTH_TASK = None
     _shutdown_db_resources()
 
 
@@ -16406,6 +16415,168 @@ def _decode_github_contents_payload(payload: dict[str, Any]) -> bytes:
         return b""
 
 
+def _github_actions_snapshot_name(filename: str) -> tuple[str, str, str] | None:
+    base = os.path.basename(str(filename or "").strip())
+    if not base:
+        return None
+    match = re.match(r"^pip-freeze-([a-z0-9_-]+)-([a-z0-9_-]+)\.txt$", base, re.IGNORECASE)
+    if not match:
+        return None
+    platform = match.group(1).lower()
+    architecture = match.group(2).lower()
+    return (f"pip-freeze-{platform}-{architecture}", platform, architecture)
+
+
+async def _github_actions_dependency_rows(
+    client: httpx.AsyncClient,
+    github_token: str,
+    owner: str,
+    repo: str,
+    release_id: str,
+    release_version: str,
+    commit_sha: str,
+) -> list[dict[str, Any]]:
+    """Return dependency artifact rows from GH Actions snapshots for a release."""
+    rows: list[dict[str, Any]] = []
+    params: dict[str, str] = {
+        "status": "completed",
+        "per_page": str(_GITHUB_ACTIONS_BACKFILL_MAX_RUNS_PER_RELEASE),
+    }
+    if commit_sha:
+        params["head_sha"] = commit_sha
+
+    try:
+        runs_resp = await client.get(
+            f"https://api.github.com/repos/{owner}/{repo}/actions/runs",
+            params=params,
+            headers=_github_api_headers(github_token),
+            timeout=20,
+        )
+    except Exception:
+        return rows
+
+    if runs_resp.status_code != 200:
+        return rows
+
+    runs_payload = runs_resp.json() if runs_resp.content else {}
+    workflow_runs = runs_payload.get("workflow_runs", []) if isinstance(runs_payload, dict) else []
+    if not isinstance(workflow_runs, list):
+        return rows
+
+    for run in workflow_runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("conclusion") or "").lower() != "success":
+            continue
+        run_id = str(run.get("id") or "").strip()
+        if not run_id:
+            continue
+
+        try:
+            artifacts_resp = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+                params={"per_page": "100"},
+                headers=_github_api_headers(github_token),
+                timeout=20,
+            )
+        except Exception:
+            continue
+        if artifacts_resp.status_code != 200:
+            continue
+
+        artifacts_payload = artifacts_resp.json() if artifacts_resp.content else {}
+        artifacts = artifacts_payload.get("artifacts", []) if isinstance(artifacts_payload, dict) else []
+        if not isinstance(artifacts, list):
+            continue
+
+        snapshot_artifact: dict[str, Any] | None = None
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            if str(artifact.get("name") or "") != _GITHUB_ACTIONS_SNAPSHOT_ARTIFACT_NAME:
+                continue
+            if bool(artifact.get("expired", False)):
+                continue
+            snapshot_artifact = artifact
+            break
+        if snapshot_artifact is None:
+            continue
+
+        archive_url = str(snapshot_artifact.get("archive_download_url") or "").strip()
+        artifact_id = str(snapshot_artifact.get("id") or "").strip()
+        if not archive_url:
+            continue
+
+        try:
+            archive_resp = await client.get(
+                archive_url,
+                headers=_github_api_headers(
+                    github_token,
+                    extra={"Accept": "application/octet-stream"},
+                ),
+                timeout=30,
+                follow_redirects=True,
+            )
+        except Exception:
+            continue
+        if archive_resp.status_code != 200 or not archive_resp.content:
+            continue
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(archive_resp.content)) as zip_file:
+                for info in zip_file.infolist():
+                    if info.is_dir():
+                        continue
+                    parsed_name = _github_actions_snapshot_name(info.filename)
+                    if not parsed_name:
+                        continue
+                    dep_name, platform, architecture = parsed_name
+                    raw_bytes = zip_file.read(info)
+                    deps = _parse_requirements_dependencies(raw_bytes.decode("utf-8", errors="replace"))
+                    if not deps:
+                        continue
+
+                    rows.append(
+                        {
+                            "Id": str(uuid.uuid4()),
+                            "ReleaseId": release_id,
+                            "ArtifactType": "dependencies-lockfile",
+                            "Name": dep_name,
+                            "ContentType": "text/plain",
+                            "Size": len(raw_bytes),
+                            "StorageRef": (
+                                f"github-actions://{owner}/{repo}/runs/{run_id}"
+                                f"/artifacts/{artifact_id}/{os.path.basename(info.filename)}"
+                            ),
+                            "ChecksumSha256": hashlib.sha256(raw_bytes).hexdigest(),
+                            "Platform": platform,
+                            "Architecture": architecture,
+                            "MetadataJson": json.dumps(
+                                {
+                                    "source": "github_actions_artifact",
+                                    "repo": f"{owner}/{repo}",
+                                    "run_id": run_id,
+                                    "run_head_sha": str(run.get("head_sha") or ""),
+                                    "release_version": release_version,
+                                    "artifact_name": str(snapshot_artifact.get("name") or ""),
+                                    "dependencies": deps,
+                                },
+                                separators=(",", ":"),
+                            ),
+                            "UploadedAt": _normalize_ch_timestamp(datetime.now(timezone.utc)),
+                            "IsDeleted": 0,
+                            "Version": int(time.time() * 1000),
+                        }
+                    )
+        except Exception:
+            continue
+
+        if rows:
+            return rows
+
+    return rows
+
+
 def _github_ref_candidates(release_version: str) -> list[str]:
     """Return Git refs to try for a release version, in priority order."""
     version = (release_version or "").strip()
@@ -16496,7 +16667,7 @@ async def _fetch_release_deps_from_github(db: "ChDbConnection") -> dict[str, int
 
     try:
         release_rows = db.execute(
-            "SELECT Id, AppId, ReleaseVersion "
+            "SELECT Id, AppId, ReleaseVersion, CommitSha "
             "FROM sobs_app_releases FINAL "
             "WHERE IsDeleted=0 "
             f"ORDER BY ReleasedAt DESC LIMIT {max_releases}"
@@ -16536,6 +16707,7 @@ async def _fetch_release_deps_from_github(db: "ChDbConnection") -> dict[str, int
         release_id = str(row[0] or "")
         app_id = str(row[1] or "")
         release_version = str(row[2] or "").strip()
+        commit_sha = str(row[3] or "").strip()
         app_info = apps_by_id.get(app_id, {})
         repo_url = str(app_info.get("repo_url") or "").strip()
         app_enabled = int(cast(Any, app_info.get("enabled")) or 0)
@@ -16549,6 +16721,22 @@ async def _fetch_release_deps_from_github(db: "ChDbConnection") -> dict[str, int
             continue
 
         attempted += 1
+
+        actions_rows = await _github_actions_dependency_rows(
+            client,
+            github_token,
+            owner,
+            repo,
+            release_id,
+            release_version,
+            commit_sha,
+        )
+        if actions_rows:
+            inserted_rows.extend(actions_rows)
+            existing_release_ids.add(release_id)
+            inserted += len(actions_rows)
+            continue
+
         found_for_release = False
         for ref in _github_ref_candidates(release_version):
             for lockfile_path, content_type, parser_kind in candidates:
@@ -17001,12 +17189,44 @@ async def _cve_scanner_loop() -> None:
         await asyncio.sleep(_CVE_SCAN_INTERVAL_S)
 
 
+async def _github_repo_health_loop() -> None:
+    """Background task: periodically sync GitHub repo health for configured repos."""
+    await asyncio.sleep(_GITHUB_REPO_HEALTH_INITIAL_DELAY_S)
+    while True:
+        try:
+            await _sync_github_repo_health_once()
+        except Exception:
+            app.logger.debug("GitHub repo health loop error", exc_info=True)
+        await asyncio.sleep(_GITHUB_REPO_HEALTH_INTERVAL_S)
+
+
+async def _sync_github_repo_health_once(db: "ChDbConnection | None" = None) -> dict[str, Any]:
+    """Run a single GitHub repo-health sync and persist summary settings."""
+    resolved_db = db if db is not None else get_db()
+    summary = await _collect_github_repo_health_summary(resolved_db)
+    if not bool(summary.get("ok")):
+        return summary
+
+    _set_app_setting(resolved_db, _GITHUB_REPO_HEALTH_LAST_SYNC_SETTING, str(summary.get("last_synced_at") or ""))
+    compact = {
+        "scanned_repos": int(summary.get("scanned_repos", 0) or 0),
+        "total_repos_considered": int(summary.get("total_repos_considered", 0) or 0),
+        "open_issues": int(summary.get("open_issues", 0) or 0),
+        "open_prs": int(summary.get("open_prs", 0) or 0),
+        "security_items": int(summary.get("security_items", 0) or 0),
+        "last_synced_at": str(summary.get("last_synced_at") or ""),
+    }
+    _set_app_setting(resolved_db, _GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING, json.dumps(compact, separators=(",", ":")))
+    return summary
+
+
 @app.before_serving
 async def _startup_enrichment() -> None:
     """Start the background CVE scanner and raw metrics window copy worker."""
-    global _CVE_SCAN_TASK, _RAW_WINDOW_COPY_TASK
+    global _CVE_SCAN_TASK, _RAW_WINDOW_COPY_TASK, _GITHUB_REPO_HEALTH_TASK
     _CVE_SCAN_TASK = asyncio.create_task(_cve_scanner_loop())
     _RAW_WINDOW_COPY_TASK = asyncio.create_task(_raw_window_copy_loop())
+    _GITHUB_REPO_HEALTH_TASK = asyncio.create_task(_github_repo_health_loop())
 
 
 # ---------------------------------------------------------------------------
@@ -17646,14 +17866,11 @@ async def api_enrichment_libraries():
             }
         )
     except Exception as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 500
+        return {"ok": False, "error": str(exc)}
 
 
-@app.route("/api/enrichment/github/repo-health", methods=["GET"])
-@require_basic_auth
-async def api_enrichment_github_repo_health():
+async def _collect_github_repo_health_summary(db: "ChDbConnection") -> dict[str, Any]:
     """Return version-scoped GitHub repo health counts for CVE workflow context."""
-    db = get_db()
     default_github_token = _load_ai_setting(db, "ai.github_token", "").strip()
 
     try:
@@ -17670,7 +17887,7 @@ async def api_enrichment_github_repo_health():
             "ORDER BY ReleasedAt DESC LIMIT 4000"
         ).fetchall()
     except Exception as exc:
-        return jsonify({"ok": False, "error": str(exc)}), 500
+        return {"ok": False, "error": str(exc)}
 
     versions_by_app: dict[str, list[str]] = {}
     for row in release_rows:
@@ -17781,19 +17998,26 @@ async def api_enrichment_github_repo_health():
         )
     )
 
-    return jsonify(
-        {
-            "ok": True,
-            "scanned_repos": scanned_repos,
-            "total_repos_considered": len(repo_targets),
-            "open_issues": total_open_issues,
-            "open_prs": total_open_prs,
-            "security_items": total_security_items,
-            "version_scoped": True,
-            "last_synced_at": _now_iso(),
-            "repos": repos_summary,
-        }
-    )
+    return {
+        "ok": True,
+        "scanned_repos": scanned_repos,
+        "total_repos_considered": len(repo_targets),
+        "open_issues": total_open_issues,
+        "open_prs": total_open_prs,
+        "security_items": total_security_items,
+        "version_scoped": True,
+        "last_synced_at": _now_iso(),
+        "repos": repos_summary,
+    }
+
+
+@app.route("/api/enrichment/github/repo-health", methods=["GET"])
+@require_basic_auth
+async def api_enrichment_github_repo_health():
+    """Return version-scoped GitHub repo health counts for CVE workflow context."""
+    db = get_db()
+    summary = await _collect_github_repo_health_summary(db)
+    return jsonify(summary)
 
 
 # ---------------------------------------------------------------------------
@@ -24244,6 +24468,8 @@ _GITHUB_BACKFILL_MAX_RELEASES_SETTING = "enrichment.github_backfill_max_releases
 _CVE_LAST_BACKFILL_ATTEMPTED_SETTING = "enrichment.cve_last_scan_github_backfill_attempted"
 _CVE_LAST_BACKFILL_INSERTED_SETTING = "enrichment.cve_last_scan_github_backfill_inserted"
 _CVE_LAST_BACKFILL_CAP_SETTING = "enrichment.cve_last_scan_github_backfill_cap"
+_GITHUB_REPO_HEALTH_LAST_SYNC_SETTING = "enrichment.github_repo_health_last_sync"
+_GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING = "enrichment.github_repo_health_last_summary"
 
 # Simple bounded in-process geo cache: {ip: geo_dict}
 _GEO_CACHE: OrderedDict[str, dict] = OrderedDict()
@@ -24264,9 +24490,14 @@ _GITHUB_BACKFILL_MAX_RELEASES_MIN = 1
 _GITHUB_BACKFILL_MAX_RELEASES_MAX = 2000
 _GITHUB_REPO_HEALTH_MAX_REPOS = 25
 _GITHUB_REPO_HEALTH_MAX_ITEMS_PER_REPO = 100
+_GITHUB_ACTIONS_SNAPSHOT_ARTIFACT_NAME = "sobs-release-dependency-snapshots"
+_GITHUB_ACTIONS_BACKFILL_MAX_RUNS_PER_RELEASE = 20
+_GITHUB_REPO_HEALTH_INITIAL_DELAY_S = 45
+_GITHUB_REPO_HEALTH_INTERVAL_S = 3600
 
 # Background CVE scan task handle
 _CVE_SCAN_TASK: "asyncio.Task[None] | None" = None
+_GITHUB_REPO_HEALTH_TASK: "asyncio.Task[None] | None" = None
 
 # Available signal sources for condition building (mirrors v_derived_signals_1m signals)
 _NOTIFICATION_SIGNAL_SOURCES: dict[str, list[str]] = {

--- a/app.py
+++ b/app.py
@@ -16438,12 +16438,15 @@ async def _github_actions_dependency_rows(
 ) -> list[dict[str, Any]]:
     """Return dependency artifact rows from GH Actions snapshots for a release."""
     rows: list[dict[str, Any]] = []
+    commit = str(commit_sha or "").strip()
+    if not commit:
+        # Without commit identity, we cannot safely bind a workflow run to this release.
+        return rows
     params: dict[str, str] = {
         "status": "completed",
         "per_page": str(_GITHUB_ACTIONS_BACKFILL_MAX_RUNS_PER_RELEASE),
     }
-    if commit_sha:
-        params["head_sha"] = commit_sha
+    params["head_sha"] = commit
 
     try:
         runs_resp = await client.get(
@@ -17866,7 +17869,7 @@ async def api_enrichment_libraries():
             }
         )
     except Exception as exc:
-        return {"ok": False, "error": str(exc)}
+        return jsonify({"ok": False, "error": str(exc)}), 500
 
 
 async def _collect_github_repo_health_summary(db: "ChDbConnection") -> dict[str, Any]:
@@ -18017,6 +18020,8 @@ async def api_enrichment_github_repo_health():
     """Return version-scoped GitHub repo health counts for CVE workflow context."""
     db = get_db()
     summary = await _collect_github_repo_health_summary(db)
+    if not bool(summary.get("ok")):
+        return jsonify(summary), 500
     return jsonify(summary)
 
 

--- a/app.py
+++ b/app.py
@@ -17210,13 +17210,33 @@ async def _sync_github_repo_health_once(db: "ChDbConnection | None" = None) -> d
     if not bool(summary.get("ok")):
         return summary
 
-    _set_app_setting(resolved_db, _GITHUB_REPO_HEALTH_LAST_SYNC_SETTING, str(summary.get("last_synced_at") or ""))
-    compact = {
+    compact_values = {
         "scanned_repos": int(summary.get("scanned_repos", 0) or 0),
         "total_repos_considered": int(summary.get("total_repos_considered", 0) or 0),
         "open_issues": int(summary.get("open_issues", 0) or 0),
         "open_prs": int(summary.get("open_prs", 0) or 0),
         "security_items": int(summary.get("security_items", 0) or 0),
+    }
+
+    previous_raw = _get_app_setting(resolved_db, _GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING) or ""
+    if previous_raw:
+        try:
+            previous = _safe_json_loads(previous_raw, {})
+            previous_values = {
+                "scanned_repos": int(previous.get("scanned_repos", 0) or 0),
+                "total_repos_considered": int(previous.get("total_repos_considered", 0) or 0),
+                "open_issues": int(previous.get("open_issues", 0) or 0),
+                "open_prs": int(previous.get("open_prs", 0) or 0),
+                "security_items": int(previous.get("security_items", 0) or 0),
+            }
+        except Exception:
+            previous_values = {}
+        if previous_values == compact_values:
+            return summary
+
+    _set_app_setting(resolved_db, _GITHUB_REPO_HEALTH_LAST_SYNC_SETTING, str(summary.get("last_synced_at") or ""))
+    compact = {
+        **compact_values,
         "last_synced_at": str(summary.get("last_synced_at") or ""),
     }
     _set_app_setting(resolved_db, _GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING, json.dumps(compact, separators=(",", ":")))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17693,6 +17693,7 @@ class TestWebTraffic:
             json={"version": "4.5.6", "environment": "prod"},
         )
         assert rel_resp.status_code == 201
+        release_id = (await rel_resp.get_json())["id"]
 
         db = sobs_app.get_db()
         sobs_app._save_ai_setting(db, "ai.github_token", "ghp-test-token")
@@ -17725,8 +17726,9 @@ class TestWebTraffic:
 
         rows = db.execute(
             "SELECT Name, MetadataJson FROM sobs_release_artifacts FINAL "
-            "WHERE ArtifactType='dependencies-lockfile' AND IsDeleted=0 "
-            "ORDER BY UploadedAt DESC LIMIT 1"
+            "WHERE ReleaseId=? AND ArtifactType='dependencies-lockfile' AND IsDeleted=0 "
+            "ORDER BY UploadedAt DESC LIMIT 1",
+            [release_id],
         ).fetchall()
         assert rows
         metadata = json.loads(str(rows[0]["MetadataJson"]))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import io
 import json
 import os
 import re
@@ -15,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import zipfile
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock
@@ -17574,6 +17576,135 @@ class TestWebTraffic:
             sobs_app._GITHUB_BACKFILL_MAX_RELEASES_SETTING,
             str(sobs_app._GITHUB_BACKFILL_MAX_RELEASES_DEFAULT),
         )
+
+    async def test_fetch_release_deps_from_github_uses_actions_artifact_snapshots(self, client, monkeypatch):
+        app_resp = await client.post(
+            "/v1/apps",
+            json={
+                "name": "GitHub Actions Backfill App",
+                "slug": f"github-actions-backfill-app-{time.time_ns()}",
+                "ownerTeam": "platform",
+                "repoUrl": "https://github.com/acme/actions-backfill",
+                "defaultEnvironment": "prod",
+            },
+        )
+        assert app_resp.status_code == 201
+        app_id = (await app_resp.get_json())["id"]
+
+        rel_resp = await client.post(
+            f"/v1/apps/{app_id}/releases",
+            json={"version": "3.4.5", "environment": "prod", "commitSha": "abc123def456"},
+        )
+        assert rel_resp.status_code == 201
+        release_id = (await rel_resp.get_json())["id"]
+
+        db = sobs_app.get_db()
+        sobs_app._save_ai_setting(db, "ai.github_token", "ghp-test-token")
+
+        archive_buffer = io.BytesIO()
+        with zipfile.ZipFile(archive_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("pip-freeze-linux-amd64.txt", "requests==2.32.3\nurllib3==2.2.2\n")
+            zip_file.writestr("pip-freeze-linux-arm64.txt", "requests==2.32.3\n")
+        archive_bytes = archive_buffer.getvalue()
+
+        class _FakeResponse:
+            def __init__(self, status_code: int, payload: dict | None = None, content: bytes = b"{}"):
+                self.status_code = status_code
+                self._payload = payload or {}
+                self.content = content
+
+            def json(self):
+                return self._payload
+
+        class _FakeClient:
+            async def get(self, url, params=None, headers=None, timeout=None, follow_redirects=False):
+                if url.endswith("/actions/runs"):
+                    return _FakeResponse(
+                        200,
+                        {
+                            "workflow_runs": [
+                                {
+                                    "id": 1001,
+                                    "conclusion": "success",
+                                    "head_sha": "abc123def456",
+                                }
+                            ]
+                        },
+                    )
+                if url.endswith("/actions/runs/1001/artifacts"):
+                    return _FakeResponse(
+                        200,
+                        {
+                            "artifacts": [
+                                {
+                                    "id": 2002,
+                                    "name": "sobs-release-dependency-snapshots",
+                                    "expired": False,
+                                    "archive_download_url": "https://api.github.com/artifacts/2002/zip",
+                                }
+                            ]
+                        },
+                    )
+                if url == "https://api.github.com/artifacts/2002/zip":
+                    return _FakeResponse(200, content=archive_bytes)
+                return _FakeResponse(404, {})
+
+        async def _fake_get_client():
+            return _FakeClient()
+
+        monkeypatch.setattr(sobs_app, "_get_async_http_client", _fake_get_client)
+
+        summary = await sobs_app._fetch_release_deps_from_github(db)
+        assert summary["attempted"] >= 1
+        assert summary["inserted"] >= 2
+
+        rows = db.execute(
+            "SELECT Name, Platform, Architecture, MetadataJson "
+            "FROM sobs_release_artifacts FINAL "
+            "WHERE ReleaseId=? AND ArtifactType='dependencies-lockfile' AND IsDeleted=0",
+            [release_id],
+        ).fetchall()
+        assert len(rows) >= 2
+        names = {str(row["Name"]) for row in rows}
+        assert "pip-freeze-linux-amd64" in names
+        assert "pip-freeze-linux-arm64" in names
+        amd64_row = next(row for row in rows if str(row["Name"]) == "pip-freeze-linux-amd64")
+        metadata = json.loads(str(amd64_row["MetadataJson"]))
+        assert metadata.get("source") == "github_actions_artifact"
+        deps = metadata.get("dependencies", [])
+        assert any(d.get("package") == "requests" and d.get("version") == "2.32.3" for d in deps)
+
+    async def test_sync_github_repo_health_once_persists_summary(self, client, monkeypatch):
+        db = sobs_app.get_db()
+
+        async def _fake_collect(_db):
+            return {
+                "ok": True,
+                "scanned_repos": 2,
+                "total_repos_considered": 3,
+                "open_issues": 4,
+                "open_prs": 5,
+                "security_items": 1,
+                "version_scoped": True,
+                "last_synced_at": "2026-04-25T00:00:00Z",
+                "repos": [],
+            }
+
+        monkeypatch.setattr(sobs_app, "_collect_github_repo_health_summary", _fake_collect)
+
+        summary = await sobs_app._sync_github_repo_health_once(db)
+        assert summary["ok"] is True
+
+        last_sync = sobs_app._get_app_setting(db, sobs_app._GITHUB_REPO_HEALTH_LAST_SYNC_SETTING)
+        assert last_sync == "2026-04-25T00:00:00Z"
+
+        compact_raw = sobs_app._get_app_setting(db, sobs_app._GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING)
+        compact = json.loads(compact_raw)
+        assert compact["scanned_repos"] == 2
+        assert compact["total_repos_considered"] == 3
+        assert compact["open_issues"] == 4
+        assert compact["open_prs"] == 5
+        assert compact["security_items"] == 1
 
     async def test_web_traffic_geo_api_empty(self, client):
         r = await client.get("/api/web-traffic/geo")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17674,6 +17674,64 @@ class TestWebTraffic:
         deps = metadata.get("dependencies", [])
         assert any(d.get("package") == "requests" and d.get("version") == "2.32.3" for d in deps)
 
+    async def test_fetch_release_deps_from_github_skips_actions_artifacts_without_commit_sha(self, client, monkeypatch):
+        app_resp = await client.post(
+            "/v1/apps",
+            json={
+                "name": "GitHub Actions No SHA App",
+                "slug": f"github-actions-no-sha-app-{time.time_ns()}",
+                "ownerTeam": "platform",
+                "repoUrl": "https://github.com/acme/actions-no-sha",
+                "defaultEnvironment": "prod",
+            },
+        )
+        assert app_resp.status_code == 201
+        app_id = (await app_resp.get_json())["id"]
+
+        rel_resp = await client.post(
+            f"/v1/apps/{app_id}/releases",
+            json={"version": "4.5.6", "environment": "prod"},
+        )
+        assert rel_resp.status_code == 201
+
+        db = sobs_app.get_db()
+        sobs_app._save_ai_setting(db, "ai.github_token", "ghp-test-token")
+
+        class _FakeResponse:
+            def __init__(self, status_code: int, payload: dict | None = None):
+                self.status_code = status_code
+                self._payload = payload or {}
+                self.content = b"{}"
+
+            def json(self):
+                return self._payload
+
+        class _FakeClient:
+            async def get(self, url, params=None, headers=None, timeout=None, follow_redirects=False):
+                if url.endswith("/contents/requirements.txt"):
+                    req_text = "requests==2.32.3\n"
+                    encoded = base64.b64encode(req_text.encode("utf-8")).decode("ascii")
+                    return _FakeResponse(200, {"encoding": "base64", "content": encoded})
+                return _FakeResponse(404, {})
+
+        async def _fake_get_client():
+            return _FakeClient()
+
+        monkeypatch.setattr(sobs_app, "_get_async_http_client", _fake_get_client)
+
+        summary = await sobs_app._fetch_release_deps_from_github(db)
+        assert summary["attempted"] >= 1
+        assert summary["inserted"] >= 1
+
+        rows = db.execute(
+            "SELECT Name, MetadataJson FROM sobs_release_artifacts FINAL "
+            "WHERE ArtifactType='dependencies-lockfile' AND IsDeleted=0 "
+            "ORDER BY UploadedAt DESC LIMIT 1"
+        ).fetchall()
+        assert rows
+        metadata = json.loads(str(rows[0]["MetadataJson"]))
+        assert metadata.get("source") == "github_contents_api"
+
     async def test_sync_github_repo_health_once_persists_summary(self, client, monkeypatch):
         db = sobs_app.get_db()
 
@@ -17705,6 +17763,40 @@ class TestWebTraffic:
         assert compact["open_issues"] == 4
         assert compact["open_prs"] == 5
         assert compact["security_items"] == 1
+
+    async def test_enrichment_libraries_returns_500_on_query_error(self, client, monkeypatch):
+        original_collect = sobs_app._collect_library_inventory
+
+        def _boom(_db):
+            raise RuntimeError("forced libraries failure")
+
+        monkeypatch.setattr(sobs_app, "_collect_library_inventory", _boom)
+        try:
+            r = await client.get("/api/enrichment/libraries")
+        finally:
+            monkeypatch.setattr(sobs_app, "_collect_library_inventory", original_collect)
+
+        assert r.status_code == 500
+        body = json.loads(await r.get_data())
+        assert body["ok"] is False
+        assert "forced libraries failure" in body["error"]
+
+    async def test_repo_health_endpoint_returns_500_when_summary_fails(self, client, monkeypatch):
+        original_collect = sobs_app._collect_github_repo_health_summary
+
+        async def _fake_collect(_db):
+            return {"ok": False, "error": "forced repo health failure"}
+
+        monkeypatch.setattr(sobs_app, "_collect_github_repo_health_summary", _fake_collect)
+        try:
+            r = await client.get("/api/enrichment/github/repo-health")
+        finally:
+            monkeypatch.setattr(sobs_app, "_collect_github_repo_health_summary", original_collect)
+
+        assert r.status_code == 500
+        body = json.loads(await r.get_data())
+        assert body["ok"] is False
+        assert "forced repo health failure" in body["error"]
 
     async def test_web_traffic_geo_api_empty(self, client):
         r = await client.get("/api/web-traffic/geo")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17766,6 +17766,46 @@ class TestWebTraffic:
         assert compact["open_prs"] == 5
         assert compact["security_items"] == 1
 
+    async def test_sync_github_repo_health_once_skips_persist_when_unchanged(self, client, monkeypatch):
+        db = sobs_app.get_db()
+        sobs_app._del_app_setting(db, sobs_app._GITHUB_REPO_HEALTH_LAST_SYNC_SETTING)
+        sobs_app._del_app_setting(db, sobs_app._GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING)
+        state = {"n": 0}
+
+        async def _fake_collect(_db):
+            state["n"] += 1
+            return {
+                "ok": True,
+                "scanned_repos": 2,
+                "total_repos_considered": 3,
+                "open_issues": 4,
+                "open_prs": 5,
+                "security_items": 1,
+                "version_scoped": True,
+                "last_synced_at": f"2026-04-25T00:00:0{state['n']}Z",
+                "repos": [],
+            }
+
+        original_set = sobs_app._set_app_setting
+        set_calls: list[str] = []
+
+        def _tracking_set(db_obj, key, value):
+            set_calls.append(str(key))
+            return original_set(db_obj, key, value)
+
+        monkeypatch.setattr(sobs_app, "_collect_github_repo_health_summary", _fake_collect)
+        monkeypatch.setattr(sobs_app, "_set_app_setting", _tracking_set)
+
+        first = await sobs_app._sync_github_repo_health_once(db)
+        assert first["ok"] is True
+        assert set_calls.count(sobs_app._GITHUB_REPO_HEALTH_LAST_SYNC_SETTING) == 1
+        assert set_calls.count(sobs_app._GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING) == 1
+
+        second = await sobs_app._sync_github_repo_health_once(db)
+        assert second["ok"] is True
+        assert set_calls.count(sobs_app._GITHUB_REPO_HEALTH_LAST_SYNC_SETTING) == 1
+        assert set_calls.count(sobs_app._GITHUB_REPO_HEALTH_LAST_SUMMARY_SETTING) == 1
+
     async def test_enrichment_libraries_returns_500_on_query_error(self, client, monkeypatch):
         original_collect = sobs_app._collect_library_inventory
 


### PR DESCRIPTION
Fixes #232

This updates the Sobs CI metadata flow so polling mode can ingest the same release dependency artifacts that push mode produces.

Summary:
- make CI always build and upload dependency snapshot artifacts even when Sobs push secrets are not configured
- add backend polling for GitHub Actions `sobs-release-dependency-snapshots` artifacts and ingest them into the release registry with provenance metadata
- keep repository lockfile backfill as a fallback when Actions artifacts are unavailable
- add a periodic background sync for configured GitHub repositories so repo-health checks run automatically
- add regression tests for Actions artifact polling and persisted repo-health sync summaries

Why:
- push-based registration and polling-based discovery need to converge on the same artifact source so CVE and release tracking stay accurate when direct push is unavailable
- configured repositories should be checked regularly without requiring manual endpoint calls

Validation:
- `isort *.py tests/ scripts`
- `black *.py tests/ scripts`
- `flake8 *.py tests/ scripts`
- `mypy app.py tests scripts`
- `pytest`
- result: 1088 passed, 4 skipped