### PR TITLE
tests: slice E/F/G — oracle-anchored unit tests for the residual pure-func 0% surface

### DIFF
--- a/go/cmd/sobs/coverage_pure_e_test.go
+++ b/go/cmd/sobs/coverage_pure_e_test.go
@@ -1,0 +1,164 @@
+package main
+
+// coverage_pure_e_test.go — oracle-anchored unit tests for SLICE E pure helpers
+// (AI / chart-JSON / LLM-stats helpers). Assertions are anchored to the FROZEN
+// ORACLE (app.py), not to "whatever Go currently returns".
+//
+// Target functions and their disposition:
+//   TESTED:
+//     queryStageStats   (ai_llm.go:291)   app.py:3481-3488 (_query_llm_stage_stats)
+//     queryRunLLMStats  (fix_query.go:314) app.py:3491-3504 (_summarize_query_llm_stats)
+//
+//   SKIPPED (already covered by prior slices — verified executed, not just named):
+//     buildFallbackCustomOptionJSON  — TestBuildFallbackCustomOptionJSON  (ai_build_chat_helpers_test.go)
+//     objGetOr                       — TestObjGetOr                       (ai_build_chat_helpers_test.go)
+//     pyExpectingValueError          — TestPyExpectingValueError          (ai_build_chat_helpers_test.go)
+//     extractChartOptionPlaceholders — TestExtractChartOptionPlaceholders (notif_chart_mcp_helpers_test.go)
+//     inferCustomMappingFromOption   — TestInferCustomMappingFromOption   (remaining_pure_helpers_test.go)
+//     mcpNormalizeMap                — TestMcpNormalizeMap                (notif_chart_mcp_helpers_test.go)
+//   The original 0%-coverage target list was stale; these six are already tested
+//   in current go-main, so retesting them adds ~0 coverage. Only the two LLM-stage
+//   stats helpers remained genuinely untested.
+//
+// NOTE on the mcpNormalizeMap oracle (for the record, since it was on the original
+// list): mcp.py:518-523 _normalize_map_value has an ast.literal_eval fallback that
+// the Go port (mcp_tools.go:374, JSON-only) lacks — so a Python-repr string like
+// "{'a': 1}" normalizes to {"a": 1} in Python but {} in Go. That divergence is
+// pre-existing and out of scope here (the func is already tested elsewhere); noting
+// it so it is not lost.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// objToMap flattens a *jsonenc.Object one level deep into a comparable map.
+// Nested *jsonenc.Object values are flattened recursively.
+func objEToMap(o *jsonenc.Object) map[string]any {
+	if o == nil {
+		return nil
+	}
+	m := map[string]any{}
+	for _, k := range o.Keys() {
+		v, _ := o.Get(k)
+		if sub, ok := v.(*jsonenc.Object); ok {
+			m[k] = objEToMap(sub)
+		} else {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// queryStageStats — ai_llm.go:291
+// Oracle: app.py:3481-3488 _query_llm_stage_stats(stats) ->
+//   {"prompt_tokens": int(payload.get("prompt_tokens") or 0),
+//    "completion_tokens": int(payload.get("completion_tokens") or 0),
+//    "thinking_tokens": int(payload.get("thinking_tokens") or 0),
+//    "elapsed_ms": int(payload.get("elapsed_ms") or 0)}
+// The Go llmStats type carries prompt/completion/thinking ints and no elapsed
+// field, so elapsed_ms is always 0 — matching the oracle for the payloads Go's
+// callers feed (where elapsed is absent/0). Key order must equal the oracle dict
+// literal order.
+// ---------------------------------------------------------------------------
+
+func TestSliceE_queryStageStats(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   llmStats
+		want map[string]any
+	}{
+		{
+			"zero stats",
+			llmStats{},
+			map[string]any{"prompt_tokens": 0, "completion_tokens": 0, "thinking_tokens": 0, "elapsed_ms": 0},
+		},
+		{
+			"populated stats",
+			llmStats{prompt: 12, completion: 34, thinking: 5},
+			map[string]any{"prompt_tokens": 12, "completion_tokens": 34, "thinking_tokens": 5, "elapsed_ms": 0},
+		},
+		{
+			"large values preserved",
+			llmStats{prompt: 100000, completion: 250000, thinking: 9999},
+			map[string]any{"prompt_tokens": 100000, "completion_tokens": 250000, "thinking_tokens": 9999, "elapsed_ms": 0},
+		},
+	}
+	wantOrder := []string{"prompt_tokens", "completion_tokens", "thinking_tokens", "elapsed_ms"}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := queryStageStats(c.in)
+			if gotMap := objEToMap(got); !reflect.DeepEqual(gotMap, c.want) {
+				t.Errorf("queryStageStats(%+v) = %v, want %v", c.in, gotMap, c.want)
+			}
+			if gotKeys := got.Keys(); !reflect.DeepEqual(gotKeys, wantOrder) {
+				t.Errorf("queryStageStats key order = %v, want %v", gotKeys, wantOrder)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// queryRunLLMStats — fix_query.go:314
+// Oracle: app.py:3491-3504 _summarize_query_llm_stats(named_query_generation=…,
+// chart_generation=…) -> {"totals": <sum of stages>, "named_query_generation":
+// <stage>, "chart_generation": <stage>}. totals is the element-wise sum of the
+// two stages; each stage is a _query_llm_stage_stats dict. Insertion order:
+// totals first (seeded by the oracle), then each stage in kwarg order.
+// ---------------------------------------------------------------------------
+
+func TestSliceE_queryRunLLMStats(t *testing.T) {
+	stage := func(p, c, th int) map[string]any {
+		return map[string]any{"prompt_tokens": p, "completion_tokens": c, "thinking_tokens": th, "elapsed_ms": 0}
+	}
+	cases := []struct {
+		desc        string
+		named, char llmStats
+		want        map[string]any
+	}{
+		{
+			"both zero",
+			llmStats{}, llmStats{},
+			map[string]any{
+				"totals":                 stage(0, 0, 0),
+				"named_query_generation": stage(0, 0, 0),
+				"chart_generation":       stage(0, 0, 0),
+			},
+		},
+		{
+			"populated stages summed into totals",
+			llmStats{prompt: 10, completion: 20, thinking: 3},
+			llmStats{prompt: 1, completion: 2, thinking: 4},
+			map[string]any{
+				"totals":                 stage(11, 22, 7),
+				"named_query_generation": stage(10, 20, 3),
+				"chart_generation":       stage(1, 2, 4),
+			},
+		},
+		{
+			"only named stage populated",
+			llmStats{prompt: 7, completion: 8, thinking: 9},
+			llmStats{},
+			map[string]any{
+				"totals":                 stage(7, 8, 9),
+				"named_query_generation": stage(7, 8, 9),
+				"chart_generation":       stage(0, 0, 0),
+			},
+		},
+	}
+	wantOrder := []string{"totals", "named_query_generation", "chart_generation"}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := queryRunLLMStats(c.named, c.char)
+			if gotMap := objEToMap(got); !reflect.DeepEqual(gotMap, c.want) {
+				t.Errorf("queryRunLLMStats(%+v, %+v) = %v, want %v", c.named, c.char, gotMap, c.want)
+			}
+			if gotKeys := got.Keys(); !reflect.DeepEqual(gotKeys, wantOrder) {
+				t.Errorf("queryRunLLMStats top-level key order = %v, want %v", gotKeys, wantOrder)
+			}
+		})
+	}
+}

--- a/go/cmd/sobs/coverage_pure_f_test.go
+++ b/go/cmd/sobs/coverage_pure_f_test.go
@@ -1,0 +1,95 @@
+package main
+
+// coverage_pure_f_test.go — oracle-anchored unit tests for SLICE F pure helpers.
+//
+// SCOPE NOTE: of the 12 functions originally assigned to slice F, 10 turned out to be ALREADY
+// covered by earlier slices in current go-main (verified by grep over *_test.go for real call
+// sites). Re-testing them adds ~0 coverage, so they are listed under SKIPPED with the existing
+// test file that covers them. Only two functions were genuinely untested; they are the TESTED set.
+//
+//   TESTED (Go-internal plumbing — no direct app.py function; behavioral assertions anchored to the
+//   small Python idiom each helper reproduces, cited in its own doc-comment):
+//     strOrBrace (upstream.go:275)  behavioral — mirrors `str(ConfigJson) or "{}"` (blank -> "{}",
+//                                   else returned verbatim, NOT trimmed)
+//     unwrapType (query_exec.go:69) behavioral — peels one chDB type wrapper:
+//                                   "Wrapper(inner)" -> ("inner", true); else ("", false).
+//                                   Drives chBaseType's Nullable/LowCardinality unwrap loop.
+//
+//   SKIPPED — already covered elsewhere in go-main (would only duplicate):
+//     requireDmSafeValue            — cmd/sobs/safeguard_dm_validate_test.go
+//     validateDmBackupName          — cmd/sobs/safeguard_dm_validate_test.go
+//     normalizeNotificationCondition— cmd/sobs/coverage_pure_b_test.go, notif_chart_mcp_helpers_test.go
+//     parseNotificationConditionsJSON— cmd/sobs/notif_chart_mcp_helpers_test.go
+//     objStrOr                      — cmd/sobs/ai_action_normalize_test.go
+//     objSub                        — cmd/sobs/ai_action_normalize_test.go
+//     objTruthy                     — cmd/sobs/ai_action_normalize_test.go
+//     upstreamFixtureKeyBody        — cmd/sobs/upstream_key_test.go
+//     rumAssetSignature             — cmd/sobs/remaining_pure_helpers_test.go
+//     quotePathSafeSlash            — internal/store/chdb_target_test.go (package store, not main)
+//
+//   DIVERGENCE: none found.
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// strOrBrace — upstream.go:275 — Go-internal, behavioral.
+//   Mirrors `str(ConfigJson) or "{}"`: a blank (after TrimSpace) input yields "{}"; a non-blank
+//   input is returned VERBATIM (no trimming applied to the returned value).
+// ---------------------------------------------------------------------------
+
+func TestSliceF_strOrBrace(t *testing.T) {
+	cases := []struct {
+		in, want, desc string
+	}{
+		{"", "{}", "empty -> {}"},
+		{"   ", "{}", "spaces only -> {}"},
+		{"\t\n", "{}", "whitespace only -> {}"},
+		{`{"a":1}`, `{"a":1}`, "non-blank object returned verbatim"},
+		{"[]", "[]", "non-blank array returned verbatim"},
+		{"null", "null", "literal null string returned verbatim"},
+		{"  {\"a\":1}  ", "  {\"a\":1}  ", "non-blank with surrounding spaces is NOT trimmed"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			if got := strOrBrace(c.in); got != c.want {
+				t.Errorf("strOrBrace(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unwrapType — query_exec.go:69 — Go-internal, behavioral.
+//   Peels one chDB type wrapper: "Wrapper(inner)" -> ("inner", true); otherwise ("", false).
+//   Must require BOTH the "Wrapper(" prefix and the trailing ")"; the inner may itself be wrapped
+//   (chBaseType calls it in a loop) or empty.
+// ---------------------------------------------------------------------------
+
+func TestSliceF_unwrapType(t *testing.T) {
+	cases := []struct {
+		typ, wrapper, wantInner string
+		wantOK                  bool
+		desc                    string
+	}{
+		{"Nullable(String)", "Nullable", "String", true, "simple unwrap"},
+		{"LowCardinality(String)", "LowCardinality", "String", true, "low-cardinality unwrap"},
+		{"Nullable(LowCardinality(String))", "Nullable", "LowCardinality(String)", true, "nested inner preserved (one peel)"},
+		{"Array(UInt8)", "Array", "UInt8", true, "array wrapper"},
+		{"Nullable()", "Nullable", "", true, "empty inner is valid"},
+		{"String", "Nullable", "", false, "no wrapper"},
+		{"Nullable(String)", "LowCardinality", "", false, "wrong wrapper name"},
+		{"NullableString)", "Nullable", "", false, "missing open paren"},
+		{"Nullable(String", "Nullable", "", false, "missing close paren"},
+		{"Nullable", "Nullable", "", false, "bare wrapper name, no parens"},
+		{"", "Nullable", "", false, "empty type"},
+		{"xNullable(String)", "Nullable", "", false, "wrapper not at start"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			inner, ok := unwrapType(c.typ, c.wrapper)
+			if ok != c.wantOK || inner != c.wantInner {
+				t.Errorf("unwrapType(%q,%q) = (%q,%v), want (%q,%v)", c.typ, c.wrapper, inner, ok, c.wantInner, c.wantOK)
+			}
+		})
+	}
+}

--- a/go/cmd/sobs/coverage_pure_g_test.go
+++ b/go/cmd/sobs/coverage_pure_g_test.go
@@ -1,0 +1,367 @@
+package main
+
+// coverage_pure_g_test.go — oracle-anchored unit tests for SLICE G pure helpers
+// (encoding / data / misc that the byte-parity corpus does not reach).
+//
+// Target functions and their disposition:
+//   TESTED:
+//     anySlice                    (handlers_misc.go:895)   — chdb Array cell normalizer (no
+//                                   single app.py line; mirrors the "FORMAT JSON yields []any,
+//                                   else json.loads of an array string" coercion used throughout
+//                                   app.py array-column handling)
+//     jsonDumpsIndent2            (handlers_misc.go:912)   app.py:10565,15747,15762
+//                                   (json.dumps(obj, ensure_ascii=False, indent=2))
+//     runHealthcheck              (main.go:112)            — failure path only (no server up →
+//                                   connection refused → returns 1); the success path needs a
+//                                   live /health server (see SKIPPED note for the 200 branch)
+//     parseGithubActionsSnapshotZip (fix_cve_helpers.go:190) app.py:16577-16624
+//                                   (_github_actions_dependency_rows zip loop)
+//
+//   SKIPPED (already covered / live IO / not unit-testable):
+//     jsonDumpsNoEscBytes  — already covered by remaining_pure_helpers_test.go
+//     exactMethodGuard     — already covered by remaining_pure_helpers_test.go
+//     sendSMTPMessage      — live SMTP: smtp.Dial(addr) is the first statement, no pure
+//                            message-building portion to isolate. Mirrors how
+//                            coverage_pure_a_test.go skips _dispatch_email_channel
+//                            ("server method making SMTP connections; not unit-testable").
+//                            (The success path is exercised only by an integration test with a
+//                            real/mock SMTP server.)
+//     runHealthcheck 200-branch — needs a live HTTP server answering /health with 200; only the
+//                            connection-refused failure path is determinable in a unit test.
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// ---------------------------------------------------------------------------
+// anySlice — handlers_misc.go:895
+// Oracle: normalize a chdb cell that should be an Array into []any. FORMAT JSON
+// yields a []any directly; a JSON-array string (defensive fallback) is parsed;
+// anything else → nil.
+// ---------------------------------------------------------------------------
+
+func TestSliceG_anySlice(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   any
+		want []any
+	}{
+		{"already []any", []any{"a", float64(1), true}, []any{"a", float64(1), true}},
+		{"empty []any", []any{}, []any{}},
+		{"json array string", `["x", 2, null]`, []any{"x", float64(2), nil}},
+		{"json empty array string", `[]`, []any{}},
+		{"json object string → not an array → nil", `{"a":1}`, nil},
+		{"json scalar string → nil", `42`, nil},
+		{"plain (non-json) string → nil", "hello", nil},
+		{"empty string → nil", "", nil},
+		{"nil → nil", nil, nil},
+		{"int → nil", 7, nil},
+		{"map → nil", map[string]any{"a": 1}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := anySlice(c.in)
+			if c.want == nil {
+				if got != nil {
+					t.Fatalf("anySlice(%#v) = %#v, want nil", c.in, got)
+				}
+				return
+			}
+			gb, _ := json.Marshal(got)
+			wb, _ := json.Marshal(c.want)
+			if string(gb) != string(wb) {
+				t.Errorf("anySlice(%#v) = %s, want %s", c.in, gb, wb)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// jsonDumpsIndent2 — handlers_misc.go:912
+// Oracle: json.dumps(obj, ensure_ascii=False, indent=2) — two-space indent,
+// "," item separator (no trailing space), ": " key separator, NO HTML-escaping
+// of <>&, non-ASCII left literal, insertion-order keys.
+// Oracle reference outputs captured from CPython (app.py:10565,15747,15762).
+// ---------------------------------------------------------------------------
+
+func TestSliceG_jsonDumpsIndent2(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   any
+		want string
+	}{
+		// CPython: json.dumps({"a":1,"b":[1,2],"c":"x<y>&z"}, ensure_ascii=False, indent=2)
+		{
+			"nested object/array + raw <>&",
+			jsonenc.NewObject().
+				Set("a", json.Number("1")).
+				Set("b", []any{json.Number("1"), json.Number("2")}).
+				Set("c", "x<y>&z"),
+			"{\n  \"a\": 1,\n  \"b\": [\n    1,\n    2\n  ],\n  \"c\": \"x<y>&z\"\n}",
+		},
+		// CPython: json.dumps({"k":"héllo→"}, ensure_ascii=False, indent=2)
+		// ensure_ascii=False keeps non-ASCII literal.
+		{
+			"non-ascii left literal",
+			jsonenc.NewObject().Set("k", "héllo→"),
+			"{\n  \"k\": \"héllo→\"\n}",
+		},
+		// Empty object: CPython json.dumps({}, indent=2) → "{}"
+		{"empty object", jsonenc.NewObject(), "{}"},
+		// Empty array: CPython json.dumps([], indent=2) → "[]"
+		{"empty array", []any{}, "[]"},
+		// Scalar string at top level.
+		{"top-level string", "hi", `"hi"`},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got, err := jsonDumpsIndent2(c.in)
+			if err != nil {
+				t.Fatalf("jsonDumpsIndent2(%#v) error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("jsonDumpsIndent2 mismatch\n got: %q\nwant: %q", got, c.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runHealthcheck — main.go:112
+// Oracle: probe local /health; 200 → 0 else 1. We can only deterministically
+// exercise the FAILURE path (no server up → connection refused → 1) and the
+// non-200 path (a stub server returning 500 → 1). The genuine 200 path needs a
+// live SOBS server, so it stays an integration concern.
+// ---------------------------------------------------------------------------
+
+func TestSliceG_runHealthcheck_ConnRefused(t *testing.T) {
+	// Point SOBS_PORT at a port with (almost certainly) nothing listening so the
+	// GET fails fast with connection-refused → returns 1. We pick a high port and
+	// restore the env afterwards.
+	orig, had := os.LookupEnv("SOBS_PORT")
+	origP, hadP := os.LookupEnv("PORT")
+	defer func() {
+		if had {
+			os.Setenv("SOBS_PORT", orig)
+		} else {
+			os.Unsetenv("SOBS_PORT")
+		}
+		if hadP {
+			os.Setenv("PORT", origP)
+		} else {
+			os.Unsetenv("PORT")
+		}
+	}()
+	os.Unsetenv("PORT")
+	os.Setenv("SOBS_PORT", "1") // privileged/unused → dial fails immediately
+
+	if rc := runHealthcheck(); rc != 1 {
+		t.Errorf("runHealthcheck() with no server = %d, want 1", rc)
+	}
+}
+
+func TestSliceG_runHealthcheck_Non200(t *testing.T) {
+	// A stub server that answers /health with 500 must yield exit code 1.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	// srv.Listener.Addr() is 127.0.0.1:<port>; runHealthcheck dials 127.0.0.1:<SOBS_PORT>.
+	port := srv.Listener.Addr().(interface{ String() string }).String()
+	// Extract the port number after the last ':'.
+	colon := -1
+	for i := len(port) - 1; i >= 0; i-- {
+		if port[i] == ':' {
+			colon = i
+			break
+		}
+	}
+	if colon < 0 {
+		t.Fatalf("unexpected listener addr %q", port)
+	}
+	portNum := port[colon+1:]
+
+	orig, had := os.LookupEnv("SOBS_PORT")
+	origP, hadP := os.LookupEnv("PORT")
+	defer func() {
+		if had {
+			os.Setenv("SOBS_PORT", orig)
+		} else {
+			os.Unsetenv("SOBS_PORT")
+		}
+		if hadP {
+			os.Setenv("PORT", origP)
+		} else {
+			os.Unsetenv("PORT")
+		}
+	}()
+	os.Unsetenv("PORT")
+	os.Setenv("SOBS_PORT", portNum)
+
+	if rc := runHealthcheck(); rc != 1 {
+		t.Errorf("runHealthcheck() against 500 server = %d, want 1", rc)
+	}
+}
+
+func TestSliceG_runHealthcheck_200(t *testing.T) {
+	// The success path: a stub server answering 200 on /health → exit code 0.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	addr := srv.Listener.Addr().String()
+	colon := -1
+	for i := len(addr) - 1; i >= 0; i-- {
+		if addr[i] == ':' {
+			colon = i
+			break
+		}
+	}
+	portNum := addr[colon+1:]
+
+	orig, had := os.LookupEnv("SOBS_PORT")
+	origP, hadP := os.LookupEnv("PORT")
+	defer func() {
+		if had {
+			os.Setenv("SOBS_PORT", orig)
+		} else {
+			os.Unsetenv("SOBS_PORT")
+		}
+		if hadP {
+			os.Setenv("PORT", origP)
+		} else {
+			os.Unsetenv("PORT")
+		}
+	}()
+	os.Unsetenv("PORT")
+	os.Setenv("SOBS_PORT", portNum)
+
+	if rc := runHealthcheck(); rc != 0 {
+		t.Errorf("runHealthcheck() against 200 /health server = %d, want 0", rc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseGithubActionsSnapshotZip — fix_cve_helpers.go:190
+// Oracle: app.py:16577-16624 — for each non-dir zip entry whose basename matches
+// pip-freeze-<platform>-<arch>.txt, parse requirements into PyPI deps and emit a
+// dependencies-lockfile artifact row. Entries that don't match, or whose parsed
+// deps are empty, are skipped. A corrupt archive yields no rows.
+// We assert the STABLE row fields (Id/UploadedAt/Version are non-deterministic).
+// ---------------------------------------------------------------------------
+
+func makeZip(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip create %q: %v", name, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestSliceG_parseGithubActionsSnapshotZip_Match(t *testing.T) {
+	// One matching entry with two pinned deps; one non-matching entry (ignored).
+	reqs := "# comment\nflask==3.0.0\nrequests==2.31.0  # inline note\nnotpinned\n"
+	archive := makeZip(t, map[string]string{
+		"pip-freeze-linux-amd64.txt": reqs,
+		"README.md":                  "ignore me",
+	})
+
+	rows := parseGithubActionsSnapshotZip(
+		archive, "octo", "repo", "run123", "art456", "rel789", "1.2.3", "deadbeef", "snapshot-artifact")
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+
+	// Stable scalar fields anchored to app.py:16591-16620.
+	stable := map[string]any{
+		"ReleaseId":      "rel789",
+		"ArtifactType":   "dependencies-lockfile",
+		"Name":           "pip-freeze-linux-amd64",
+		"ContentType":    "text/plain",
+		"Size":           len(reqs),
+		"Platform":       "linux",
+		"Architecture":   "amd64",
+		"IsDeleted":      0,
+		"StorageRef":     "github-actions://octo/repo/runs/run123/artifacts/art456/pip-freeze-linux-amd64.txt",
+		"ChecksumSha256": sha256Sum([]byte(reqs)),
+	}
+	for k, want := range stable {
+		if got := r[k]; got != want {
+			t.Errorf("row[%q] = %#v, want %#v", k, got, want)
+		}
+	}
+
+	// MetadataJson mirrors json.dumps({...}, separators=(",", ":")) with the deps
+	// in file order (app.py:16606-16617). Build the same object and compare bytes.
+	wantMeta := jsonenc.NewObject().
+		Set("source", "github_actions_artifact").
+		Set("repo", "octo/repo").
+		Set("run_id", "run123").
+		Set("run_head_sha", "deadbeef").
+		Set("release_version", "1.2.3").
+		Set("artifact_name", "snapshot-artifact").
+		Set("dependencies", []any{
+			depObj("flask", "3.0.0", "PyPI"),
+			depObj("requests", "2.31.0", "PyPI"),
+		})
+	wantMetaJSON := string(jsonenc.Encode(wantMeta, cveCompactDumpsOpts))
+	if got := r["MetadataJson"]; got != wantMetaJSON {
+		t.Errorf("MetadataJson mismatch\n got: %v\nwant: %v", got, wantMetaJSON)
+	}
+
+	// Non-deterministic fields must still be present + typed.
+	if id, _ := r["Id"].(string); id == "" {
+		t.Errorf("Id should be a non-empty uuid string, got %#v", r["Id"])
+	}
+	if _, ok := r["UploadedAt"].(string); !ok {
+		t.Errorf("UploadedAt should be a string timestamp, got %#v", r["UploadedAt"])
+	}
+}
+
+func TestSliceG_parseGithubActionsSnapshotZip_NoMatchOrEmpty(t *testing.T) {
+	// Corrupt archive → zip.NewReader fails → nil (app.py broad except → []).
+	if rows := parseGithubActionsSnapshotZip([]byte("not a zip"), "o", "r", "i", "a", "rel", "v", "sha", "n"); len(rows) != 0 {
+		t.Errorf("corrupt archive: expected 0 rows, got %d", len(rows))
+	}
+
+	// A matching name but no pinned (==) deps → parseRequirementsDeps empty → skipped.
+	archive := makeZip(t, map[string]string{
+		"pip-freeze-darwin-arm64.txt": "# only comments\nunpinnedpkg\n",
+		"nested/dir/notmatching.txt":  "flask==1.0.0\n",
+	})
+	rows := parseGithubActionsSnapshotZip(archive, "o", "r", "i", "a", "rel", "v", "sha", "n")
+	if len(rows) != 0 {
+		t.Errorf("no-deps + non-matching name: expected 0 rows, got %d", len(rows))
+	}
+
+	// Empty zip (no files) → no rows.
+	empty := makeZip(t, map[string]string{})
+	if rows := parseGithubActionsSnapshotZip(empty, "o", "r", "i", "a", "rel", "v", "sha", "n"); len(rows) != 0 {
+		t.Errorf("empty zip: expected 0 rows, got %d", len(rows))
+	}
+}

--- a/go/internal/jsonenc/coverage_utf16_test.go
+++ b/go/internal/jsonenc/coverage_utf16_test.go
@@ -1,0 +1,65 @@
+package jsonenc
+
+// coverage_utf16_test.go — oracle-anchored unit test for utf16Pair.
+//
+// TESTED:
+//   utf16Pair(r rune) (rune, rune)  (jsonenc.go:311) — the UTF-16 surrogate-pair
+//     split used when EnsureASCII=True emits an astral-plane rune as
+//     \uXXXX\uXXXX (jsonenc.go:300-305). This mirrors CPython's json encoder,
+//     which escapes any rune > U+FFFF as a high/low surrogate pair.
+//
+// Oracle values captured from CPython:
+//   json.dumps(chr(0x1F600)) == "😀", etc. (ensure_ascii default True).
+// The algorithm: c -= 0x10000; high = 0xD800 + (c >> 10); low = 0xDC00 + (c & 0x3FF).
+
+import "testing"
+
+func TestUtf16Pair_SurrogateSplit(t *testing.T) {
+	cases := []struct {
+		desc           string
+		r              rune
+		wantHi, wantLo rune
+	}{
+		// CPython: json.dumps("\U0001F600") -> "😀" (😀 grinning face)
+		{"U+1F600 emoji", 0x1F600, 0xD83D, 0xDE00},
+		// First astral code point: json.dumps("\U00010000") -> "𐀀"
+		{"U+10000 lowest astral", 0x10000, 0xD800, 0xDC00},
+		// Last valid code point: json.dumps("\U0010FFFF") -> "􏿿"
+		{"U+10FFFF highest", 0x10FFFF, 0xDBFF, 0xDFFF},
+		// Musical symbol G clef: json.dumps("\U0001D11E") -> "𝄞"
+		{"U+1D11E G clef", 0x1D11E, 0xD834, 0xDD1E},
+		// Pile of poo: json.dumps("\U0001F4A9") -> "💩"
+		{"U+1F4A9 pile of poo", 0x1F4A9, 0xD83D, 0xDCA9},
+		// CJK ext B: json.dumps("\U0002070E") -> "𠜎"
+		{"U+2070E CJK ext-B", 0x2070E, 0xD841, 0xDF0E},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			hi, lo := utf16Pair(c.r)
+			if hi != c.wantHi || lo != c.wantLo {
+				t.Errorf("utf16Pair(%#x) = (%#x, %#x), want (%#x, %#x)",
+					c.r, hi, lo, c.wantHi, c.wantLo)
+			}
+			// Both halves must land in the valid surrogate ranges.
+			if hi < 0xD800 || hi > 0xDBFF {
+				t.Errorf("high surrogate %#x out of [D800,DBFF]", hi)
+			}
+			if lo < 0xDC00 || lo > 0xDFFF {
+				t.Errorf("low surrogate %#x out of [DC00,DFFF]", lo)
+			}
+		})
+	}
+}
+
+// TestUtf16Pair_RoundTrip verifies the pair recombines back to the original rune
+// via the standard UTF-16 surrogate-decoding formula — a cross-check independent
+// of the hand-tabulated oracle values above.
+func TestUtf16Pair_RoundTrip(t *testing.T) {
+	for r := rune(0x10000); r <= 0x10FFFF; r += 0x111 {
+		hi, lo := utf16Pair(r)
+		got := 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00)
+		if got != r {
+			t.Fatalf("round-trip failed for %#x: pair (%#x,%#x) -> %#x", r, hi, lo, got)
+		}
+	}
+}

--- a/go/internal/render/coverage_divvalues_test.go
+++ b/go/internal/render/coverage_divvalues_test.go
@@ -1,0 +1,148 @@
+package render
+
+// coverage_divvalues_test.go — oracle-anchored unit test for divValues, the
+// Jinja `/` (Python 3 TRUE-division) operator.
+//
+// TESTED:
+//   divValues(a, b any) any  (eval.go:525)
+//     Oracle: Python 3 true division `/` (PEP 238). Jinja's `/` delegates to it,
+//     so the result is ALWAYS a float — int/int included (4/2 == 2.0, not 2).
+//     Templates use it as e.g. {{ (ms / 1000) | round(1) }} where `ms` has been
+//     coerced to float by `| float` first (templates/traces.html:113 fmt_ms),
+//     so the live operands reaching divValues are int (literals) and float64.
+//
+// CPython reference (the frozen oracle Jinja matches), captured locally:
+//     4/2   == 2.0   (float, NOT int)
+//     7/2   == 3.5
+//     5/2.0 == 2.5
+//     -7/2  == -3.5
+//     0/5   == 0.0
+//     1/3   == 0.3333333333333333
+//     1/0   -> ZeroDivisionError (no template divides by zero)
+//
+// DIVERGENCE (latent, reported loudly — see TestDivValues_Divergence_NonGoNumberOperands):
+//   divValues relies on numFloat, which only recognizes Go int and float64.
+//   json.Number and numeric *strings* fall through to the zero-guard and return
+//   0.0, where Python true-division would yield the real quotient. This is
+//   unreachable from the known templates (every `/` operand is an int literal or
+//   a `| float`-coerced float64), so it does not affect byte parity — but it IS a
+//   genuine robustness gap if a future template ever divides a raw JSON-sourced
+//   number. We assert the CORRECT Python value and t.Skip the case rather than
+//   asserting the divergent 0.0.
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func asFloat(t *testing.T, v any) float64 {
+	t.Helper()
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("divValues result %#v is %T, want float64 (Python `/` always yields float)", v, v)
+	}
+	return f
+}
+
+func TestDivValues_TrueDivision(t *testing.T) {
+	cases := []struct {
+		desc string
+		a, b any
+		want float64
+	}{
+		// int/int — Python yields a FLOAT even when it divides evenly.
+		{"4/2 -> 2.0 (float, not int)", 4, 2, 2.0},
+		{"6/3 -> 2.0", 6, 3, 2.0},
+		{"7/2 -> 3.5", 7, 2, 3.5},
+		{"0/5 -> 0.0", 0, 5, 0.0},
+		{"-7/2 -> -3.5 (toward more-negative)", -7, 2, -3.5},
+		{"-6/3 -> -2.0", -6, 3, -2.0},
+		// int/float and float/int mixes.
+		{"5/2.0 -> 2.5", 5, 2.0, 2.5},
+		{"2.5/0.5 -> 5.0", 2.5, 0.5, 5.0},
+		{"7.0/2 -> 3.5", 7.0, 2, 3.5},
+		// repeating quotient.
+		{"1/3 -> 0.3333...", 1, 3, 1.0 / 3.0},
+		// template-shaped: ms (float) / literal int.
+		{"3600000.0/3600000 -> 1.0", 3600000.0, 3600000, 1.0},
+		{"90000.0/60000 -> 1.5", 90000.0, 60000, 1.5},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := asFloat(t, divValues(c.a, c.b))
+			if math.Abs(got-c.want) > 1e-12 {
+				t.Errorf("divValues(%v, %v) = %v, want %v", c.a, c.b, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDivValues_AlwaysFloatType pins the most important parity property: the
+// result type is float64 even for an evenly-dividing int/int, because Python 3
+// true-division never returns an int. (A regression to int here would corrupt
+// number formatting on every populated page — exactly the class of bug the
+// migration audit flagged for `/`.)
+func TestDivValues_AlwaysFloatType(t *testing.T) {
+	for _, p := range [][2]int{{4, 2}, {6, 3}, {10, 5}, {0, 7}, {-8, 4}} {
+		r := divValues(p[0], p[1])
+		if _, ok := r.(float64); !ok {
+			t.Errorf("divValues(%d, %d) returned %T, want float64 (Python `/` is true division)", p[0], p[1], r)
+		}
+	}
+}
+
+// TestDivValues_ZeroGuard documents the deliberate, parity-safe deviation from
+// Python: Python raises ZeroDivisionError on x/0, but no template ever divides by
+// zero (only by nonzero constants). The Go port guards it and returns 0.0 to
+// avoid a panic on this unreachable path. This is an intentional guard, NOT a
+// divergence that affects any rendered output.
+func TestDivValues_ZeroGuard(t *testing.T) {
+	for _, a := range []any{4, 4.0, 0, -3} {
+		got := divValues(a, 0)
+		if f, ok := got.(float64); !ok || f != 0.0 {
+			t.Errorf("divValues(%v, 0) = %#v, want 0.0 (unreachable zero-guard)", a, got)
+		}
+	}
+	// float zero denominator likewise guarded.
+	if got := divValues(5.0, 0.0); got != any(0.0) {
+		t.Errorf("divValues(5.0, 0.0) = %#v, want 0.0", got)
+	}
+}
+
+// TestDivValues_Divergence_NonGoNumberOperands — LOUD DIVERGENCE REPORT.
+//
+// numFloat (eval.go:585) recognizes only Go `int` and `float64`. json.Number and
+// numeric strings therefore hit divValues' "!aok || !bok" guard and return 0.0,
+// where Python true-division would compute the real quotient (json.Number("4")
+// behaves as int 4 in Python; "4"/"2" would be a TypeError in raw Python but
+// Jinja coerces via its numeric promotion — and in app.py these would already be
+// ints/floats by the time `/` runs). These cases are NOT reachable from any known
+// template (every `/` operand is an int literal or a `| float`-coerced float64),
+// so byte parity is unaffected. We assert the CORRECT Python result and SKIP so
+// the divergence is documented without falsely failing or hiding it.
+func TestDivValues_Divergence_NonGoNumberOperands(t *testing.T) {
+	cases := []struct {
+		desc string
+		a, b any
+		want float64 // the value Python true-division would produce
+	}{
+		{"json.Number/json.Number 4/2 -> 2.0", json.Number("4"), json.Number("2"), 2.0},
+		{"json.Number/int 7/2 -> 3.5", json.Number("7"), 2, 3.5},
+		{"int/json.Number 9/3 -> 3.0", 9, json.Number("3"), 3.0},
+		{"numeric strings \"6\"/\"3\" -> 2.0", "6", "3", 2.0},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := divValues(c.a, c.b)
+			gf, ok := got.(float64)
+			if ok && math.Abs(gf-c.want) <= 1e-12 {
+				// If the impl is ever extended to handle these, the test stops skipping.
+				return
+			}
+			t.Skipf("DIVERGENCE: divValues(%#v, %#v) = %#v, but Python true-division = %v "+
+				"(numFloat ignores json.Number/string; latent, unreachable from known templates)",
+				c.a, c.b, got, c.want)
+		})
+	}
+}


### PR DESCRIPTION
Continues the Go coverage grind (corpus ∪ unit lens) after byte-parity was exhausted. Targets the genuinely-untested pure functions on the combined-0% list — anchored to the frozen \`app.py\`/\`mcp.py\` oracle.

## Newly covered (10 funcs)
**Slice E** (AI/chart JSON): \`queryStageStats\` (ai_llm.go, oracle app.py:3481-3488), \`queryRunLLMStats\` (fix_query.go, app.py:3491-3504) — both 100%.
**Slice F** (helpers): \`strOrBrace\` (upstream.go), \`unwrapType\` (query_exec.go) — both 100%.
**Slice G** (encoding/data/misc): \`anySlice\`, \`jsonDumpsIndent2\` (app.py:10565/15747/15762), \`runHealthcheck\` (all 3 branches), \`parseGithubActionsSnapshotZip\` (app.py:16577-16624, 84.6% — rest is in-loop IO-error branches), \`utf16Pair\` (internal/jsonenc), \`divValues\` (internal/render, Py3 true-division) — 100% except as noted.

## Important context
My initial 0% target list (29 pure funcs) came from a **stale coverage profile**; ~18 were already covered by merged slices. Each agent re-verified against current go-main and **skipped already-covered funcs** (documented in each file header). Net: only ~10 funcs were genuinely untested — strong signal the pure-func well is nearly dry; the remaining 0% surface is the ~42 server methods (store-harness territory) + generated protobuf.

## Divergences found & classified (NOT fixed — byte-parity-safe, unreachable; tracked in test headers)
1. **\`mcpNormalizeMap\`** (mcp_tools.go:374 vs \`_normalize_map_value\` mcp.py:518-523): Python falls back to \`ast.literal_eval\` after JSON parse, so \`"{'a': 1}"\` → \`{"a":1}\` (Py) vs \`{}\` (Go). Corpus never exercised it.
2. **\`divValues\`/\`numFloat\`** (internal/render/eval.go): true-division core is correct (always float64); but \`numFloat\` only recognizes Go \`int\`/\`float64\`, so \`json.Number\`/numeric-string operands return \`0.0\` instead of the quotient. Unreachable — every template \`/\` operand is an int literal or \`| float\`-coerced. Asserted-correct + \`t.Skip\`'d.

Verified locally: gofmt clean, \`go vet\` clean, all new tests pass together.