### PR TITLE
migration: dmcov profile — cover DM store-reader methods

### DIFF
--- a/migration/manifest/routes.yaml
+++ b/migration/manifest/routes.yaml
@@ -7308,6 +7308,24 @@ routes:
   - <td class="fw-semibold">[0-9][0-9.]* [A-Z]*B</td>
   - "[0-9]+\\.[0-9]+\xD7|[0-9]+\xD7"
   - <span class="text-(?:warning|success)">\s*[0-9]+
+# dmcov profile: non-sensitive DM settings seeded (backup_enabled=1, s3_bucket, s3_region,
+# s3_access_key_id, s3_path_prefix, ttl_logs_days, ttl_traces_days). The GET renders the form
+# with populated field values, exercising the if-raw-non-empty branch in handleDataManagementGet
+# and the template's backup/TTL value-display paths (backup_enabled checked, s3_bucket/region/
+# prefix/access_key_id shown, TTL day inputs populated). dm_secret_present stays {false,false}
+# since neither sensitive key is seeded. db-stats card masked (non-deterministic system.parts).
+- id: get__settings_data_management__dmcov
+  path: /settings/data-management
+  methods:
+  - GET
+  profile: dmcov
+  mask:
+  - <table class="table table-sm table-hover mb-0 dm-stats-table">[\s\S]*?</table>
+  - Total rows \(active parts\)</td>\s*<td class="fw-semibold">\s*[0-9,]+
+  - <td class="fw-semibold">[0-9][0-9.]* [A-Z]*B</td>
+  - "[0-9]+\\.[0-9]+\xD7|[0-9]+\xD7"
+  - <span class="text-(?:warning|success)">\s*[0-9]+
+  mask_reason: "db-stats table (system.parts active-part merge timing) is non-deterministic; all DM settings form values are byte-compared."
 # dmttl profile: data-management save with apply_ttl=1 (app.py save_dm_settings -> _apply_dm_ttl).
 # Parity-invisible on the base empty POST, so a dedicated profile exercises the TTL branch. The
 # OTel tables exist in the base fixture, so the day-based ALTER … MODIFY TTL runs for real; the

--- a/migration/tools/profiles.py
+++ b/migration/tools/profiles.py
@@ -438,6 +438,14 @@ PROFILES: dict[str, dict[str, str]] = {
     # dmbackup: data_management.backup_enabled=1 so backup/run + restore reach their enabled branch
     # (no S3 configured -> deterministic "S3 bucket is not configured" / "backup_name is required").
     "dmbackup": {},
+    # dmcov: non-sensitive DM settings seeded (s3_bucket, s3_region, s3_access_key_id,
+    # s3_path_prefix, backup_enabled, ttl_logs_days, ttl_traces_days) so GET
+    # /settings/data-management renders with populated form fields. Exercises the
+    # handleDataManagementGet if-raw-non-empty branch and the template's backup/TTL-related
+    # value-display paths. Sensitive keys (s3_secret_access_key, backup_encryption_password)
+    # are not seeded → dm_secret_present stays {false,false} (no SOBS_SETTINGS_ENCRYPTION_KEY
+    # needed). No env overlay — pure isolated seed.
+    "dmcov": {},
     # dmsecret: SOBS_SETTINGS_ENCRYPTION_KEY set so the data-management secret-save path runs its
     # at-rest-encryption branch. Its POST stores s3_secret_access_key + backup_encryption_password
     # (Fernet-encrypted at rest), then a follow-up GET renders dm_secret_present=true with the
@@ -1404,6 +1412,7 @@ SEEDED_PROFILES = {
     "notifagentmiss",
     "anomalycheck",
     "dmbackup",
+    "dmcov",
     "k8s",
     "k8srich",
     "k8sprom",

--- a/migration/tools/seed_fixtures.py
+++ b/migration/tools/seed_fixtures.py
@@ -813,6 +813,28 @@ def seed_dm_backup(db) -> None:
     db.execute("OPTIMIZE TABLE sobs_app_settings FINAL")
 
 
+def seed_dm_cov(db) -> None:
+    # dmcov: seed non-sensitive DM settings so GET /settings/data-management renders with
+    # populated form values (s3_bucket, s3_region, s3_access_key_id, s3_path_prefix,
+    # backup_enabled, ttl_logs_days, ttl_traces_days). This exercises the
+    # handleDataManagementGet populated-data branch (the if raw != "" and not sensitive branch).
+    # Sensitive keys (s3_secret_access_key, backup_encryption_password) are intentionally NOT
+    # seeded here (dm_secret_present stays false for both), keeping the test deterministic and
+    # not requiring SOBS_SETTINGS_ENCRYPTION_KEY (that is covered by dmsecret).
+    # All values are fixed/constant — no now()-derived non-determinism.
+    rows = [
+        {"Key": "data_management.backup_enabled", "Value": "1", "UpdatedAt": _TS},
+        {"Key": "data_management.s3_bucket", "Value": "my-parity-bucket", "UpdatedAt": _TS},
+        {"Key": "data_management.s3_region", "Value": "us-east-1", "UpdatedAt": _TS},
+        {"Key": "data_management.s3_access_key_id", "Value": "AKIAPARITYTEST0001", "UpdatedAt": _TS},
+        {"Key": "data_management.s3_path_prefix", "Value": "sobs-backups", "UpdatedAt": _TS},
+        {"Key": "data_management.ttl_logs_days", "Value": "30", "UpdatedAt": _TS},
+        {"Key": "data_management.ttl_traces_days", "Value": "7", "UpdatedAt": _TS},
+    ]
+    _insert(db, "sobs_app_settings", rows)
+    db.execute("OPTIMIZE TABLE sobs_app_settings FINAL")
+
+
 def seed_repo_app(db) -> None:
     # One registered app + a release + a github token, so the /settings/repositories/<id>/...
     # actions (realtime/rotate/revoke/save/releases/delete) and github-token/validate run their
@@ -5570,6 +5592,7 @@ PROFILE_SEEDS = {
     "anomalycheck": seed_anomalycheck,  # anomaly-prod log spike -> outlier event -> rate-limited agent_runs entry
     "notifeval": seed_notifeval,  # rules w/ REAL conditions+matching tags -> eval fire/no-fire/cooldown/disabled arms
     "dmbackup": seed_dm_backup,
+    "dmcov": seed_dm_cov,  # non-sensitive DM settings -> GET /settings/data-management populated form
     "k8s": seed_k8s,  # backup_enabled=1; backup/run + restore reach their enabled branch
     "k8srich": seed_k8srich,  # OTEL-native k8s.* gauge rows -> _fetch_k8s_from_otel otel-branch populated
     "k8sprom": seed_k8sprom,  # prometheus (kube_*) gauge+sum rows -> _fetch_k8s_from_otel prometheus-branch


### PR DESCRIPTION
Adds a `dmcov` byte-parity profile seeding non-sensitive DM settings (s3 config, backup_enabled, ttl_*) so GET /settings/data-management renders populated, exercising the corpus-0% `appSettingOr`/`dmSettingValue`/`buildS3BackupDest` readers. Recovered from an interrupted migration-coder; CI Docker parity is the verification.