### PR TITLE
chore(go): delete 4 dead functions (confirmed cruft, no port gaps)

### DIFF
--- a/go/cmd/sobs/ai_llm.go
+++ b/go/cmd/sobs/ai_llm.go
@@ -260,19 +260,6 @@ func (s *server) callLLMChat(req llmRequest) (string, llmStats, error) {
 	return content, st, nil
 }
 
-// callLLMEndpoint is the no-messages wrapper kept for call sites whose prompt construction is not
-// yet ported: it builds a default request from the main ai.* settings (empty messages). Parity is
-// unaffected (the mock ignores the body); at runtime these sites send an under-specified request
-// until their messages are threaded through callLLMChat.
-func (s *server) callLLMEndpoint(endpoint string) (string, llmStats, error) {
-	return s.callLLMChat(llmRequest{
-		endpoint:      endpoint,
-		model:         strings.TrimSpace(s.loadAISetting("ai.model", "")),
-		apiKey:        strings.TrimSpace(s.loadAISetting("ai.api_key", "")),
-		thinkingLevel: strings.TrimSpace(s.loadAISetting("ai.thinking_level", "off")),
-	})
-}
-
 // jnInt reads an int from a parsed-JSON object (json.Number-aware).
 func jnInt(o *jsonenc.Object, key string) int {
 	v, _ := o.Get(key)
@@ -452,45 +439,4 @@ func parseChartSpecJSON(raw string) (*jsonenc.Object, string) {
 		return nil, "top-level chart spec must be a JSON object"
 	}
 	return obj, ""
-}
-
-// vannaRefineChartSpec mirrors app.py _vanna_refine_chart_spec: validate the current spec, build
-// the refinement system+user messages (spec + a data sample of up to 20 rows + the user
-// instruction), ask the LLM, and return the re-serialized refined spec.
-func (s *server) vannaRefineChartSpec(endpoint, model, currentSpec, instruction string, columns, sampleRows []any) (string, string) {
-	if endpoint == "" || model == "" {
-		return "", "AI endpoint not configured."
-	}
-	if _, err := parseJSONValue([]byte(currentSpec)); err != nil {
-		return "", "Current chart spec is invalid JSON: " + err.Error()
-	}
-	rows := sampleRows
-	if len(rows) > 20 {
-		rows = rows[:20]
-	}
-	sampleOpts := jsonenc.Options{SortKeys: false, EnsureASCII: false, ItemSep: ",", KeySep: ":"}
-	sampleStr := string(jsonenc.Encode(jsonenc.NewObject().Set("columns", columns).Set("rows", rows), sampleOpts))
-	userMsg := "Current ECharts spec structure:\n" + currentSpec +
-		"\n\nData available (columns + up to 20 sample rows):\n" + sampleStr +
-		"\n\nUser instruction: " + instruction +
-		"\n\nPlease refine the chart spec to fulfill this request. Return only the updated JSON."
-	messages := []any{
-		jsonenc.NewObject().Set("role", "system").Set("content", s.buildChartRefinementPrompt()),
-		jsonenc.NewObject().Set("role", "user").Set("content", userMsg),
-	}
-	content, _, err := s.callLLMChat(llmRequest{
-		endpoint:      endpoint,
-		model:         model,
-		apiKey:        strings.TrimSpace(s.loadAISetting("ai.api_key", "")),
-		thinkingLevel: strings.TrimSpace(s.loadAISetting("ai.thinking_level", "off")),
-		messages:      messages,
-	})
-	if err != nil || content == "" {
-		return "", "LLM did not return a refined chart spec."
-	}
-	parsed, perr := parseChartSpecJSON(content)
-	if parsed != nil {
-		return string(jsonenc.Encode(parsed, dumpsDefault)), ""
-	}
-	return "", "Refined chart spec JSON parse error: " + perr
 }

--- a/go/cmd/sobs/fix_mutations1.go
+++ b/go/cmd/sobs/fix_mutations1.go
@@ -123,10 +123,11 @@ func toJSONObject(m map[string]any) *jsonenc.Object {
 	return o
 }
 
