### PR TITLE
test(mutation): harden harness + document findings (step 2)

### DIFF
--- a/migration/MUTATION_FINDINGS.md
+++ b/migration/MUTATION_FINDINGS.md
@@ -1,0 +1,51 @@
+# Mutation-testing findings
+
+Produced by `migration/tools/mutation_test.py` — "verify the verifier". It perturbs a COVERED
+constant in app.py (bool flip / int+1 / str+"X"), re-captures the named golden route(s) from the
+mutated oracle, and checks whether the golden bytes change:
+- **KILLED**  — a golden changed → the corpus observes this line (good).
+- **SURVIVED** — goldens identical → the line ran during full-corpus coverage but its effect never
+  reaches *the compared route's* captured response.
+
+A survivor bounds what byte-parity can catch: parity could not detect a Go divergence on that exact
+line either. So survivors are either real corpus blind spots or methodology artifacts (below).
+
+## Result (2026-06-20, representative sample)
+
+The corpus **kills behavioral mutations on exercised lines** — e.g. in `summary()`:
+`'SELECT count() AS cnt FROM ('` → killed, and the `if … or "true"` boolean literal → killed. This
+confirms the verifier works: changing oracle behavior changes the goldens.
+
+## Methodology caveat (why per-function scores read low)
+
+`mutation_test.py` mutates **every** covered constant in a function span, but `--only` compares a
+**single** route+profile. A multi-branch handler (e.g. `summary()` has base / `summaryrich` /
+`cveview` / cve-overview branches gated by settings + seeded data) is only partially exercised by
+any one route, so constants in the *other* branches survive **trivially** — not because the corpus
+is blind, but because that route doesn't run them. Meaningful scoring requires pairing a function
+with the route+profile that maximally exercises it (or `--lines` narrowed to the route's hot path).
+A full campaign (every function × its exercising routes) is future work; the mechanism + harness are
+validated here.
+
+## Harness hardening (this session)
+
+A mutant that *breaks* the oracle (capture subprocess crashes) is now counted **KILLED** (a crash is
+a detectable change) instead of aborting the whole sweep via `check=True`. So one pathological
+mutant no longer kills the run.
+
+## Open gap (worthwhile to close)
+
+### G1 — summary cve-overview *populated* severity tally is not byte-asserted
+`summary()` lines ~10945–10958 tally `sobs_cve_findings` by severity into
+`cve_overview[critical|high|medium|low|total]`. Mutating the `'LOW'`/`'low'`/`'MEDIUM'`/… branch
+constants **survives** because no golden renders the *populated* counts:
+- `get__root` (base): renders `0 total` — the for-loop severity branches never run (no findings).
+- `get__root__cveview`: renders `CVE scanning is disabled.` — also does not surface populated counts.
+
+(Observed by byte-diffing the two goldens; neither contains a non-zero `critical/high/medium/low`
+tally, so the populated path is unobserved regardless of the exact gating.)
+
+So the per-severity tallying branches — and the Go port of them — are not byte-verified. **To close:**
+add a profile that BOTH seeds `sobs_cve_findings` (1+/severity) AND leaves cve enabled, capture
+`get__root` under it, and confirm parity GREEN — the populated `critical:N high:N …` counts then
+byte-assert the branches and kill the mutants. (A discrete M-series corpus-expansion item.)

--- a/migration/tools/mutation_test.py
+++ b/migration/tools/mutation_test.py
@@ -42,6 +42,7 @@ PY = sys.executable
 
 def _covered_lines() -> set[int]:
     import json
+
     c = json.loads((REPO / "migration" / "coverage_app.json").read_text())
     k = next(x for x in c["files"] if x.endswith("app.py"))
     return set(c["files"][k]["executed_lines"])
@@ -95,10 +96,13 @@ def _apply(src_lines: list[str], m) -> str:
 
 
 def _seed_and_capture(profile: str, only: str) -> None:
-    subprocess.run([PY, str(TOOLS / "seed_fixtures.py")], cwd=str(REPO), check=True,
-                   stdout=subprocess.DEVNULL)
-    subprocess.run([PY, str(TOOLS / "capture_routes.py"), "--profile", profile, "--only", only],
-                   cwd=str(REPO), check=True, stdout=subprocess.DEVNULL)
+    subprocess.run([PY, str(TOOLS / "seed_fixtures.py")], cwd=str(REPO), check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        [PY, str(TOOLS / "capture_routes.py"), "--profile", profile, "--only", only],
+        cwd=str(REPO),
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def _snapshot(route_ids: list[str], dst: Path) -> None:
@@ -160,13 +164,18 @@ def main() -> int:
             ln, _c0, _c1, orig, new = m
             APP.write_text(_apply(src_lines, m))
             try:
-                _seed_and_capture(args.profile, args.only)
-                dead = _differs(route_ids, baseline)
+                try:
+                    _seed_and_capture(args.profile, args.only)
+                    dead = _differs(route_ids, baseline)
+                except subprocess.CalledProcessError:
+                    # The mutant broke the oracle (capture crashed) — that IS a detectable change,
+                    # so the corpus would catch it: count as killed rather than aborting the sweep.
+                    dead = True
             finally:
                 APP.write_text(src)  # restore the pristine oracle
             tag = "KILLED " if dead else "SURVIVED"
             killed += dead
-            survived += (not dead)
+            survived += not dead
             print(f"  [{tag}] L{ln}: {orig} -> {new}", flush=True)
     finally:
         APP.write_text(src)  # guarantee the pristine oracle is restored
@@ -174,8 +183,10 @@ def main() -> int:
 
     total = killed + survived
     score = (killed / total * 100) if total else 0.0
-    print(f"\nMutation score: {killed}/{total} killed ({score:.0f}%). "
-          f"{survived} survivor(s) = covered-but-unasserted holes.")
+    print(
+        f"\nMutation score: {killed}/{total} killed ({score:.0f}%). "
+        f"{survived} survivor(s) = covered-but-unasserted holes."
+    )
     return 0
 
 


### PR DESCRIPTION
Mutation testing run: corpus kills behavioral mutations on exercised lines (verifier validated). Hardened the harness (capture-crash -> killed, no abort) and documented findings + one worthwhile gap (G1: summary cve-overview populated tally not byte-asserted). See migration/MUTATION_FINDINGS.md.