### PR TITLE
test: de-flake onboarding-wizard integration test (retry dismiss)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1700,8 +1700,19 @@ class TestUIQA:
 
         close_btn = page.locator("#onboardingWizardModal .btn-close").first
         if close_btn.count() > 0:
-            close_btn.click(timeout=5000)
-            page.wait_for_selector("#onboardingWizardModal.show", state="hidden", timeout=5000)
+            # Bootstrap ignores a hide() issued while the modal is still running its fade-in
+            # transition, so a single close click that lands mid-animation is silently swallowed
+            # and the wizard stays open — an intermittent CI flake. Retry the dismiss until the
+            # modal is actually hidden rather than assuming one click takes effect.
+            for _ in range(3):
+                close_btn.click(timeout=5000)
+                try:
+                    page.wait_for_selector("#onboardingWizardModal.show", state="hidden", timeout=5000)
+                    break
+                except PlaywrightError:
+                    continue
+            else:
+                page.wait_for_selector("#onboardingWizardModal.show", state="hidden", timeout=10000)
 
         assert not dialog_alerts, f"Native browser dialogs on /settings/repositories: {dialog_alerts}"
 


### PR DESCRIPTION
`test_settings_repositories_onboarding_wizard_opens` intermittently fails waiting for the wizard modal to hide after clicking close — it has reddened go-main **push** runs (e.g. `65bbd69`, `64e430c`) and just flaked PR #414's run.

**Root cause:** Bootstrap ignores a `hide()` issued while the modal is still running its fade-in transition, so a close click that lands mid-animation is silently swallowed and the modal stays visible ("14 × locator resolved to visible").

**Fix:** retry the dismiss up to 3×, breaking as soon as the modal is hidden, with a final generous wait so a genuinely stuck modal still fails the test. The wizard-*opens* assertions (the test's actual purpose) are unchanged — only the teardown dismiss is hardened.

Test-only change to a non-frozen file. AST valid, all lines ≤120 (black/flake8 line-length 120).