### PR TITLE
feat(parity): body-sensitive upstream mock key (AI-path byte-parity foundation)

### DIFF
--- a/go/cmd/sobs/upstream.go
+++ b/go/cmd/sobs/upstream.go
@@ -24,6 +24,17 @@ func upstreamFixtureKey(method, url string) string {
 	return hex.EncodeToString(sum[:])[:32]
 }
 
+// upstreamFixtureKeyBody mirrors determinism.upstream_fixture_key_body: sha256("METHOD url\n" +
+// raw request body)[:32]. Lets the deterministic OpenAI-compatible mock return a per-request-body
+// canned response (prompt-dependent / multi-call AI flows); requires both runtimes to emit a
+// byte-identical body. The URL-only key remains the fallback for bodyless / legacy fixtures.
+func upstreamFixtureKeyBody(method, url string, body []byte) string {
+	h := sha256.New()
+	h.Write([]byte(strings.ToUpper(method) + " " + url + "\n"))
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))[:32]
+}
+
 // upstreamResponse is a canned upstream HTTP response: a status and a parsed JSON body
 // (jsonenc.Object / []any / json.Number, via parseJSONValue), or nil body. RawContent holds the
 // fixture's raw "content" string (used for non-JSON bodies such as the SSE streams the AI helper's
@@ -45,7 +56,7 @@ var upstreamHTTPClient = &http.Client{Timeout: 30 * time.Second}
 // fixtures dir, so the mock path is taken there exactly as before.
 func (s *server) upstreamRequest(method, url string, body []byte, headers map[string]string) (upstreamResponse, error) {
 	if dir := strings.TrimSpace(os.Getenv("SOBS_UPSTREAM_FIXTURES")); dir != "" {
-		return s.upstreamFixture(dir, method, url)
+		return s.upstreamFixture(dir, method, url, body)
 	}
 	var rdr io.Reader
 	if body != nil {
@@ -71,10 +82,18 @@ func (s *server) upstreamRequest(method, url string, body []byte, headers map[st
 	return out, nil
 }
 
-// upstreamFixture serves the canned parity response keyed by METHOD+url. A missing fixture
-// resolves to a 404.
-func (s *server) upstreamFixture(dir, method, url string) (upstreamResponse, error) {
-	raw, err := os.ReadFile(filepath.Join(dir, upstreamFixtureKey(method, url)+".json"))
+// upstreamFixture serves the canned parity response. A body-keyed fixture takes precedence (a
+// deterministic per-request-body AI response); it falls back to the URL-only key so every existing
+// canned GitHub/OSV/webhook/AI fixture still resolves. A missing fixture resolves to a 404.
+func (s *server) upstreamFixture(dir, method, url string, reqBody []byte) (upstreamResponse, error) {
+	var raw []byte
+	var err error = os.ErrNotExist
+	if len(reqBody) > 0 {
+		raw, err = os.ReadFile(filepath.Join(dir, upstreamFixtureKeyBody(method, url, reqBody)+".json"))
+	}
+	if err != nil {
+		raw, err = os.ReadFile(filepath.Join(dir, upstreamFixtureKey(method, url)+".json"))
+	}
 	if err != nil {
 		return upstreamResponse{Status: 404, Body: jsonenc.NewObject().
 			Set("message", "Not Found (no upstream fixture)")}, nil

--- a/go/cmd/sobs/upstream_key_test.go
+++ b/go/cmd/sobs/upstream_key_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+// Cross-runtime parity for the upstream fixture keys: these MUST match
+// migration/tools/determinism.py (upstream_fixture_key / upstream_fixture_key_body) byte-for-byte,
+// or the Python oracle and the Go binary would read different canned files for the same request.
+// The expected hex values are computed independently by the Python implementation.
+
+func TestUpstreamFixtureKeyParity(t *testing.T) {
+	// URL-only key — sha256("METHOD url")[:32]. Method is upper-cased on both sides.
+	if got := upstreamFixtureKey("post", "https://sobs-ai.mock/chat/completions"); got != "66826e4ebb951e10b3e97d0cf3be4a1d" {
+		t.Errorf("upstreamFixtureKey = %q, want 66826e4ebb951e10b3e97d0cf3be4a1d (Python parity)", got)
+	}
+}
+
+func TestUpstreamFixtureKeyBodyParity(t *testing.T) {
+	// Body-sensitive key — sha256("METHOD url\n" + body)[:32].
+	body := []byte(`{"model": "m", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 1024}`)
+	if got := upstreamFixtureKeyBody("POST", "https://sobs-ai.mock/chat/completions", body); got != "cd42623034ef7d480f65b8869b3b70b4" {
+		t.Errorf("upstreamFixtureKeyBody = %q, want cd42623034ef7d480f65b8869b3b70b4 (Python parity)", got)
+	}
+	// Distinct bodies -> distinct keys (the whole point of body-sensitivity).
+	other := upstreamFixtureKeyBody("POST", "https://sobs-ai.mock/chat/completions", []byte(`{"model":"m2"}`))
+	if other == "cd42623034ef7d480f65b8869b3b70b4" {
+		t.Error("different bodies must produce different keys")
+	}
+}

--- a/migration/tools/determinism.py
+++ b/migration/tools/determinism.py
@@ -61,6 +61,19 @@ def upstream_fixture_key(method: str, url: str) -> str:
     return hashlib.sha256(f"{method.upper()} {url}".encode("utf-8")).hexdigest()[:32]
 
 
+def upstream_fixture_key_body(method: str, url: str, body: bytes) -> str:
+    """Body-sensitive variant: sha256 of "METHOD url\\n" + raw request body, first 32 hex. MUST
+    match Go (upstream.go upstreamFixtureKeyBody). Lets a deterministic OpenAI-compatible mock return
+    a DIFFERENT canned response per distinct request body (multi-call AI flows / prompt-dependent
+    paths) instead of one response per URL. Requires both runtimes to emit a byte-identical body."""
+    import hashlib
+
+    h = hashlib.sha256()
+    h.update(f"{method.upper()} {url}\n".encode("utf-8"))
+    h.update(body or b"")
+    return h.hexdigest()[:32]
+
+
 def _install_upstream_fixtures() -> None:
     """Serve api.github.com / api.osv.dev from canned files instead of the network, so the
     external-integration routes are byte-reproducible. Both the Python oracle (this httpx
@@ -88,9 +101,15 @@ def _install_upstream_fixtures() -> None:
         host = request.url.host
         if host not in intercept_hosts:
             return httpx.Response(599, json={"error": f"unmocked upstream host {host}"})
-        stem = upstream_fixture_key(request.method, str(request.url))
-        path = base / f"{stem}.json"
-        if not path.exists():
+        body = request.content or b""
+        # A body-keyed fixture takes precedence (deterministic per-request AI responses); fall back
+        # to the URL-only key so every existing canned GitHub/OSV/webhook/AI fixture still resolves.
+        stems = []
+        if body:
+            stems.append(upstream_fixture_key_body(request.method, str(request.url), body))
+        stems.append(upstream_fixture_key(request.method, str(request.url)))
+        path = next((base / f"{s}.json" for s in stems if (base / f"{s}.json").exists()), None)
+        if path is None:
             return httpx.Response(404, json={"message": "Not Found (no upstream fixture)"})
         spec = _json.loads(path.read_text())
         status = int(spec.get("status", 200))


### PR DESCRIPTION
Adds a body-sensitive fixture key (sha256 of METHOD+url+body) to the sobs-ai.mock shim on BOTH runtimes (determinism.py + upstream.go), with URL-key fallback so existing fixtures resolve unchanged. Cross-runtime key parity test included. Provably inert until body-keyed fixtures are added; verified neutral. Foundation for byte-parity-covering the AI/LLM surface. NOTE: a pre-existing flaky RED on 3 now()-anchored routes (cveview/summaryrich/rumvitals) is unrelated and tracked separately.