### PR TITLE
fix(go): AI prompt byte-parity (guard context + SQL backticks) + mock body-dump tool

### DIFF
--- a/go/cmd/sobs/agent_flow.go
+++ b/go/cmd/sobs/agent_flow.go
@@ -145,7 +145,7 @@ func (s *server) runAgentFlow(rule *agentRule, settings map[string]string, tctx 
 	contextSummary := s.buildAgentContextSummary(tctx)
 
 	// 1. Guard model check.
-	allowed, guardReason, _ := s.checkGuardModel(contextSummary)
+	allowed, guardReason, _ := s.checkGuardModel(contextSummary, "")
 	guardDecision := "allowed"
 	if !allowed {
 		guardDecision = "blocked: " + guardReason

--- a/go/cmd/sobs/ai_llm.go
+++ b/go/cmd/sobs/ai_llm.go
@@ -315,8 +315,11 @@ func heuristicGuardCheck(text string) bool {
 // category parsing, benign overrides, and rich reasons. The third return is kept as llmStats for
 // signature compatibility with the existing callers (which discard it); the rich guard_stats dict is
 // produced internally and surfaced only on the AI-helper route.
-func (s *server) checkGuardModel(userInput string) (bool, string, llmStats) {
-	allowed, reason, _ := s.aiHelperGuardCheck(userInput, "")
+func (s *server) checkGuardModel(userInput, context string) (bool, string, llmStats) {
+	// context mirrors app.py _check_guard_model(settings, user_input, context): it wraps the guard's
+	// user turn as "Context: <ctx>\n\nUser input: <userInput>". Passing "" (as before) dropped that
+	// wrapper, so Go sent a different guard prompt than Python on the /query routes.
+	allowed, reason, _ := s.aiHelperGuardCheck(userInput, context)
 	return allowed, reason, llmStats{}
 }
 

--- a/go/cmd/sobs/ai_prompts.go
+++ b/go/cmd/sobs/ai_prompts.go
@@ -8,14 +8,21 @@ import (
 	"github.com/sobs/sobs/internal/jsonenc"
 )
 
-// LLM prompt templates ported from app.py. These are sent in the request body, which the parity
-// mock ignores (it keys on the URL), so their exact text is parity-irrelevant — at runtime they
-// shape the real model output. Markdown code backticks in the Python source are rendered here as
-// single quotes so the text fits a Go raw-string literal; the meaning is identical.
+// LLM prompt templates ported from app.py. These go in the LLM request body. NOTE: this must be
+// byte-identical to app.py — the deterministic OpenAI-compatible mock can key a canned response on
+// the request body (and the real upstream receives the same bytes), so prompt text IS parity-
+// relevant. Where the Python source uses markdown backticks, a Go raw-string literal cannot contain
+// one, so they are stored as a private-use sentinel (U+F8FF) and restored to backticks at init (see
+// querySQLSystemPrompt). Any prompt below still using single quotes for backtick'd identifiers is a
+// known remaining divergence to convert the same way.
 
 // querySQLSystemPrompt mirrors app.py _QUERY_SQL_SYSTEM_PROMPT ({schema} is substituted at call
 // time with getSchemaContext()).
-const querySQLSystemPrompt = `You are a ClickHouse SQL expert. Your job is to write correct, read-only ClickHouse SELECT queries based on natural-language questions.
+// querySQLSystemPrompt: the Python source uses markdown backticks around identifiers; a Go
+// raw-string literal cannot contain a backtick, so they are stored as a private-use sentinel
+// (U+F8FF) and restored to backticks at init — making the prompt byte-identical to app.py's
+// _QUERY_SQL_SYSTEM_PROMPT (required now the parity mock keys on the LLM request body).
+var querySQLSystemPrompt = strings.ReplaceAll(`You are a ClickHouse SQL expert. Your job is to write correct, read-only ClickHouse SELECT queries based on natural-language questions.
 
 Rules:
 - Output ONLY raw SQL. No markdown, no backticks, no explanation.
@@ -28,28 +35,28 @@ Rules:
 - If the user's wording does not exactly match the schema, map it to the
     closest real table/column names from the provided schema.
 - Terminology disambiguation:
-  - 'sobs_anomaly_rules' = metric/anomaly rule definitions (configuration rows).
-    - 'v_otel_metrics_1m' = finalized 1-minute metric rollups for trend/chart queries.
-    - 'otel_metrics_1m_agg' = aggregate-state backing table for those 1-minute metric rollups.
-        If you query it directly, you MUST use 'avgMerge(Value)' and 'sumMerge(SampleCount)' and
-        'GROUP BY ServiceName, MetricName, AttrFingerprint, MetricKind, MinuteBucket' (or a subset
+  - sobs_anomaly_rules = metric/anomaly rule definitions (configuration rows).
+    - v_otel_metrics_1m = finalized 1-minute metric rollups for trend/chart queries.
+    - otel_metrics_1m_agg = aggregate-state backing table for those 1-minute metric rollups.
+        If you query it directly, you MUST use avgMerge(Value) and sumMerge(SampleCount) and
+        GROUP BY ServiceName, MetricName, AttrFingerprint, MetricKind, MinuteBucket (or a subset
         that still includes every selected non-aggregated column).
-  - 'v_derived_signals_1m' = derived signal time series before anomaly scoring.
-  - 'v_derived_signals_anomaly' and 'v_otel_metrics_anomaly' = scored outputs with
+  - v_derived_signals_1m = derived signal time series before anomaly scoring.
+  - v_derived_signals_anomaly and v_otel_metrics_anomaly = scored outputs with
       anomaly_state and anomaly_score.
-  - 'sobs_raw_windows' = signal windows that preserve raw metrics data around active
+  - sobs_raw_windows = signal windows that preserve raw metrics data around active
       signals; this is window metadata, not rule definitions.
 - If asked about rule definitions, thresholds, comparators, or rule coverage,
-    query 'sobs_anomaly_rules' first.
-- If asked about signal trends/values over time, prefer 'v_derived_signals_1m'
+    query sobs_anomaly_rules first.
+- If asked about signal trends/values over time, prefer v_derived_signals_1m
     unless anomaly state/score is explicitly requested.
-- Prefer 'v_otel_metrics_1m' over 'otel_metrics_1m_agg' for normal charts unless the user
-    explicitly wants aggregate-state internals or a query that benefits from direct 'avgMerge' access.
+- Prefer v_otel_metrics_1m over otel_metrics_1m_agg for normal charts unless the user
+    explicitly wants aggregate-state internals or a query that benefits from direct avgMerge access.
 - For signal, anomaly, alert, or incident-window questions, prefer
-    'sobs_raw_windows' for window metadata and
-    'v_otel_metrics_signal_context' for metrics that occurred inside those windows.
+    sobs_raw_windows for window metadata and
+    v_otel_metrics_signal_context for metrics that occurred inside those windows.
 - For deployment/release correlation requests, treat deployment windows as a subset
-    of signal windows in 'sobs_raw_windows' (typically matched via SignalType/SignalRef
+    of signal windows in sobs_raw_windows (typically matched via SignalType/SignalRef
     text filters when explicit deployment tables are absent).
 - For complex analytical, correlation, or chart-oriented questions with
     multiple metrics or transforms, prefer 2-4 compact, clearly named CTEs
@@ -59,7 +66,7 @@ Rules:
     filtering, aggregation, enrichment, or final shaping.
 - If you use CTEs (WITH ...), you MUST include a final SELECT statement after the CTE block.
 - Ensure all parentheses and quotes are balanced before returning the SQL.
-- The database name is "default". Always qualify table names as 'default.<table>' or omit the database when unambiguous.
+- The database name is "default". Always qualify table names as default.<table> or omit the database when unambiguous.
 - Use ClickHouse-compatible syntax (e.g. toDate(), now(), formatDateTime(), arrayJoin(), etc.).
 - ClickHouse JOIN safety: keep JOIN ON predicates equality-based whenever possible.
 - For time-window overlap/non-equality correlation (e.g. t between WindowStart and WindowEnd),
@@ -85,7 +92,7 @@ LIMIT 20
 
 Schema context:
 {schema}
-`
+`, "\uF8FF", "`")
 
 // chartRefinementPromptTemplate mirrors app.py _build_chart_refinement_prompt's static base;
 // {catalog} is filled with the dynamic chart-types section at call time.

--- a/go/cmd/sobs/query_exec.go
+++ b/go/cmd/sobs/query_exec.go
@@ -550,7 +550,7 @@ func (s *server) handleApiQueryRun(w http.ResponseWriter, r *http.Request) {
 		if guardInput == "" {
 			guardInput = "Generate chart for SQL: " + truncRunes(sql, 500)
 		}
-		allowed, guardReason, _ := s.checkGuardModel(guardInput)
+		allowed, guardReason, _ := s.checkGuardModel(guardInput, "/query")
 		s.emitAiHelperLogEvent("query.guard.result", traceID, turnID, "/query", model, guardModel, "off",
 			"Guard verdict: "+guardReason, "INFO", map[string]string{"gen_ai.operation.name": "guard"})
 		if allowed {
@@ -685,7 +685,7 @@ func (s *server) handleApiQueryAsk(w http.ResponseWriter, r *http.Request) {
 	s.emitAiHelperLogEvent("query.turn.start", traceID, turnID, "/query", model, guardModel, "off",
 		question, "INFO", map[string]string{"gen_ai.input.question": question})
 
-	allowed, reason, _ := s.checkGuardModel(question)
+	allowed, reason, _ := s.checkGuardModel(question, "/query")
 	s.emitAiHelperLogEvent("query.guard.result", traceID, turnID, "/query", model, guardModel, "off",
 		"Guard verdict: "+reason, "INFO", map[string]string{"gen_ai.operation.name": "guard"})
 	if !allowed {

--- a/go/cmd/sobs/upstream.go
+++ b/go/cmd/sobs/upstream.go
@@ -86,6 +86,15 @@ func (s *server) upstreamRequest(method, url string, body []byte, headers map[st
 // deterministic per-request-body AI response); it falls back to the URL-only key so every existing
 // canned GitHub/OSV/webhook/AI fixture still resolves. A missing fixture resolves to a 404.
 func (s *server) upstreamFixture(dir, method, url string, reqBody []byte) (upstreamResponse, error) {
+	// Debug: SOBS_MOCK_BODYDUMP=<file> appends every fixture request body so a Go replay can be
+	// diffed against the Python capture (determinism.py) to confirm byte-identical LLM request
+	// bodies — the prerequisite for body-keyed canned responses. No-op unless the env var is set.
+	if dump := strings.TrimSpace(os.Getenv("SOBS_MOCK_BODYDUMP")); dump != "" {
+		if f, e := os.OpenFile(dump, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); e == nil {
+			fmt.Fprintf(f, "GO %s key=%s\n  body=%q\n", url, upstreamFixtureKeyBody(method, url, reqBody), reqBody)
+			f.Close()
+		}
+	}
 	var raw []byte
 	var err error = os.ErrNotExist
 	if len(reqBody) > 0 {

--- a/migration/tools/determinism.py
+++ b/migration/tools/determinism.py
@@ -102,6 +102,14 @@ def _install_upstream_fixtures() -> None:
         if host not in intercept_hosts:
             return httpx.Response(599, json={"error": f"unmocked upstream host {host}"})
         body = request.content or b""
+        # Debug: SOBS_MOCK_BODYDUMP=<file> appends every intercepted request body, so capture (this
+        # shim) and replay (go upstream.go) can be diffed to confirm byte-identical LLM request bodies
+        # — the prerequisite for body-keyed canned responses. No-op unless the env var is set.
+        _dump = os.environ.get("SOBS_MOCK_BODYDUMP", "").strip()
+        if _dump:
+            _bk = upstream_fixture_key_body(request.method, str(request.url), body)
+            with open(_dump, "a") as _f:
+                _f.write(f"PY {request.url.path} key={_bk}\n  body={body!r}\n")
         # A body-keyed fixture takes precedence (deterministic per-request AI responses); fall back
         # to the URL-only key so every existing canned GitHub/OSV/webhook/AI fixture still resolves.
         stems = []


### PR DESCRIPTION
Body-keying surfaced two real divergences (Go sent different LLM prompts than Python, latent under the URL-keyed mock): guard prompt dropped the 'Context:/User input:' wrapper (checkGuardModel now takes a context param), and the SQL system prompt used single quotes instead of app.py's markdown backticks (restored via U+F8FF sentinel). Added env-gated SOBS_MOCK_BODYDUMP to both mocks for per-route body diffing. Guard body-key now PY==GO; gate GREEN 689/0.