### PR TITLE
Fix go-main CI: lint migration/tools (black + flake8)

### DIFF
--- a/migration/tools/classify_coverage.py
+++ b/migration/tools/classify_coverage.py
@@ -21,6 +21,7 @@ with uncovered lines is bucketed so the work is sized and routable:
 
 This converts "42% unknown" into "here are N functions, here is exactly what each needs."
 """
+
 from __future__ import annotations
 
 import ast
@@ -33,11 +34,35 @@ APP = REPO / "app.py"
 COV = REPO / "migration" / "coverage_app.json"
 
 ROUTE_DECORATORS = {"route", "get", "post", "put", "delete", "patch", "websocket"}
-LIFECYCLE_DECORATORS = {"before_serving", "after_serving", "while_serving",
-                        "before_request", "after_request", "errorhandler", "teardown_request"}
-BACKGROUND_HINTS = ("loop", "worker", "dispatch", "scan", "poll", "consume", "background",
-                    "scheduler", "_tick", "lifespan", "_cron", "drain", "flush_queue",
-                    "_task", "ensure_", "_run_agent", "watchdog", "reconcile")
+LIFECYCLE_DECORATORS = {
+    "before_serving",
+    "after_serving",
+    "while_serving",
+    "before_request",
+    "after_request",
+    "errorhandler",
+    "teardown_request",
+}
+BACKGROUND_HINTS = (
+    "loop",
+    "worker",
+    "dispatch",
+    "scan",
+    "poll",
+    "consume",
+    "background",
+    "scheduler",
+    "_tick",
+    "lifespan",
+    "_cron",
+    "drain",
+    "flush_queue",
+    "_task",
+    "ensure_",
+    "_run_agent",
+    "watchdog",
+    "reconcile",
+)
 
 
 def _decorator_name(dec: ast.expr) -> str | None:
@@ -108,16 +133,18 @@ def main() -> int:
     rows = []
     for i, rec in per_func.items():
         s, e, name, bucket, route_meta = funcs[i]
-        rows.append({
-            "function": name,
-            "bucket": bucket,
-            "start": s,
-            "end": e,
-            "uncovered": len(rec["missing"]),
-            "span": e - s + 1,
-            "route": route_meta,
-            "missing_sample": rec["missing"][:8],
-        })
+        rows.append(
+            {
+                "function": name,
+                "bucket": bucket,
+                "start": s,
+                "end": e,
+                "uncovered": len(rec["missing"]),
+                "span": e - s + 1,
+                "route": route_meta,
+                "missing_sample": rec["missing"][:8],
+            }
+        )
     rows.sort(key=lambda r: r["uncovered"], reverse=True)
 
     by_bucket: dict[str, dict] = {}
@@ -139,14 +166,16 @@ def main() -> int:
     (REPO / "migration" / "coverage_backlog.json").write_text(json.dumps(backlog, indent=2))
 
     # Markdown report.
-    lines = ["# app.py uncovered-line backlog",
-             "",
-             f"Oracle coverage **{backlog['summary_pct']}%** · **{total_uncovered}** uncovered statements.",
-             "",
-             "## By bucket",
-             "",
-             "| bucket | functions | uncovered lines | meaning |",
-             "|---|---:|---:|---|"]
+    lines = [
+        "# app.py uncovered-line backlog",
+        "",
+        f"Oracle coverage **{backlog['summary_pct']}%** · **{total_uncovered}** uncovered statements.",
+        "",
+        "## By bucket",
+        "",
+        "| bucket | functions | uncovered lines | meaning |",
+        "|---|---:|---:|---|",
+    ]
     meaning = {
         "route": "needs a fixture/profile (corpus expansion; byte-verifiable)",
         "lifecycle": "background/lifecycle — needs a function-level difftest (capture can't reach)",
@@ -163,8 +192,13 @@ def main() -> int:
         sub = [r for r in rows if r["bucket"] == b]
         if not sub:
             continue
-        lines += ["", f"## {b} — top by uncovered lines ({len(sub)} functions)", "",
-                  "| function | lines | uncovered | route |", "|---|---|---:|---|"]
+        lines += [
+            "",
+            f"## {b} — top by uncovered lines ({len(sub)} functions)",
+            "",
+            "| function | lines | uncovered | route |",
+            "|---|---|---:|---|",
+        ]
         for r in sub[:40]:
             rt = ""
             if r["route"]:

--- a/migration/tools/coverage_capture.py
+++ b/migration/tools/coverage_capture.py
@@ -16,6 +16,7 @@ Outputs:
     migration/coverage_app.json  — machine-readable per-line coverage of app.py
     stdout                       — coverage.py report (Stmts/Miss/Cover + missing line ranges)
 """
+
 from __future__ import annotations
 
 import subprocess

