### PR TITLE
fix(go): LLM request body compact to match httpx (fidelity + body-key enabler)

### DIFF
--- a/go/cmd/sobs/ai_llm.go
+++ b/go/cmd/sobs/ai_llm.go
@@ -195,7 +195,11 @@ func llmRequestBody(req llmRequest) []byte {
 	if len(req.tools) > 0 {
 		payload.Set("tools", req.tools)
 	}
-	return jsonenc.Encode(payload, dumpsDefault)
+	// httpx (the app's HTTP client) serializes `json=payload` COMPACT (separators (",", ":"), raw
+	// UTF-8) — NOT json.dumps' spaced default. The request body must be byte-identical to Python's so
+	// the deterministic OpenAI-compatible mock can key a canned response on it (and so the real
+	// upstream receives the same bytes). dumpsDefault (", "/": ") would silently differ.
+	return jsonenc.Encode(payload, jsonenc.Compact)
 }
 
 // llmRequestHeaders mirrors app.py _llm_request_headers.

--- a/go/cmd/sobs/ai_llm_body_test.go
+++ b/go/cmd/sobs/ai_llm_body_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// llmRequestBody must serialize byte-identically to the app's httpx client (`json=payload`), which
+// uses COMPACT separators (",", ":") and raw UTF-8 (ensure_ascii=False). The want value below is the
+// exact httpx.Request(...).content captured from the parity image for the same payload — so the
+// deterministic OpenAI-compatible mock can key a canned response on the request body, and the real
+// upstream receives identical bytes from both runtimes.
+func TestLLMRequestBodyMatchesHTTPX(t *testing.T) {
+	req := llmRequest{
+		model:     "m",
+		messages:  []any{jsonenc.NewObject().Set("role", "user").Set("content", "café 日本語")},
+		maxTokens: 1024,
+	}
+	want := `{"model":"m","messages":[{"role":"user","content":"café 日本語"}],"max_tokens":1024}`
+	if got := string(llmRequestBody(req)); got != want {
+		t.Errorf("llmRequestBody mismatch vs httpx:\n got: %s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
Go's llmRequestBody used spaced separators; httpx serializes json=payload COMPACT (","/":", raw UTF-8). Go's /chat/completions body was byte-different from Python's on every LLM call (latent: URL-keyed mock ignored the body). Switch to jsonenc.Compact + a test pinned to the httpx bytes. Fixes a real divergence and enables the body-sensitive mock (#364). Canonical gate GREEN 689/0.