-// vannaRefineChartSpecTL is the thinking-level-aware variant of vannaRefineChartSpec (ai_llm.go):
-// identical behavior, but the caller-supplied thinkingLevel (from the request body) is threaded
-// into the LLM call instead of the stored ai.thinking_level setting — mirroring app.py
-// _vanna_refine_chart_spec(..., thinking_level=thinking_level). On the parity path the AI endpoint
+// vannaRefineChartSpecTL mirrors app.py _vanna_refine_chart_spec(..., thinking_level=thinking_level):
+// validate the current spec, build the refinement system+user messages (spec + a data sample of up
+// to 20 rows + the user instruction), ask the LLM, and return the re-serialized refined spec. The
+// caller-supplied thinkingLevel (from the request body) is threaded into the LLM call instead of the
+// stored ai.thinking_level setting. On the parity path the AI endpoint
 // is the URL-keyed mock which ignores the body, so the canned response is unchanged.
 func (s *server) vannaRefineChartSpecTL(endpoint, model, currentSpec, instruction string, columns, sampleRows []any, thinkingLevel string) (string, string) {
 	if endpoint == "" || model == "" {

--- a/go/cmd/sobs/handlers_mutations2.go
+++ b/go/cmd/sobs/handlers_mutations2.go
@@ -488,16 +488,6 @@ func (s *server) githubBackfillMaxReleases() int {
 	return n
 }
 
-// cveInventoryCount counts library-inventory rows across the three _collect_library_inventory
-// tiers (release lockfiles, telemetry.sdk.* attrs, scope name+version). 0 on the fixture.
-func (s *server) cveInventoryCount() int {
-	return s.countRows("SELECT count() FROM sobs_release_artifacts FINAL WHERE ArtifactType='dependencies-lockfile' AND IsDeleted=0") +
-		s.countRows("SELECT count() FROM otel_traces WHERE ResourceAttributes['telemetry.sdk.version'] != ''") +
-		s.countRows("SELECT count() FROM otel_logs WHERE ResourceAttributes['telemetry.sdk.version'] != ''") +
-		s.countRows("SELECT count() FROM otel_traces WHERE ScopeName != '' AND ScopeVersion != ''") +
-		s.countRows("SELECT count() FROM otel_logs WHERE ScopeName != '' AND ScopeVersion != ''")
-}
-
 // POST /api/enrichment/cve/scan — app.py _run_cve_scan. CVE enrichment is enabled by default;
 // with no ai.github_token the GitHub backfill is a no-op (0/0/cap) and persists its bookkeeping
 // settings, and an empty library inventory short-circuits to the zero summary. Manifest-last.

--- a/go/cmd/sobs/handlers_pages_errors_items.go
+++ b/go/cmd/sobs/handlers_pages_errors_items.go
@@ -1,11 +1,5 @@
 package main
 
-import (
-	"strings"
-
-	"github.com/sobs/sobs/internal/jsonenc"
-)
-
 // ---------------------------------------------------------------------------
 // Error-item helpers unique to the errors view. The shared error-item family
 // (_build_error_item / _extract_structured_error_summary / _try_pretty_json_text /
@@ -73,55 +67,4 @@ func (s *server) getResolvedErrorIDs() map[string]bool {
 		out[cStr(m, "ErrorId")] = true
 	}
 	return out
-}
-
-// loadWorkItemLinksForRefIDsObject mirrors _load_work_item_links_for_ref_ids(db, ref_ids) but
-// returns an ordered *jsonenc.Object. The map[string]any form used by the page handlers lives in
-// handlers_incident.go as loadWorkItemLinksForRefIDs; this ordered variant is retained for any
-// caller that needs deterministic key order. (Currently unreferenced — kept for parity fidelity.)
-func (s *server) loadWorkItemLinksForRefIDsObject(refIDs []string) *jsonenc.Object {
-	result := jsonenc.NewObject()
-	refSet := map[string]bool{}
-	var uniqueRefs []string
-	for _, r := range refIDs {
-		if r != "" && !refSet[r] {
-			refSet[r] = true
-			uniqueRefs = append(uniqueRefs, r)
-		}
-	}
-	if len(uniqueRefs) == 0 {
-		return result
-	}
-	placeholders := make([]string, len(uniqueRefs))
-	params := make([]any, len(uniqueRefs))
-	for i, r := range uniqueRefs {
-		placeholders[i] = "?"
-		params[i] = r
-	}
-	query := "SELECT AnomalyRuleId, IssueUrl, CanonicalIssueUrl, IssueNumber, IssueState " +
-		"FROM sobs_github_work_items FINAL " +
-		"WHERE IsDeleted=0 AND IssueUrl != '' AND AnomalyRuleId IN (" + strings.Join(placeholders, ", ") + ") " +
-		"ORDER BY CreatedAt DESC"
-	res, err := s.db.Execute(query, params...)
-	if err != nil {
-		return result
-	}
-	for _, m := range rowMaps(res) {
-		ref := cStr(m, "AnomalyRuleId")
-		if !refSet[ref] {
-			continue
-		}
-		if _, present := result.Get(ref); present {
-			continue
-		}
-		issueURL := cStr(m, "IssueUrl")
-		if issueURL == "" {
-			issueURL = cStr(m, "CanonicalIssueUrl")
-		}
-		result.Set(ref, jsonenc.NewObject().
-			Set("issue_url", issueURL).
-			Set("issue_number", cInt(m, "IssueNumber")).
-			Set("issue_state", cStr(m, "IssueState")))
-	}
-	return result
 }


### PR DESCRIPTION
Removes four uncalled functions in the Go port. Each was investigated against the frozen `app.py` oracle and confirmed a dead duplicate, **not** a hidden functional gap.

| Func | File | Verdict |
|---|---|---|
| `callLLMEndpoint` | `ai_llm.go` | stale no-messages wrapper; sites now use `callLLMChat`/`aiHelperGuardCheck` with proper messages |
| `vannaRefineChartSpec` | `ai_llm.go` | superseded by `vannaRefineChartSpecTL` (every caller uses the TL variant) |
| `loadWorkItemLinksForRefIDsObject` | `handlers_pages_errors_items.go` | superseded by `loadWorkItemLinksForRefIDs` (handlers_incident.go, used by 3 routes) |
| `cveInventoryCount` | `handlers_mutations2.go` | no app.py equivalent; `runCveScan` uses `collectLibraryInventory` |

Shared helpers (`callLLMChat`, `buildChartRefinementPrompt`, `parseChartSpecJSON`, `countRows`) are retained — all still used elsewhere. Removing `loadWorkItemLinksForRefIDsObject` orphaned that file's only imports, so they're dropped too. The `vannaRefineChartSpecTL` doc-comment was reworded to not reference the deleted func.

**Pure dead-code removal** — these were never called, so byte-parity is unaffected. Local: `go build`/`vet`/`test` clean, `gofmt` clean. −125 lines.

Context: makes the corpus-0%-coverage list honest (removes intentionally-retained-but-dead scaffolding that was inflating the uncovered count).