--- a/migration/tools/coverage_gate.py
+++ b/migration/tools/coverage_gate.py
@@ -4,10 +4,10 @@
 Reads migration/coverage_app.json (written by coverage_capture.py) and migration/COVERAGE_FLOOR.
 As corpus expansion raises coverage, bump COVERAGE_FLOOR so it can only go up.
 """
+
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 TOOLS = Path(__file__).resolve().parent
@@ -21,8 +21,10 @@ def main() -> int:
     floor = float((REPO / "migration" / "COVERAGE_FLOOR").read_text().strip())
     print(f"app.py oracle coverage: {pct:.2f}%  (floor {floor:.2f}%)")
     if pct + 1e-6 < floor:
-        print(f"::error::oracle coverage regressed: {pct:.2f}% < floor {floor:.2f}% — "
-              "a fixture/profile likely broke, or covered behavior was removed.")
+        print(
+            f"::error::oracle coverage regressed: {pct:.2f}% < floor {floor:.2f}% — "
+            "a fixture/profile likely broke, or covered behavior was removed."
+        )
         return 1
     if pct - floor >= 1.0:
         print(f"::notice::coverage is {pct - floor:.1f} pts above the floor — bump migration/COVERAGE_FLOOR.")

--- a/migration/tools/fuzz_diff.py
+++ b/migration/tools/fuzz_diff.py
@@ -13,6 +13,7 @@ generated ids advance both counters in lockstep.
 
 Run inside the parity Docker image (chdb + libchdb + Go). Exit 1 on any byte mismatch.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -246,7 +247,7 @@ def main() -> int:
         print(f"  py: status={ps} len={len(pb)}  go: status={gs} len={len(gb)}")
         for i, (a, b) in enumerate(zip(pb, gb)):
             if a != b:
-                print(f"  first diff @byte {i}: py={pb[max(0,i-10):i+20]!r} go={gb[max(0,i-10):i+20]!r}")
+                print(f"  first diff @byte {i}: py={pb[max(0, i-10):i+20]!r} go={gb[max(0, i-10):i+20]!r}")
                 break
         else:
             if len(pb) != len(gb):

--- a/migration/tools/mutation_test.py
+++ b/migration/tools/mutation_test.py
@@ -22,6 +22,7 @@ corpus is regenerated scratch, so it needs no restore. If interrupted hard, rest
 
 Run inside the parity Docker image. Exit 0 always (it's a report); non-zero only on harness error.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/migration/tools/seed_fixtures.py
+++ b/migration/tools/seed_fixtures.py
@@ -4162,7 +4162,7 @@ def seed_aiturns(db) -> None:
     #   B1 (turn B): assistant message with reasoning_content STRING -> _coerce_reasoning_text str arm;
     #                output assistant content string drives turn B assistant_message.
     #   B2 (turn B): user message (content str -> turn B user_message) + a parts list with a
-    #                type:reasoning entry, plus reasoning as a LIST -> the reasoning list arm + parts
+    # type: reasoning entry, plus reasoning as a LIST -> the reasoning list arm + parts
     #                reasoning arm of _genai_message_reasoning_to_text.
     #
     # Each span's gen_ai.turn_id pins the turn group; gen_ai.request.model + tokens make is_llm_call

--- a/migration/tools/structural_checks.py
+++ b/migration/tools/structural_checks.py
@@ -13,12 +13,12 @@ byte-diff can miss. Read-only static analysis (no chdb / no capture needed).
 
 Output: migration/structural_report.md + stdout summary. Exit 1 iff the route matrix has a gap.
 """
+
 from __future__ import annotations
 
 import ast
 import re
 import subprocess
-import sys
 from pathlib import Path
 
 TOOLS = Path(__file__).resolve().parent
@@ -57,8 +57,8 @@ def _canon(path: str) -> str:
     """Canonicalize a route: Python <x> and Go {x} dynamic segments -> '*'; Go '/{$}' (exact root)
     -> '/'."""
     path = path.replace("/{$}", "/")
-    path = re.sub(r"\{[^}]*\}", "*", path)   # Go {param}
-    path = re.sub(r"<[^>]*>", "*", path)     # Python <param>
+    path = re.sub(r"\{[^}]*\}", "*", path)  # Go {param}
+    path = re.sub(r"<[^>]*>", "*", path)  # Python <param>
     return path
 
 
@@ -116,7 +116,10 @@ def check_stubs() -> list[str]:
     try:
         out = subprocess.run(
             ["grep", "-rniE", pat, str(GO_DIR / "cmd" / "sobs"), str(GO_DIR / "internal")],
-            capture_output=True, text=True, cwd=str(REPO))
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+        )
         lines = [ln for ln in out.stdout.splitlines() if ln.strip()]
     except Exception:
         lines = []
@@ -131,10 +134,14 @@ def main() -> int:
     const_findings = check_constants(tree, go_src)
     stub_lines = check_stubs()
 
-    md = ["# Structural checks", "",
-          f"- Python routes: **{len(all_py)}**, unmapped in Go: **{len(missing_routes)}**",
-          f"- Constant collections with members absent from Go source: **{len(const_findings)}**",
-          f"- Go stub/deferral markers: **{len(stub_lines)}**", ""]
+    md = [
+        "# Structural checks",
+        "",
+        f"- Python routes: **{len(all_py)}**, unmapped in Go: **{len(missing_routes)}**",
+        f"- Constant collections with members absent from Go source: **{len(const_findings)}**",
+        f"- Go stub/deferral markers: **{len(stub_lines)}**",
+        "",
+    ]
 
     md.append("## 1. Route matrix (HARD)")
     if not missing_routes:


### PR DESCRIPTION
## Why
The `Code Style & Linting` CI job on go-main has been red since the #368/#369 merges: 7 `migration/tools/*.py` files were committed unformatted (black) and two carried unused `sys` imports (flake8 F401), plus one E231 inside an f-string black won't touch.

## What
- `black .` reformat: classify_coverage, coverage_capture, coverage_gate, fuzz_diff, mutation_test, seed_fixtures, structural_checks
- flake8 F401: drop unused `import sys` in coverage_gate.py + structural_checks.py
- flake8 E231: space after comma in fuzz_diff.py f-string

## Scope / safety
Pure cosmetic whitespace + dead-import removal in **migration tooling only**. No `app.py` (frozen oracle), no Go, no fixtures touched → byte-parity behavior unchanged. CI parity gate (`run_parity_ci.py`) runs on this PR and must stay GREEN before merge.

Verified locally: `black --check .`, `isort --check-only .`, `flake8 .` all clean.