### PR TITLE
ci: stop uploading integration screenshots on every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,12 +184,15 @@ jobs:
         run: pytest tests/test_integration.py -v
 
       - name: Upload screenshots
-        if: always()
+        # Only on failure — screenshots are a debugging aid for failed integration
+        # runs; uploading 2.8MB every green run filled the account artifact quota.
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: integration-screenshots
           path: tests/screenshots/
           if-no-files-found: warn
+          retention-days: 5
 
   docker:
     name: Build & Push Docker Image


### PR DESCRIPTION
integration-screenshots uploaded on if: always() (2.8MB/run) was filling the account-wide artifact storage quota, which blocked ALL artifact uploads (incl. pivit). Now uploads only on failure (when the screenshots are actually useful) with 5-day retention.