### PR TITLE
test(go): pure-helper unit tests (float/AI/RUM/work-items/chart-builder/MCP)

### DIFF
--- a/go/cmd/sobs/ai_build_chat_helpers_test.go
+++ b/go/cmd/sobs/ai_build_chat_helpers_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// Pure helpers in the AI build/chat path — corpus-unreachable (the LLM upstream can't be driven
+// deterministically). Oracles: _tool_status_label (app.py:4005), _AI_ASSISTANT_META_RE
+// (app.py:3455), the ```-fence strip, CPython json "Expecting value" error text, and
+// _build_fallback_custom_option_json.
+
+func TestStripCodeFences(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"```json\n{\"a\":1}\n```", `{"a":1}`},
+		{"```\n[1,2]\n```", "[1,2]"},
+		{"```python\nx\n```", "x"},
+		{"  no fences here  ", "no fences here"}, // trimmed, unchanged otherwise
+	}
+	for _, c := range cases {
+		if got := stripCodeFences(c.in); got != c.want {
+			t.Errorf("stripCodeFences(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPyExpectingValueError(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", "Expecting value: line 1 column 1 (char 0)"},
+		{"abc", "Expecting value: line 1 column 1 (char 0)"},
+		{"  x", "Expecting value: line 1 column 3 (char 2)"},
+		{"\n y", "Expecting value: line 2 column 2 (char 2)"},
+	}
+	for _, c := range cases {
+		if got := pyExpectingValueError(c.in); got != c.want {
+			t.Errorf("pyExpectingValueError(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestChartSpecParseError(t *testing.T) {
+	if got := chartSpecParseError(""); got != "empty chart spec" {
+		t.Errorf("empty: got %q", got)
+	}
+	if got := chartSpecParseError("   "); got != "empty chart spec" {
+		t.Errorf("whitespace: got %q", got)
+	}
+	// Non-empty, non-JSON delegates to the CPython "Expecting value" wording.
+	if got := chartSpecParseError("garbage"); got != "Expecting value: line 1 column 1 (char 0)" {
+		t.Errorf("garbage: got %q", got)
+	}
+}
+
+func TestBuildFallbackCustomOptionJSON(t *testing.T) {
+	out := buildFallbackCustomOptionJSON()
+	var parsed any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	for _, want := range []string{`"backgroundColor"`, "transparent", `"{{points}}"`, `"Value"`, `"line"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("fallback option JSON missing %s:\n%s", want, out)
+		}
+	}
+}
+
+func TestObjGetOr(t *testing.T) {
+	o := jsonenc.NewObject().Set("k", "v")
+	if got := objGetOr(o, "k", "def"); got != "v" {
+		t.Errorf("present key: got %v, want v", got)
+	}
+	if got := objGetOr(o, "missing", "def"); got != "def" {
+		t.Errorf("missing key: got %v, want def", got)
+	}
+}
+
+func TestExtractAssistantMetaText(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"no meta", "just the answer", "just the answer"},
+		{"full block removed", "Answer.<assistant_meta>secret</assistant_meta> More", "Answer. More"},
+		{"dangling open cut", "Real answer<assistant_meta foo=1 bar", "Real answer"},
+	}
+	for _, c := range cases {
+		if got := extractAssistantMetaText(c.in); got != c.want {
+			t.Errorf("%s: extractAssistantMetaText(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestToolStatusLabel(t *testing.T) {
+	cases := []struct {
+		status  string
+		confirm bool
+		want    string
+	}{
+		{"executed", false, "Executed"},
+		{"EXECUTED", true, "Executed"}, // case/whitespace normalized
+		{"unsupported", true, "Not available in this page action manifest"},
+		{"proposed", true, "Awaiting confirmation"},
+		{"proposed", false, "Queued"},
+		{"", false, "Queued"},
+	}
+	for _, c := range cases {
+		if got := toolStatusLabel(c.status, c.confirm); got != c.want {
+			t.Errorf("toolStatusLabel(%q, %v) = %q, want %q", c.status, c.confirm, got, c.want)
+		}
+	}
+}
+
+func TestTruthyStr(t *testing.T) {
+	for _, s := range []string{"1", "true", "TRUE", "yes", "on", "  On  "} {
+		if !truthyStr(s) {
+			t.Errorf("truthyStr(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"0", "false", "no", "off", "", "maybe"} {
+		if truthyStr(s) {
+			t.Errorf("truthyStr(%q) = true, want false", s)
+		}
+	}
+}

--- a/go/cmd/sobs/chart_builder_mcp_test.go
+++ b/go/cmd/sobs/chart_builder_mcp_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// Pure chart-builder + MCP-arg helpers. Oracles: Python truthiness (isFalsyAny), `str(v) or default`
+// trimming (orStrDefault), _compile_builder_sql guards, int(value) coercion/clamp for MCP args.
+
+func TestIsFalsyAny(t *testing.T) {
+	falsy := []any{nil, "", false, json.Number("0"), 0, 0.0}
+	for _, v := range falsy {
+		if !isFalsyAny(v) {
+			t.Errorf("isFalsyAny(%v) = false, want true", v)
+		}
+	}
+	truthy := []any{"x", true, json.Number("5"), 3, 2.5}
+	for _, v := range truthy {
+		if isFalsyAny(v) {
+			t.Errorf("isFalsyAny(%v) = true, want false", v)
+		}
+	}
+}
+
+func TestOrStrDefault(t *testing.T) {
+	cases := []struct {
+		name    string
+		v       any
+		present bool
+		def     string
+		want    string
+	}{
+		{"absent -> trimmed default", nil, false, "  d  ", "d"},
+		{"falsy empty -> default", "", true, "d", "d"},
+		{"present string trimmed", "  y  ", true, "d", "y"},
+		{"present number", json.Number("5"), true, "d", "5"},
+	}
+	for _, c := range cases {
+		if got := orStrDefault(c.v, c.present, c.def); got != c.want {
+			t.Errorf("%s: orStrDefault(%v,%v,%q) = %q, want %q", c.name, c.v, c.present, c.def, got, c.want)
+		}
+	}
+}
+
+func TestCountPerMinuteSeries(t *testing.T) {
+	out := countPerMinuteSeries("toStartOfMinute(Timestamp)", "otel_logs", "ServiceName='x'", "scored.* FROM scored")
+	for _, want := range []string{
+		"WITH per_minute AS", "toStartOfMinute(Timestamp) AS time", "FROM otel_logs",
+		"WHERE ServiceName='x'", "baseline_mean", "scored.* FROM scored",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("countPerMinuteSeries output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestCompileBuilderSQLGuards(t *testing.T) {
+	if sql, errMsg := compileBuilderSQL("custom_echarts", jsonenc.NewObject()); sql != "" || errMsg != "custom_echarts requires sql.mode='raw'" {
+		t.Errorf("custom_echarts: got (%q, %q)", sql, errMsg)
+	}
+	data := jsonenc.NewObject().Set("source_view", "bogus_view")
+	if sql, errMsg := compileBuilderSQL("time_series_percentiles", data); sql != "" || errMsg != "Unsupported source for builder mode" {
+		t.Errorf("unsupported source: got (%q, %q)", sql, errMsg)
+	}
+}
+
+func TestMcpToInt(t *testing.T) {
+	ok := []struct {
+		in   any
+		want int
+	}{
+		{json.Number("5"), 5},
+		{json.Number("5.9"), 5}, // int(float) truncates toward zero
+		{float64(3.7), 3},
+		{float64(-2.5), -2}, // trunc toward zero, not floor
+		{7, 7},
+	}
+	for _, c := range ok {
+		if n, valid := mcpToInt(c.in); !valid || n != c.want {
+			t.Errorf("mcpToInt(%v) = (%d, %v), want (%d, true)", c.in, n, valid, c.want)
+		}
+	}
+	for _, v := range []any{nil, math.NaN(), math.Inf(1)} {
+		if n, valid := mcpToInt(v); valid {
+			t.Errorf("mcpToInt(%v) = (%d, true), want (_, false)", v, n)
+		}
+	}
+}
+
+func TestMcpClampArg(t *testing.T) {
+	o := jsonenc.NewObject().
+		Set("mid", json.Number("50")).
+		Set("hi", json.Number("200")).
+		Set("lo", json.Number("0")).
+		Set("bad", "abc")
+	if got := mcpClampArg(o, "mid", 1, 100, 10); got != 50 {
+		t.Errorf("in-range: got %d, want 50", got)
+	}
+	if got := mcpClampArg(o, "hi", 1, 100, 10); got != 100 {
+		t.Errorf("above hi: got %d, want 100", got)
+	}
+	if got := mcpClampArg(o, "lo", 1, 100, 10); got != 1 {
+		t.Errorf("below lo: got %d, want 1", got)
+	}
+	if got := mcpClampArg(o, "bad", 1, 100, 10); got != 10 {
+		t.Errorf("non-int: got %d, want 10 (default)", got)
+	}
+	if got := mcpClampArg(o, "missing", 1, 100, 10); got != 10 {
+		t.Errorf("missing: got %d, want 10 (default)", got)
+	}
+}

--- a/go/cmd/sobs/chart_render_floatstrict_test.go
+++ b/go/cmd/sobs/chart_render_floatstrict_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// pyFloatStrict mirrors CPython's float(): coerce int/float/bool/numeric-string, RAISE on a
+// non-numeric string / None / other type (it must NOT best-effort to 0), with CPython's exact
+// ValueError/TypeError text (surfaced as the 400 body by _public_dashboard_query_error).
+func TestPyFloatStrict(t *testing.T) {
+	ok := []struct {
+		name string
+		in   any
+		want float64
+	}{
+		{"int", 5, 5.0},
+		{"int64", int64(7), 7.0},
+		{"float64", 2.5, 2.5},
+		{"bool true -> 1.0", true, 1.0},
+		{"bool false -> 0.0", false, 0.0},
+		{"string int", "42", 42.0},
+		{"string float", "3.14", 3.14},
+		{"string trimmed", "  6  ", 6.0},
+		{"string scientific", "1e3", 1000.0},
+		{"string negative", "-2.5", -2.5},
+		{"json.Number", json.Number("8.5"), 8.5},
+	}
+	for _, c := range ok {
+		got, err := pyFloatStrict(c.in)
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", c.name, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+
+	// inf / nan are accepted by both float() and ParseFloat.
+	if f, err := pyFloatStrict("inf"); err != nil || !math.IsInf(f, 1) {
+		t.Errorf(`pyFloatStrict("inf") = (%v, %v), want (+Inf, nil)`, f, err)
+	}
+	if f, err := pyFloatStrict("nan"); err != nil || !math.IsNaN(f) {
+		t.Errorf(`pyFloatStrict("nan") = (%v, %v), want (NaN, nil)`, f, err)
+	}
+
+	// Error cases RAISE with CPython's message text.
+	errCases := []struct {
+		name   string
+		in     any
+		wantTx string
+	}{
+		{"non-numeric string", "abc", "could not convert string to float: 'abc'"},
+		{"empty string", "", "could not convert string to float: ''"},
+		{"nil/None", nil, "float() argument must be a string or a real number, not 'NoneType'"},
+	}
+	for _, c := range errCases {
+		_, err := pyFloatStrict(c.in)
+		if err == nil {
+			t.Errorf("%s: got nil error, want %q", c.name, c.wantTx)
+			continue
+		}
+		if err.Error() != c.wantTx {
+			t.Errorf("%s: error = %q, want %q", c.name, err.Error(), c.wantTx)
+		}
+	}
+
+	// Any other (non string/number) type is a TypeError, never a silent 0.
+	if _, err := pyFloatStrict([]int{1, 2}); err == nil {
+		t.Error("slice: got nil error, want TypeError")
+	}
+}
+
+func TestFloatStrConvErr(t *testing.T) {
+	if got := floatStrConvErr("xyz").Error(); got != "could not convert string to float: 'xyz'" {
+		t.Errorf("floatStrConvErr(xyz) = %q", got)
+	}
+}

--- a/go/cmd/sobs/fix_rum_helpers_test.go
+++ b/go/cmd/sobs/fix_rum_helpers_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// RUM stringify/coerce helpers — pure ports of Python str()/bool()/json.dumps semantics on
+// JSON-decoded values (numbers arrive as json.Number under UseNumber). Oracle: _stringify_attrs,
+// str(x), str(x) if x else "", bool(x).
+
+func TestRumStr(t *testing.T) {
+	if got := rumStr(json.Number("5")); got != "5" {
+		t.Errorf("json.Number: got %q, want 5", got)
+	}
+	if got := rumStr("hello"); got != "hello" {
+		t.Errorf("string: got %q, want hello", got)
+	}
+}
+
+func TestRumFloatStr(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{5.0, "5.0"}, // integral float keeps .0 (Python str(5.0))
+		{0.0, "0.0"},
+		{-2.0, "-2.0"},
+		{3.14, "3.14"},
+		{5.5, "5.5"},
+	}
+	for _, c := range cases {
+		if got := rumFloatStr(c.in); got != c.want {
+			t.Errorf("rumFloatStr(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRumStringifyAttrs(t *testing.T) {
+	in := map[string]any{
+		"s":    "x",
+		"bt":   true,
+		"bf":   false,
+		"n":    json.Number("5"),
+		"f":    5.0,
+		"drop": nil, // None values are dropped
+	}
+	out := rumStringifyAttrs(in)
+	want := map[string]string{"s": "x", "bt": "True", "bf": "False", "n": "5", "f": "5.0"}
+	if len(out) != len(want) {
+		t.Fatalf("len = %d, want %d (out=%v)", len(out), len(want), out)
+	}
+	for k, w := range want {
+		if got, _ := out[k].(string); got != w {
+			t.Errorf("key %q: got %q, want %q", k, got, w)
+		}
+	}
+	if _, ok := out["drop"]; ok {
+		t.Error("None value should be dropped")
+	}
+	// nil map -> empty (non-nil) map.
+	if got := rumStringifyAttrs(nil); got == nil || len(got) != 0 {
+		t.Errorf("nil input: got %v, want empty map", got)
+	}
+}
+
+func TestRumStringifyContentAttr(t *testing.T) {
+	if got := rumStringifyContentAttr("plain"); got != "plain" {
+		t.Errorf("string passthrough: got %q", got)
+	}
+	if got := rumStringifyContentAttr(true); got != "true" { // json.dumps(True)
+		t.Errorf("bool: got %q, want true", got)
+	}
+}
+
+func TestRumStrOrEmpty(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{nil, ""},
+		{"x", "x"},
+		{true, "True"},
+		{false, ""}, // falsy bool -> ""
+		{json.Number("0"), ""},
+		{json.Number("0.0"), ""},
+		{json.Number("5"), "5"},
+		{5.0, "5.0"}, // float64 nonzero -> rumFloatStr -> "5.0"
+	}
+	for _, c := range cases {
+		if got := rumStrOrEmpty(c.in); got != c.want {
+			t.Errorf("rumStrOrEmpty(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRumStrRaw(t *testing.T) {
+	if got := rumStrRaw(nil); got != "" {
+		t.Errorf("nil: got %q, want empty", got)
+	}
+	if got := rumStrRaw(json.Number("7")); got != "7" {
+		t.Errorf("number: got %q, want 7", got)
+	}
+	if got := rumStrRaw("v"); got != "v" {
+		t.Errorf("string: got %q, want v", got)
+	}
+}
+
+func TestRumTruthy(t *testing.T) {
+	truthy := []any{true, "x", json.Number("5"), 2.5, []any{1}, map[string]any{"k": 1}}
+	for _, v := range truthy {
+		if !rumTruthy(v) {
+			t.Errorf("rumTruthy(%v) = false, want true", v)
+		}
+	}
+	falsy := []any{nil, false, "", json.Number("0"), json.Number("0.0"), 0.0, []any{}, map[string]any{}}
+	for _, v := range falsy {
+		if rumTruthy(v) {
+			t.Errorf("rumTruthy(%v) = true, want false", v)
+		}
+	}
+}
+
+func TestObjShallowMap(t *testing.T) {
+	o := jsonenc.NewObject().Set("a", "1").Set("b", json.Number("2"))
+	m := objShallowMap(o)
+	if len(m) != 2 || m["a"] != "1" || m["b"] != json.Number("2") {
+		t.Errorf("objShallowMap = %v", m)
+	}
+}

--- a/go/cmd/sobs/work_items_helpers_test.go
+++ b/go/cmd/sobs/work_items_helpers_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+// Pure work-item helpers. Oracles: Python int() strict parsing (atoiStrict), cInt + default
+// (cIntDef), _safe_json_loads(value, []) (safeJSONLoadsList), and _work_item_to_utc_iso —
+// datetime.fromisoformat then .isoformat(timespec="milliseconds") with +00:00 -> Z.
+
+func TestAtoiStrict(t *testing.T) {
+	ok := []struct {
+		in   string
+		want int
+	}{
+		{"42", 42},
+		{"+5", 5},
+		{"-3", -3},
+		{"  7  ", 7},
+		{"0", 0},
+	}
+	for _, c := range ok {
+		if n, valid := atoiStrict(c.in); !valid || n != c.want {
+			t.Errorf("atoiStrict(%q) = (%d, %v), want (%d, true)", c.in, n, valid, c.want)
+		}
+	}
+	bad := []string{"", "  ", "1.5", "abc", "12x", "-", "+", "1 2", "0x10"}
+	for _, c := range bad {
+		if n, valid := atoiStrict(c); valid {
+			t.Errorf("atoiStrict(%q) = (%d, true), want (_, false)", c, n)
+		}
+	}
+}
+
+func TestCIntDef(t *testing.T) {
+	if got := cIntDef(map[string]any{"k": float64(5)}, "k", 99); got != 5 {
+		t.Errorf("nonzero float: got %d, want 5", got)
+	}
+	if got := cIntDef(map[string]any{"k": "7"}, "k", 99); got != 7 {
+		t.Errorf("numeric string: got %d, want 7", got)
+	}
+	// cInt==0 (explicit zero, missing key, or unparseable) falls back to the default.
+	if got := cIntDef(map[string]any{"k": float64(0)}, "k", 99); got != 99 {
+		t.Errorf("zero value: got %d, want 99 (default)", got)
+	}
+	if got := cIntDef(map[string]any{}, "k", 99); got != 99 {
+		t.Errorf("missing key: got %d, want 99 (default)", got)
+	}
+	if got := cIntDef(map[string]any{"k": "abc"}, "k", 99); got != 99 {
+		t.Errorf("unparseable: got %d, want 99 (default)", got)
+	}
+}
+
+func TestSafeJSONLoadsList(t *testing.T) {
+	if got := safeJSONLoadsList(`[1, 2, 3]`); len(got) != 3 {
+		t.Errorf("array: len = %d, want 3", len(got))
+	}
+	for _, raw := range []string{"", "   ", "{}", `{"a":1}`, "not json", "null", "42"} {
+		if got := safeJSONLoadsList(raw); len(got) != 0 {
+			t.Errorf("safeJSONLoadsList(%q) len = %d, want 0 (empty list)", raw, len(got))
+		}
+	}
+}
+
+func TestWorkItemToUTCISO(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"2026-03-29 12:00:00", "2026-03-29T12:00:00.000Z"},
+		{"2026-03-29T12:00:00Z", "2026-03-29T12:00:00.000Z"},
+		{"not a date", "not a date"}, // unparseable -> original raw
+	}
+	for _, c := range cases {
+		if got := workItemToUTCISO(c.in); got != c.want {
+			t.Errorf("workItemToUTCISO(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Batch 2 of the corpus-unreachable grind: ~30 pure-logic functions across 5 files, each anchored to its app.py oracle (Python str()/int()/float()/bool() semantics, CPython json error text, SQL builders). Highlights: `pyFloatStrict` (raises like CPython float(), exact error text), `pyExpectingValueError`, `atoiStrict`, `mcpToInt` (trunc-toward-zero), the RUM stringify cluster. Full `go test ./...` GREEN; gofmt clean.