### PR TITLE
Fix AI trace view grouped detail filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -18681,12 +18681,12 @@ async def view_ai():
                 trace_ids = [str(r["TraceId"]) for r in trace_rows if str(r["TraceId"])]
                 if trace_ids:
                     placeholders = ",".join(["?"] * len(trace_ids))
+                    detail_where = f"{trace_where} AND TraceId IN ({placeholders})"
                     rows = db.execute(
                         f"SELECT Timestamp, ServiceName, TraceId, SpanName, Duration, SpanAttributes "
-                        f"FROM otel_traces WHERE TraceId IN ({placeholders}) "
-                        f"AND {_AI_SPAN_CONDITION} "
+                        f"FROM otel_traces {detail_where} "
                         "ORDER BY Timestamp ASC",
-                        trace_ids,
+                        params + trace_ids,
                     ).fetchall()
             else:
                 total = db.execute(f"SELECT COUNT(*) FROM otel_traces {where}", params).fetchone()[0]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6624,8 +6624,8 @@ class TestGenAICompliance:
         assert "trace-svc-b" in body
         assert "2 calls" in body
 
-    async def test_ai_view_trace_mode_operation_filter_keeps_trace_context(self, client):
-        """Trace mode operation filter should still show other GenAI calls within matching traces."""
+    async def test_ai_view_trace_mode_operation_filter_filters_trace_detail_rows(self, client):
+        """Trace mode operation filter should only show grouped detail rows that match the active filter."""
         trace_id = "trace-group-filter-xyz"
         r1 = await client.post(
             "/v1/ai",
@@ -6663,7 +6663,7 @@ class TestGenAICompliance:
         assert r3.status_code == 200
         body = await r3.get_data(as_text=True)
         assert "trace-chat-svc" in body
-        assert "trace-embed-svc" in body
+        assert "trace-embed-svc" not in body
 
     async def test_ai_view_trace_mode_has_full_detail_tabs(self, client):
         """Trace group mode should preserve full per-call detail tabs."""


### PR DESCRIPTION
Fixes #269.

## Summary
- reuse the filtered AI trace-view `WHERE` clause when fetching grouped trace detail rows
- prevent trace groups from pulling in unrelated AI spans from the same trace that do not match the active filters
- update the regression test to assert filtered-only detail rows in trace view

## Validation
- `/Users/abartrim/Documents/dev/sobs/.venv/bin/python -m pytest -q tests/test_app.py::TestGenAICompliance::test_ai_view_trace_group_mode_groups_calls tests/test_app.py::TestGenAICompliance::test_ai_view_trace_mode_operation_filter_filters_trace_detail_rows tests/test_app.py::TestGenAICompliance::test_ai_view_trace_mode_has_full_detail_tabs tests/test_app.py::TestGenAICompliance::test_ai_trace_view_treats_message_only_span_as_llm_call`