### PR TITLE
Fix Docker image missing telemetry package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py .
 COPY masking.py .
 COPY mcp.py .
+COPY telemetry/ telemetry/
 COPY scripts/docker-entrypoint.sh scripts/docker-entrypoint.sh
 COPY scripts/render_clickhouse_config.py scripts/render_clickhouse_config.py
 COPY templates/ templates/


### PR DESCRIPTION
## Summary
- copy the in-repo `telemetry/` package into the production image
- fix container startup for the current `app.py` import path
- resolve the `ModuleNotFoundError: No module named 'telemetry'` seen in Kubernetes pods

## Validation
- local source import works for `telemetry`
- Docker image build was not run in this workspace because no Docker daemon was available

Closes #278