### PR TITLE
feat(go): injectable authGate seam for request authentication

### DIFF
--- a/go/cmd/sobs/providers.go
+++ b/go/cmd/sobs/providers.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/sobs/sobs/internal/store"
+import (
+	"net/http"
+
+	"github.com/sobs/sobs/internal/store"
+)
 
 // Provider seams
 // --------------
@@ -16,4 +20,13 @@ import "github.com/sobs/sobs/internal/store"
 // loop, so any implementation may return a transient error to request a retry.
 var openStore = func(cfg config) (store.DB, error) {
 	return store.Open(cfg.DataDir)
+}
+
+// authGate runs the request auth gate before the router. It returns true when it has fully written
+// a blocking response (401/403/500), in which case ServeHTTP short-circuits; otherwise the request
+// proceeds. The default applies the built-in api-key / basic / external-URL enforcement
+// (s.enforceAuth). An alternate build can reassign it to a provider that authenticates differently
+// (e.g. validating a bearer token) and attaches identity/roles to the request context.
+var authGate = func(s *server, w http.ResponseWriter, r *http.Request) bool {
+	return s.enforceAuth(w, r)
 }

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -90,8 +90,9 @@ func (s *server) enqueueWrite(op func() error) error {
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rec := &headerCapture{ResponseWriter: w, req: r, cfg: s.cfg}
 	// Optional auth layers (no-ops unless SOBS_API_KEY / SOBS_BASIC_AUTH_* / SOBS_EXTERNAL_AUTH_URL
-	// are set), written through rec so blocking responses still carry the security headers.
-	if s.enforceAuth(rec, r) {
+	// are set), written through rec so blocking responses still carry the security headers. Routed
+	// through the authGate seam so an alternate build can substitute a different authenticator.
+	if authGate(s, rec, r) {
 		return
 	}
 	s.mux.ServeHTTP(rec, r)


### PR DESCRIPTION
Routes the pre-router auth gate through a package-level `authGate` function value instead of calling `s.enforceAuth` directly in `ServeHTTP`.

**Behavior-neutral:** the default `authGate` runs exactly the built-in api-key / basic / external-URL enforcement, so runtime behavior and byte-parity are unchanged.

This is the auth counterpart to the `openStore` seam (#413) — the generic point at which the request authenticator is chosen. Keeping it a `var` lets an alternate build substitute a different authenticator (e.g. one that validates a bearer token and attaches identity/roles to the request context) without touching `ServeHTTP` or the built-in auth logic. No provider-specific naming in the public repo.

With this, the storage + auth seam pair is complete. Local: `go build`/`vet`/`test` green, `gofmt` clean; relying on the CI parity gate to confirm the byte-diff.