### PR TITLE
test(go): store.DB fake + cover DB-dependent registry lookups

### DIFF
--- a/go/cmd/sobs/app_registry_lookup_test.go
+++ b/go/cmd/sobs/app_registry_lookup_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/store"
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+// These exercise the app-registry seed dedup guards through the store.DB seam with an injected
+// fake — the seed path itself is disabled under parity, so the byte-parity corpus never reaches
+// them. Oracle: app.py _lookup_app_id_by_slug / _lookup_release_id return the row's Id when a
+// non-deleted match exists, else "".
+
+func TestLookupAppIDBySlug(t *testing.T) {
+	// Found: a non-deleted app with the slug → its Id.
+	s := &server{db: &storetest.FakeDB{ExecuteFunc: func(q string, p ...any) (*store.Result, error) {
+		if !strings.Contains(q, "sobs_apps") || !strings.Contains(q, "Slug=?") {
+			t.Fatalf("unexpected query: %s", q)
+		}
+		if len(p) != 1 || p[0] != "web" {
+			t.Fatalf("unexpected params: %v", p)
+		}
+		return storetest.Result([]string{"Id"}, []any{"app-123"}), nil
+	}}}
+	if got := s.lookupAppIDBySlug("web"); got != "app-123" {
+		t.Fatalf("lookupAppIDBySlug found: got %q, want app-123", got)
+	}
+
+	// Not found: empty result → "".
+	sEmpty := &server{db: &storetest.FakeDB{}}
+	if got := sEmpty.lookupAppIDBySlug("nope"); got != "" {
+		t.Fatalf("lookupAppIDBySlug not-found: got %q, want empty", got)
+	}
+}
+
+func TestLookupReleaseID(t *testing.T) {
+	// Found: match on all four keys → the release Id.
+	s := &server{db: &storetest.FakeDB{ExecuteFunc: func(q string, p ...any) (*store.Result, error) {
+		if !strings.Contains(q, "sobs_app_releases") {
+			t.Fatalf("unexpected query: %s", q)
+		}
+		want := []any{"app-1", "1.2.3", "abc123", "prod"}
+		if len(p) != len(want) {
+			t.Fatalf("param count: got %d, want %d", len(p), len(want))
+		}
+		for i := range want {
+			if p[i] != want[i] {
+				t.Fatalf("param %d: got %v, want %v", i, p[i], want[i])
+			}
+		}
+		return storetest.Result([]string{"Id"}, []any{"rel-9"}), nil
+	}}}
+	if got := s.lookupReleaseID("app-1", "1.2.3", "abc123", "prod"); got != "rel-9" {
+		t.Fatalf("lookupReleaseID found: got %q, want rel-9", got)
+	}
+
+	// Not found: empty result → "".
+	sEmpty := &server{db: &storetest.FakeDB{}}
+	if got := sEmpty.lookupReleaseID("x", "y", "z", "prod"); got != "" {
+		t.Fatalf("lookupReleaseID not-found: got %q, want empty", got)
+	}
+}

--- a/go/internal/store/storetest/fake.go
+++ b/go/internal/store/storetest/fake.go
@@ -1,0 +1,66 @@
+// Package storetest provides an in-memory store.DB double for unit tests. It is only ever
+// imported by test code, so it is not linked into the production binary — yet it lets any
+// server method or helper that depends on s.db be exercised directly, without the embedded
+// engine. This is the same seam the store.DB interface was designed for (see store.go).
+package storetest
+
+import "github.com/sobs/sobs/internal/store"
+
+// FakeDB is a configurable store.DB double. Set ExecuteFunc to answer queries; InsertJSONEachRow
+// calls are recorded in Inserts in call order. The zero value is usable: Execute returns an empty
+// result and inserts are accepted.
+type FakeDB struct {
+	// ExecuteFunc answers Execute. When nil, Execute returns an empty *store.Result (no rows).
+	ExecuteFunc func(query string, params ...any) (*store.Result, error)
+	// Inserts records every InsertJSONEachRow call, in order.
+	Inserts []Insert
+	// Closed is set true by Close.
+	Closed bool
+}
+
+// Insert is one recorded InsertJSONEachRow call.
+type Insert struct {
+	Table string
+	Rows  []map[string]any
+}
+
+// Execute implements store.DB.
+func (f *FakeDB) Execute(query string, params ...any) (*store.Result, error) {
+	if f.ExecuteFunc != nil {
+		return f.ExecuteFunc(query, params...)
+	}
+	return &store.Result{}, nil
+}
+
+// InsertJSONEachRow implements store.DB, recording the call and reporting all rows written.
+func (f *FakeDB) InsertJSONEachRow(table string, rows []map[string]any) (int, error) {
+	f.Inserts = append(f.Inserts, Insert{Table: table, Rows: rows})
+	return len(rows), nil
+}
+
+// Close implements store.DB.
+func (f *FakeDB) Close() error { f.Closed = true; return nil }
+
+// Result builds a *store.Result from column names and rows (each row parallel to cols).
+func Result(cols []string, rows ...[]any) *store.Result {
+	return &store.Result{Columns: cols, Rows: rows}
+}
+
+// SettingsDB returns a FakeDB whose Execute answers the app-settings read path
+// (`SELECT Value FROM sobs_app_settings ... WHERE Key = ?`) from the given map: params[0] is the
+// key, and the single-cell "Value" result is returned (empty result for unknown keys). Any other
+// query falls through to ExecuteFunc if set, else an empty result. This covers the many helpers
+// that read configuration via appSetting/appSettingRaw.
+func SettingsDB(settings map[string]string) *FakeDB {
+	return &FakeDB{ExecuteFunc: func(query string, params ...any) (*store.Result, error) {
+		if len(params) == 1 {
+			if key, ok := params[0].(string); ok {
+				if v, present := settings[key]; present {
+					return Result([]string{"Value"}, []any{v}), nil
+				}
+				return &store.Result{}, nil
+			}
+		}
+		return &store.Result{}, nil
+	}}
+}


### PR DESCRIPTION
First slice of the store-seam testability work.

Adds `internal/store/storetest.FakeDB` — an in-memory `store.DB` double (the swap seam `store.DB` was designed for, per its own doc-comment). It's only imported by test code, so it is **not linked into the production binary**, yet it lets any `*server` method or helper that depends on `s.db` be exercised directly — no embedded engine, no libchdb, sub-second.

Proves the seam by covering two funcs the byte-parity corpus can't reach (the app-registry seed path is disabled under parity): `lookupAppIDBySlug` / `lookupReleaseID`, oracle-anchored to app.py `_lookup_app_id_by_slug` / `_lookup_release_id`.

Also adds `storetest.SettingsDB` — a fake preconfigured to answer the app-settings read path (`SELECT Value FROM sobs_app_settings WHERE Key=?`), which the next slice uses for the config-reading helpers (DM/S3 backup dest builder, etc.).

**Additive / test-only** — no production code changed, byte-parity unaffected. `go test ./...` green, `gofmt` clean. This is the reusable harness that lets the remaining DB-dependent 0%-coverage helpers become fast unit tests.