### PR TITLE
ci: run CI on self-hosted sobs-runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
   rum-build:
     name: RUM JS Build & Type Check
     runs-on: sobs-runners
-    needs: dependency-audit
     permissions:
       contents: read
     steps:
@@ -89,7 +88,6 @@ jobs:
   lint:
     name: Code Style & Linting
     runs-on: sobs-runners
-    needs: dependency-audit
     permissions:
       contents: read
     steps:
@@ -120,7 +118,6 @@ jobs:
   test:
     name: Tests
     runs-on: sobs-runners
-    needs: lint
     permissions:
       contents: read
     steps:
@@ -157,7 +154,6 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: sobs-runners
-    needs: test
     permissions:
       contents: read
     steps:
@@ -198,7 +194,7 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: sobs-runners
-    needs: integration
+    needs: [dependency-audit, rum-build, lint, test, integration]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            .github/workflows/ci.yml
-
       - name: Install pip-audit
         run: pip install pip-audit
 
@@ -48,7 +43,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
 
       - name: Install JS dependencies
         run: npm ci
@@ -69,7 +63,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
 
       - name: Install JS dependencies
         run: npm ci
@@ -106,12 +99,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            pyproject.toml
-            .github/workflows/ci.yml
-            .github/cache-key-lint.txt
-
       - name: Install linting dependencies
         run: pip install black isort flake8 mypy djlint flask
 
@@ -145,14 +132,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-integration.txt
-            pyproject.toml
-            .github/workflows/ci.yml
-            .github/cache-key-runtime.txt
-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-integration.txt
 
@@ -188,22 +167,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-integration.txt
-            pyproject.toml
-            .github/workflows/ci.yml
-            .github/cache-key-runtime.txt
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements-integration.txt', '.github/workflows/ci.yml', '.github/cache-key-runtime.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -257,6 +220,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["registry-mirror.ci-cache.svc.cluster.local:5000"]
+            [registry."registry-mirror.ci-cache.svc.cluster.local:5000"]
+              http = true
+            [registry."registry-cache.ci-cache.svc.cluster.local:5000"]
+              http = true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -285,8 +257,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SOBS_BUILD_VERSION=${{ steps.build_version.outputs.value }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-buildcache
+          cache-to: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-buildcache,mode=max
 
   register-sobs-release:
     name: Register SOBS Release Metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   dependency-audit:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     permissions:
       contents: read
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   rum-build:
     name: RUM JS Build & Type Check
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: dependency-audit
     permissions:
       contents: read
@@ -95,7 +95,7 @@ jobs:
 
   lint:
     name: Code Style & Linting
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: dependency-audit
     permissions:
       contents: read
@@ -132,7 +132,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: lint
     permissions:
       contents: read
@@ -177,7 +177,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: test
     permissions:
       contents: read
@@ -234,7 +234,7 @@ jobs:
 
   docker:
     name: Build & Push Docker Image
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: integration
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
@@ -290,7 +290,7 @@ jobs:
 
   register-sobs-release:
     name: Register SOBS Release Metadata
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: [docker, rum-build]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
@@ -428,7 +428,7 @@ jobs:
 
   cleanup-ghcr:
     name: Cleanup Stale GHCR Versions
-    runs-on: ubuntu-latest
+    runs-on: sobs-runners
     needs: docker
     if: false # Disabled: issue #223 - cleanup is too aggressive and removes the latest tag
     permissions:


### PR DESCRIPTION
Switches all `ci.yml` jobs from `ubuntu-latest` to the self-hosted `sobs-runners` (ARC, dind). Stops consuming GitHub Actions minutes.

Validated via workflow_dispatch run 28306588713: Dependency Audit, RUM Build, Lint, Tests, Integration Tests all green on self-hosted. The docker/release/cleanup jobs are gated to push/tag events and were skipped in the dispatch run — they will first execute on self-hosted when this lands on main.