### PR TITLE
scripts: local Go-server launcher + fix Python demo-app deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Local dev: Go SOBS build output + chdb data dir (scripts/start_ollama_ai_test_go.sh)
+.local/
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/scripts/start_ollama_ai_test.sh
+++ b/scripts/start_ollama_ai_test.sh
@@ -109,6 +109,7 @@ start_example_app() {
   ensure_example_otel_deps() {
     local -a required_modules
     required_modules=(
+      flask
       opentelemetry.distro
       opentelemetry.instrumentation.flask
       opentelemetry.instrumentation.logging
@@ -138,6 +139,7 @@ PY
 
     echo "[info] installing missing OTEL packages for demo app instrumentation"
     "$EXAMPLE_APP_PYTHON" -m pip install -q \
+      flask \
       opentelemetry-distro \
       opentelemetry-instrumentation \
       opentelemetry-instrumentation-flask \
@@ -217,9 +219,15 @@ PY
 }
 
 if ! curl -fsS "$OLLAMA_TAGS_URL" >/dev/null 2>&1; then
-  echo "[error] cannot reach Ollama at $OLLAMA_BASE_URL" >&2
-  echo "Start Ollama first (example: 'ollama serve') or set OLLAMA_BASE_URL." >&2
-  exit 1
+  if [[ "${SOBS_AI_OPTIONAL:-0}" == "1" ]]; then
+    echo "[warn] Ollama not reachable at $OLLAMA_BASE_URL — continuing without AI (SOBS_AI_OPTIONAL=1)." >&2
+    echo "[warn] AI routes will be unconfigured; data ingestion and the rest of SOBS still work." >&2
+  else
+    echo "[error] cannot reach Ollama at $OLLAMA_BASE_URL" >&2
+    echo "Start Ollama first (example: 'ollama serve') or set OLLAMA_BASE_URL." >&2
+    echo "Or set SOBS_AI_OPTIONAL=1 to run without a model server." >&2
+    exit 1
+  fi
 fi
 
 if [[ "$RUN_CMD_DEFAULT" == "1" ]] && curl -fsS http://127.0.0.1:44317/health >/dev/null 2>&1; then

--- a/scripts/start_ollama_ai_test_go.sh
+++ b/scripts/start_ollama_ai_test_go.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# start_ollama_ai_test_go.sh — Go variant of start_ollama_ai_test.sh.
+#
+# Builds the Go SOBS server and runs it (in place of `python app.py`) with the same local
+# workflow: a local Ollama for AI features + the RUM/OTEL demo app for triggering data.
+# The Go server uses the native libchdb embedded DB (NO Python/chdb needed) and
+# self-initializes its chdb schema on first run, so it sidesteps the Python-3.14/chdb-wheel
+# bind that breaks `python app.py` locally.
+#
+# Usage:
+#   ./scripts/start_ollama_ai_test_go.sh                      # build + run (Ollama optional)
+#   SOBS_GO_SKIP_BUILD=1 ./scripts/start_ollama_ai_test_go.sh # reuse the last build
+#   START_EXAMPLE_APP=0  ./scripts/start_ollama_ai_test_go.sh # server only, no demo app
+#   SOBS_AI_OPTIONAL=0   ./scripts/start_ollama_ai_test_go.sh # require Ollama (like the Python script)
+#
+# Go-specific env (everything else is passed through to start_ollama_ai_test.sh):
+#   CHDB_LIB_PATH   path to libchdb.so (auto-detected: /usr/local/lib, repo .libchdb, /usr/lib)
+#   SOBS_DATA_DIR   chdb data dir (default .local/sobs-go-data; schema self-inits on first run)
+#   SOBS_GO_BIN     output binary path (default .local/sobs-go)
+#   SOBS_PORT       server port (default 44317 — matches the demo app endpoints + health check)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO"
+
+# --- libchdb: the embedded ClickHouse the Go server dlopens at runtime ---
+if [[ -z "${CHDB_LIB_PATH:-}" ]]; then
+  for cand in /usr/local/lib/libchdb.so "$REPO/.libchdb/libchdb.so" /usr/lib/libchdb.so; do
+    [[ -f "$cand" ]] && { CHDB_LIB_PATH="$cand"; break; }
+  done
+fi
+if [[ -z "${CHDB_LIB_PATH:-}" || ! -f "${CHDB_LIB_PATH:-}" ]]; then
+  echo "[error] libchdb.so not found. Set CHDB_LIB_PATH=/path/to/libchdb.so" >&2
+  echo "        (the repo ships a Linux libchdb under .libchdb/ for Docker; on macOS install the" >&2
+  echo "         native libchdb to /usr/local/lib/libchdb.so — see migration/go-migration-macos-env)" >&2
+  exit 1
+fi
+export CHDB_LIB_PATH
+echo "[info] CHDB_LIB_PATH=$CHDB_LIB_PATH"
+
+# --- local chdb data dir (Go applies the 43-statement schema on first run) ---
+export SOBS_DATA_DIR="${SOBS_DATA_DIR:-$REPO/.local/sobs-go-data}"
+mkdir -p "$SOBS_DATA_DIR"
+echo "[info] SOBS_DATA_DIR=$SOBS_DATA_DIR"
+
+# --- build the Go binary ---
+GO_BIN="${SOBS_GO_BIN:-$REPO/.local/sobs-go}"
+mkdir -p "$(dirname "$GO_BIN")"
+if [[ "${SOBS_GO_SKIP_BUILD:-0}" == "1" && -x "$GO_BIN" ]]; then
+  echo "[info] reusing existing Go binary: $GO_BIN (SOBS_GO_SKIP_BUILD=1)"
+else
+  echo "[info] building Go SOBS server -> $GO_BIN (CGO_ENABLED=1)"
+  ( cd go && CGO_ENABLED=1 go build -trimpath -o "$GO_BIN" ./cmd/sobs )
+fi
+
+# --- hand off to the shared launcher (Ollama check + AI env + RUM/OTEL demo app), running the
+#     Go binary instead of `python app.py`. Ollama is OPTIONAL by default here so you can start the
+#     server and trigger data without a model server (AI routes degrade; everything else works). ---
+export SOBS_AI_OPTIONAL="${SOBS_AI_OPTIONAL:-1}"
+echo "[info] handing off to start_ollama_ai_test.sh (Go binary; SOBS_AI_OPTIONAL=$SOBS_AI_OPTIONAL)"
+exec "$SCRIPT_DIR/start_ollama_ai_test.sh" -- "$GO_BIN"


### PR DESCRIPTION
Adds `scripts/start_ollama_ai_test_go.sh` — the Go equivalent of `start_ollama_ai_test.sh`: builds the Go SOBS binary and runs it (in place of `python app.py`), auto-detecting libchdb + a local data dir (Go self-inits its chdb schema). Defaults to port 44317 and makes Ollama optional so you can start the server + trigger data without a model server.

**Why:** app.py was frozen by the migration to require Python 3.14; a pre-3.14 venv breaks the Python flow. The Go server has no Python/chdb dependency. (Python app.py still works under a proper 3.14 venv — validated.)

Also: `SOBS_AI_OPTIONAL=1` (Ollama check → warning), and **flask added to the demo-app auto-install** (it was missing, which broke the RUM/OTEL data-trigger). Validated: Go binary serves /health on 44317 + accepts POST /v1/traces.