### PR TITLE
tooling: Go integration-coverage measurement from the parity corpus

### DIFF
--- a/go/cmd/sobs/main.go
+++ b/go/cmd/sobs/main.go
@@ -13,7 +13,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -34,6 +36,19 @@ func main() {
 	srv := newServer(cfg)
 
 	addr := resolveBindAddr(cfg.Port)
+	// Coverage flush hook (NO-OP unless GOCOVERDIR is set, i.e. a `go build -cover` measurement run):
+	// a -cover binary only writes its GOCOVERDIR data on a clean exit, but the parity harness stops
+	// the server with SIGTERM, which by default kills it without running the runtime's exit hooks.
+	// When measuring, trap SIGTERM/SIGINT and os.Exit(0) so the counters are flushed. Production and
+	// normal parity runs never set GOCOVERDIR, so behaviour there is unchanged.
+	if os.Getenv("GOCOVERDIR") != "" {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		go func() {
+			<-sigCh
+			os.Exit(0)
+		}()
+	}
 	log.Printf("sobs (go) listening on %s  parity=%v dataDir=%s", addr, cfg.Parity, cfg.DataDir)
 	if err := http.ListenAndServe(addr, srv); err != nil {
 		log.Fatal(err)

--- a/migration/.gitignore
+++ b/migration/.gitignore
@@ -10,3 +10,8 @@ tools/__pycache__/
 # headers) carry environment-derived mtimes. Regenerate locally to run parity_check.
 golden/
 _run/
+
+# Go integration-coverage artifacts (produced by an SOBS_GOCOVER=1 corpus replay; see
+# GO_COVERAGE.md). The raw covdata files and the textfmt profile are regenerated, not source.
+.gocov/
+go_coverage.txt

--- a/migration/GO_COVERAGE.md
+++ b/migration/GO_COVERAGE.md
@@ -1,0 +1,61 @@
+# Go integration coverage (byte-parity corpus replay)
+
+A second coverage lens alongside `coverage_app.json` (which measures the **Python oracle**). This
+one measures **how much of the Go server the byte-parity corpus actually exercises** — built with
+`go build -cover`, replayed across every profile, merged with `go tool covdata`.
+
+It is *integration* coverage (the corpus replay), not unit-test coverage.
+
+## Latest snapshot — 2026-06-20 (go-main `d855ad9`, corpus = 689 parity routes, GREEN 689/0)
+
+| Scope | Coverage | Statements |
+|---|---:|---|
+| All Go | 69.4% | 15,403 / 22,202 |
+| Generated OTLP protobuf (`internal/otlp/genpb/*`) | 16.3% | 249 / 1,527 |
+| **Hand-written Go (excl. generated)** | **73.3%** | 15,154 / 20,675 |
+
+By area (hand-written):
+
+| Coverage | Package | Notes |
+|---:|---|---|
+| 72.9% | `cmd/sobs` (13,844 / 18,991) | handlers, server, business logic — the bulk |
+| 79.7% | `internal/jsonenc` | order-preserving JSON encoder |
+| 78.6% | `internal/render` | the Jinja template engine |
+| 66.4% | `internal/store` | chdb wrapper |
+
+### Reading it
+
+- **73.3%** is the meaningful number (generated protobuf is auto-generated getters/marshalers we do
+  not hand-test; excluding it is correct).
+- It runs **~6 pts below the oracle's 79.7%**, and that gap is expected, not a parity hole: the Go
+  server carries code with **no `app.py` counterpart** that the parity corpus (`SOBS_PARITY=1`)
+  deliberately never exercises — real network egress, WebPush/notification dispatch, chdb disk
+  encryption, Fernet settings encryption, source-map real fetch, the write-queue, non-parity RUM
+  token signing, boot/config. Those lower Go coverage but cannot lower oracle coverage (they do not
+  exist in the oracle).
+
+## How to reproduce
+
+Inside the parity Docker image (bind-mount the repo, supply libchdb), with `SOBS_GOCOVER=1` so
+`parity_check._build_go` adds `-cover -coverpkg=./...`, and `GOCOVERDIR` on the mounted volume so
+the per-profile counter files survive the container:
+
+```bash
+mkdir -p migration/.gocov
+docker run --rm -v "<repo>:/repo" -w "/repo/<worktree>" \
+  -e CHDB_LIB_PATH=/repo/.libchdb/libchdb.so \
+  -e SOBS_GOCOVER=1 -e GOCOVERDIR=/repo/<worktree>/migration/.gocov \
+  sobs-parity:latest \
+  bash -c "python migration/tools/seed_fixtures.py && python migration/tools/parity_check.py"
+
+# then, in the go/ module dir:
+go tool covdata percent -i=../migration/.gocov
+go tool covdata textfmt -i=../migration/.gocov -o ../migration/go_coverage.txt
+go tool cover -func=../migration/go_coverage.txt | tail -1   # overall total
+go tool cover -html=../migration/go_coverage.txt             # optional HTML drill-down
+```
+
+Coverage flush relies on the `GOCOVERDIR`-gated SIGTERM/SIGINT hook in `cmd/sobs/main.go` (a
+`-cover` binary only writes on a clean exit, but the harness stops the server with SIGTERM). The
+hook is a **no-op unless `GOCOVERDIR` is set**, so normal/parity/production runs are unchanged — the
+instrumented replay above is itself parity GREEN 689/0.

--- a/migration/tools/parity_check.py
+++ b/migration/tools/parity_check.py
@@ -127,7 +127,15 @@ def _compute_uncovered(routes: list, generated: list, excluded: set) -> list[str
 
 def _build_go() -> None:
     print("Building Go binary…")
-    r = subprocess.run(["go", "build", "-o", str(GO_DIR / "sobs"), "./cmd/sobs"], cwd=GO_DIR)
+    cmd = ["go", "build"]
+    # SOBS_GOCOVER=1 → build a coverage-instrumented binary so a full corpus replay measures Go
+    # integration coverage. Each per-profile boot writes counters into GOCOVERDIR (set in the env and
+    # inherited by _boot_go); merge them afterwards with `go tool covdata`. Off by default, so the
+    # normal parity build produces the usual binary.
+    if os.environ.get("SOBS_GOCOVER"):
+        cmd += ["-cover", "-coverpkg=./..."]
+    cmd += ["-o", str(GO_DIR / "sobs"), "./cmd/sobs"]
+    r = subprocess.run(cmd, cwd=GO_DIR)
     if r.returncode != 0:
         raise SystemExit("Go build failed — fix compilation before parity can run.")
 


### PR DESCRIPTION
Adds a **Go coverage lens** alongside the Python oracle coverage: `go build -cover` + full corpus replay → `go tool covdata`.

- `cmd/sobs/main.go`: `GOCOVERDIR`-gated SIGTERM hook so a -cover binary flushes counters (no-op unless measuring → normal/parity/prod unchanged).
- `parity_check._build_go`: `-cover -coverpkg=./...` when `SOBS_GOCOVER=1`.
- `migration/GO_COVERAGE.md`: report + reproduce steps; gitignore the regenerated artifacts.

**First measurement** (go-main `d855ad9`, 689 routes): hand-written Go **73.3%** (15,154/20,675; 69.4% incl. generated OTLP protobuf at 16.3%) — cmd/sobs 72.9%, render 78.6%, jsonenc 79.7%, store 66.4%. ~6 pts under the oracle's 79.7% (Go-only runtime with no app.py counterpart).

Instrumented full-corpus replay is itself parity **GREEN 689 / RED 0**; gofmt/vet/black/isort/flake8 clean.