### PR TITLE
test(go): MCP/RUM/tail/spec/timestamp/CVE pure-helper tests (batches 6-7)

### DIFF
--- a/go/cmd/sobs/mcp_rum_misc_helpers_test.go
+++ b/go/cmd/sobs/mcp_rum_misc_helpers_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// Pure MCP / OTLP-list / RUM-asset / misc helpers — corpus-unreachable or only incidentally hit.
+// Oracles: MCP where/time clause builders, urllib-style asset signature payload, httpx exception
+// class naming, JSON coercion.
+
+func TestMcpWhere(t *testing.T) {
+	if got := mcpWhere(nil); got != "" {
+		t.Errorf("empty: %q", got)
+	}
+	if got := mcpWhere([]string{"a = ?", "b = ?"}); got != "WHERE a = ? AND b = ?" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMcpAddEq(t *testing.T) {
+	conds := []string{}
+	params := []any{}
+	mcpAddEq(&conds, &params, "x = ?", "v")
+	mcpAddEq(&conds, &params, "y = ?", "") // empty value -> skipped
+	if len(conds) != 1 || conds[0] != "x = ?" || len(params) != 1 || params[0] != "v" {
+		t.Errorf("conds=%v params=%v", conds, params)
+	}
+}
+
+func TestMcpTimeWhere(t *testing.T) {
+	// explicit from+to -> two ? predicates + two params
+	conds := []string{}
+	params := []any{}
+	mcpTimeWhere("Timestamp", "2026-01-01 00:00:00", "2026-01-02 00:00:00", &conds, &params)
+	if len(conds) != 2 || len(params) != 2 {
+		t.Errorf("from+to: conds=%v params=%v", conds, params)
+	}
+	// no from -> default now()-INTERVAL clause, no param for it
+	conds = []string{}
+	params = []any{}
+	mcpTimeWhere("Timestamp", "", "", &conds, &params)
+	if len(conds) != 1 || len(params) != 0 {
+		t.Errorf("default: conds=%v params=%v", conds, params)
+	}
+}
+
+func TestMcpParseTs(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"2026-03-29T12:00:00Z", "2026-03-29 12:00:00"},
+		{"2026-03-29T12:00:00", "2026-03-29 12:00:00"},
+		{"not a ts", ""},
+	}
+	for _, c := range cases {
+		if got := mcpParseTs(c.in); got != c.want {
+			t.Errorf("mcpParseTs(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMcpErrTypeName(t *testing.T) {
+	if got := mcpErrTypeName(nil); got != "Error" {
+		t.Errorf("nil: got %q, want Error", got)
+	}
+	if got := mcpErrTypeName(errors.New("boom")); got != "errorString" {
+		t.Errorf("errors.New: got %q, want errorString", got)
+	}
+}
+
+func TestOtlpFloatIntList(t *testing.T) {
+	if got := otlpFloatList([]any{1, 2, 3}); len(got) != 3 {
+		t.Errorf("floatList len %d, want 3", len(got))
+	}
+	if got := otlpFloatList("not a list"); len(got) != 0 {
+		t.Errorf("floatList non-list len %d, want 0", len(got))
+	}
+	if got := otlpIntList([]any{1, 2}); len(got) != 2 {
+		t.Errorf("intList len %d, want 2", len(got))
+	}
+	if got := otlpIntList(nil); len(got) != 0 {
+		t.Errorf("intList nil len %d, want 0", len(got))
+	}
+}
+
+func TestAssetExtension(t *testing.T) {
+	cases := []struct{ name, ct, want string }{
+		{"logo.PNG", "", "png"},               // from filename ext, lowercased
+		{"data.json", "", "json"},             // from filename ext
+		{"noext", "application/json", "json"}, // from content-type mapping
+		{"noext", "image/jpeg", "jpg"},
+		{"noext", "application/octet-stream", "bin"},
+	}
+	for _, c := range cases {
+		if got := assetExtension(c.name, c.ct); got != c.want {
+			t.Errorf("assetExtension(%q,%q) = %q, want %q", c.name, c.ct, got, c.want)
+		}
+	}
+}
+
+func TestRumAssetSignaturePayload(t *testing.T) {
+	got := rumAssetSignaturePayload("post", "/v1/rum/assets", "1700000000", "abc", "Application/JSON", " Source-Map ", "app.js.map")
+	want := "POST\n/v1/rum/assets\n1700000000\nabc\napplication/json\nsource-map\napp.js.map"
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+type fakeTimeoutErr struct{}
+
+func (fakeTimeoutErr) Error() string   { return "i/o timeout" }
+func (fakeTimeoutErr) Timeout() bool   { return true }
+func (fakeTimeoutErr) Temporary() bool { return false }
+
+func TestHttpxExceptionClassName(t *testing.T) {
+	if got := httpxExceptionClassName(nil); got != "ConnectError" {
+		t.Errorf("nil: got %q", got)
+	}
+	if got := httpxExceptionClassName(errors.New("refused")); got != "ConnectError" {
+		t.Errorf("plain: got %q", got)
+	}
+	if got := httpxExceptionClassName(fakeTimeoutErr{}); got != "ConnectTimeout" {
+		t.Errorf("timeout: got %q, want ConnectTimeout", got)
+	}
+}
+
+func TestAsJSONObject(t *testing.T) {
+	o := jsonenc.NewObject().Set("a", "1")
+	if got := asJSONObject(o); got != o {
+		t.Error("object passthrough")
+	}
+	if got := asJSONObject(`{"a":1}`); got == nil {
+		t.Error("JSON string should parse to object")
+	}
+	if got := asJSONObject("not json"); got != nil {
+		t.Error("non-JSON string -> nil")
+	}
+	if got := asJSONObject(5); got != nil {
+		t.Error("non-string/non-object -> nil")
+	}
+}
+
+func TestChatLabelFromFirstTurn(t *testing.T) {
+	if got := chatLabelFromFirstTurn("  the question  ", "req"); got != "the question" {
+		t.Errorf("question wins: %q", got)
+	}
+	if got := chatLabelFromFirstTurn("", "the request"); got != "the request" {
+		t.Errorf("request fallback: %q", got)
+	}
+	if got := chatLabelFromFirstTurn("", ""); got != "New chat" {
+		t.Errorf("default: %q", got)
+	}
+}

--- a/go/cmd/sobs/tail_spec_ts_helpers_test.go
+++ b/go/cmd/sobs/tail_spec_ts_helpers_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// SSE-tail / spec-mode / timestamp-parse / cve-snapshot / query-stats pure helpers.
+
+func TestSSEEventField(t *testing.T) {
+	ev := jsonenc.NewObject().Set("source", "errors").Set("n", 5)
+	if got := sseEventField(ev, "source"); got != "errors" {
+		t.Errorf("string: %q", got)
+	}
+	if got := sseEventField(ev, "n"); got != "" {
+		t.Errorf("non-string -> empty, got %q", got)
+	}
+	if got := sseEventField(ev, "missing"); got != "" {
+		t.Errorf("missing -> empty, got %q", got)
+	}
+}
+
+func TestSSEEventMatches(t *testing.T) {
+	if !sseEventMatches("", "all", "") {
+		t.Error(`source="all" + no filter should match anything`)
+	}
+	if sseEventMatches(`{"source":"logs"}`, "errors", "") {
+		t.Error("source mismatch should NOT match")
+	}
+	if !sseEventMatches(`{"source":"errors"}`, "errors", "") {
+		t.Error("source match should match")
+	}
+}
+
+func TestSpecSQLMode(t *testing.T) {
+	m := map[string]any{"spec": map[string]any{"sql": map[string]any{"mode": " raw "}}}
+	if got := specSQLMode(m); got != "raw" {
+		t.Errorf("nested: got %q, want raw", got)
+	}
+	if got := specSQLMode(map[string]any{}); got != "" {
+		t.Errorf("missing: got %q", got)
+	}
+}
+
+func TestSpecModeGuard(t *testing.T) {
+	// valid mode -> not guarded (returns false, no write)
+	req := httptest.NewRequest("POST", "/x", strings.NewReader(`{"spec":{"sql":{"mode":"raw"}}}`))
+	w := httptest.NewRecorder()
+	if specModeGuard(w, req, nil) {
+		t.Error("raw mode should pass (return false)")
+	}
+	// missing/invalid mode -> guarded 400
+	req2 := httptest.NewRequest("POST", "/x", strings.NewReader(`{}`))
+	w2 := httptest.NewRecorder()
+	if !specModeGuard(w2, req2, nil) {
+		t.Error("missing mode should be guarded (return true)")
+	}
+	if w2.Code != 400 {
+		t.Errorf("want 400, got %d", w2.Code)
+	}
+}
+
+func TestStringAttrTruthy(t *testing.T) {
+	for _, v := range []any{"1", "true", "YES", "y", "On"} {
+		if !stringAttrTruthy(v) {
+			t.Errorf("stringAttrTruthy(%v) = false, want true", v)
+		}
+	}
+	for _, v := range []any{"0", "false", "no", 5, ""} {
+		if stringAttrTruthy(v) {
+			t.Errorf("stringAttrTruthy(%v) = true, want false", v)
+		}
+	}
+}
+
+func TestParseISOFloorAndNormalize(t *testing.T) {
+	tm, ok := parseISOFloor("2026-03-29 12:00:00")
+	if !ok {
+		t.Fatal("should parse")
+	}
+	if got := normalizeChTimestampTime(tm); got != "2026-03-29 12:00:00.000000" {
+		t.Errorf("normalize: got %q", got)
+	}
+	if _, ok := parseISOFloor("not a timestamp"); ok {
+		t.Error("garbage should not parse")
+	}
+	if tm2, ok := parseCHTimestamp("2026-03-29T12:00:00Z"); !ok || tm2.UTC().Hour() != 12 {
+		t.Errorf("parseCHTimestamp Z form: ok=%v hour=%d", ok, tm2.UTC().Hour())
+	}
+}
+
+func TestNormalizeChTimestampTime(t *testing.T) {
+	tm := time.Date(2026, 3, 29, 12, 0, 0, 0, time.UTC)
+	if got := normalizeChTimestampTime(tm); got != "2026-03-29 12:00:00.000000" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMustParseJSON(t *testing.T) {
+	if v, ok := mustParseJSON([]byte(`[1,2,3]`)).([]any); !ok || len(v) != 3 {
+		t.Error("valid array")
+	}
+	if _, ok := mustParseJSON([]byte(`not json`)).(*jsonenc.Object); !ok {
+		t.Error("invalid -> empty object")
+	}
+}
+
+func TestToJSONObject(t *testing.T) {
+	o := toJSONObject(map[string]any{"a": 1, "b": map[string]any{"c": 2}})
+	if v, _ := o.Get("a"); v != 1 {
+		t.Errorf("a = %v", v)
+	}
+	sub, ok := o.Get("b")
+	if !ok {
+		t.Fatal("missing b")
+	}
+	if so, ok := sub.(*jsonenc.Object); !ok {
+		t.Errorf("b should be nested object, got %T", sub)
+	} else if cv, _ := so.Get("c"); cv != 2 {
+		t.Errorf("b.c = %v", cv)
+	}
+}
+
+func TestGetObjField(t *testing.T) {
+	o := jsonenc.NewObject().Set("k", "v")
+	if got := getObjField(o, "k"); got != "v" {
+		t.Errorf("present: %v", got)
+	}
+	if got := getObjField(o, "missing"); got != nil {
+		t.Errorf("missing -> nil, got %v", got)
+	}
+}
+
+func TestGithubActionsSnapshotName(t *testing.T) {
+	dep, plat, arch, ok := githubActionsSnapshotName("pip-freeze-linux-amd64.txt")
+	if !ok || dep != "pip-freeze-linux-amd64" || plat != "linux" || arch != "amd64" {
+		t.Errorf("got (%q,%q,%q,%v)", dep, plat, arch, ok)
+	}
+	// path basename is used
+	if _, _, _, ok := githubActionsSnapshotName("artifacts/pip-freeze-darwin-arm64.txt"); !ok {
+		t.Error("should match on basename")
+	}
+	if _, _, _, ok := githubActionsSnapshotName("requirements.txt"); ok {
+		t.Error("non-matching name should fail")
+	}
+}
+
+func TestZeroQueryLLMStats(t *testing.T) {
+	o := zeroQueryLLMStats()
+	for _, stage := range []string{"totals", "named_query_generation", "chart_generation"} {
+		v, ok := o.Get(stage)
+		if !ok {
+			t.Errorf("missing stage %q", stage)
+			continue
+		}
+		so := v.(*jsonenc.Object)
+		if pt, _ := so.Get("prompt_tokens"); pt != 0 {
+			t.Errorf("%s.prompt_tokens = %v, want 0", stage, pt)
+		}
+	}
+}


### PR DESCRIPTION
~24 more corpus-unreachable pure helpers, oracle-anchored (MCP clause builders, OTLP list coercion, RUM asset signature payload, httpx exception naming, SSE-tail filters, spec-mode guard, ISO/CH timestamp parsers, CVE snapshot name, query LLM-stats zeroing). go test ./... GREEN.