### PR TITLE
feat(go): injectable openStore seam for store.DB construction

### DIFF
--- a/go/cmd/sobs/providers.go
+++ b/go/cmd/sobs/providers.go
@@ -1,0 +1,19 @@
+package main
+
+import "github.com/sobs/sobs/internal/store"
+
+// Provider seams
+// --------------
+// These package-level function values are the single points at which the server's swappable
+// backends are constructed. They default to the embedded, self-contained implementations; an
+// alternate build can reassign them (e.g. in an init()) to inject a different store.DB without
+// modifying newServer or any handler. Keeping this as a var — not a direct call — is what makes
+// the store.DB interface (see internal/store/store.go) genuinely swappable, and it is the same
+// seam the storetest fake uses in unit tests.
+
+// openStore opens the process's store. The default opens the embedded chdb session at
+// cfg.DataDir (mirroring app.py's ChDbConnection). newServer calls this through its open-retry
+// loop, so any implementation may return a transient error to request a retry.
+var openStore = func(cfg config) (store.DB, error) {
+	return store.Open(cfg.DataDir)
+}

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -39,7 +39,7 @@ func newServer(cfg config) *server {
 	// fresh process, which clears the global chdb state.
 	var lastErr error
 	for attempt := 0; attempt < 5; attempt++ {
-		db, err := store.Open(cfg.DataDir)
+		db, err := openStore(cfg)
 		if err == nil {
 			s.db = db
 			break


### PR DESCRIPTION
Factors the server's store construction behind a package-level `openStore` function value. `newServer` calls `openStore(cfg)` (through its existing open-retry loop) instead of `store.Open(cfg.DataDir)` directly.

**Behavior-neutral:** the default `openStore` opens exactly the same embedded chdb session at `cfg.DataDir`, so runtime behavior and byte-parity are unchanged.

This is the single, generic seam at which the `store.DB` implementation is selected — keeping it a `var` (not a direct call) is what makes the interface genuinely swappable without touching `newServer` or any handler, and it composes with the `storetest` fake already used in unit tests.

Local: `go build`/`vet`/`test` green, `gofmt` clean. Relying on the CI parity gate to confirm the byte-diff is unchanged.