### PR TITLE
fix: prevent AI conversation panel 404 behind base path

### DIFF
--- a/templates/ai.html
+++ b/templates/ai.html
@@ -1031,6 +1031,8 @@ initAiErrorTips(document);
 
 var AI_PAGE_FROM_TS = {{ from_ts | tojson }};
 var AI_PAGE_TO_TS = {{ to_ts | tojson }};
+var AI_CONVERSATION_URL = {{ url_for('get_ai_conversation') | tojson }};
+var AI_SPAN_ATTRIBUTES_URL = {{ url_for('get_ai_span_attributes') | tojson }};
 
 document.addEventListener('show.bs.collapse', function(ev) {
   var target = ev.target;
@@ -1042,7 +1044,7 @@ document.addEventListener('show.bs.collapse', function(ev) {
   var service = lazy.getAttribute('data-conv-service') || '';
   var traceId = lazy.getAttribute('data-conv-trace-id') || '';
   var spanName = lazy.getAttribute('data-conv-span-name') || '';
-  var url = '/api/ai/conversation?ts=' + encodeURIComponent(ts) + '&service=' + encodeURIComponent(service);
+  var url = AI_CONVERSATION_URL + '?ts=' + encodeURIComponent(ts) + '&service=' + encodeURIComponent(service);
   if (traceId) url += '&trace_id=' + encodeURIComponent(traceId);
   if (spanName) url += '&span_name=' + encodeURIComponent(spanName);
   if (AI_PAGE_FROM_TS) url += '&from_ts=' + encodeURIComponent(AI_PAGE_FROM_TS);
@@ -1227,7 +1229,7 @@ function loadAiRawAttrs(btn, preId, copyBtnId, ts, service, traceId, spanName) {
     btn.innerHTML = '<i class="bi bi-download me-1"></i>Loading';
   }
 
-  fetch('/api/ai/span-attributes?' + params.toString(), { credentials: 'same-origin' })
+  fetch(AI_SPAN_ATTRIBUTES_URL + '?' + params.toString(), { credentials: 'same-origin' })
     .then(function(resp) { return resp.json(); })
     .then(function(payload) {
       if (!payload || !payload.ok) {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5443,6 +5443,14 @@ class TestBasePathSupport:
         assert b'href="/sobs/errors"' in await r.get_data()
         assert b'src="/sobs/static/bootstrap.bundle.min.js"' in await r.get_data()
 
+    async def test_forwarded_prefix_ai_page_uses_prefixed_api_urls(self, client):
+        """AI page JS should call prefixed API routes when deployed behind a forwarded path prefix."""
+        r = await client.get("/ai", headers={"X-Forwarded-Prefix": "/sobs"})
+        assert r.status_code == 200
+        body = await r.get_data()
+        assert b'var AI_CONVERSATION_URL = "/sobs/api/ai/conversation";' in body
+        assert b'var AI_SPAN_ATTRIBUTES_URL = "/sobs/api/ai/span-attributes";' in body
+
 
 # ---------------------------------------------------------------------------
 # Basic Auth


### PR DESCRIPTION
## Summary
- replace hardcoded AI page API endpoints in `templates/ai.html` with `url_for(...)`-generated URLs
- ensure conversation and span-attributes fetch calls respect base path / forwarded prefix deployments
- add base-path regression test for AI page API URL rendering under `X-Forwarded-Prefix`

Closes #253

## Validation
- `pytest -q tests/test_app.py -k "TestBasePathSupport"`
  - `3 passed, 994 deselected`
