### PR TITLE
ci: dockerize the Python Tests + Integration jobs (bake deps in layers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,8 +317,11 @@ jobs:
       - name: Run unit tests with coverage + diff-cover gate
         # Runs inside the deps image (chdb baked in) against the bind-mounted workspace, so
         # coverage.xml and .git stay on the shared runner/dind volume for the gate + artifact.
+        # SOBS_CHDB_MAX_SERVER_MB=0 disables chdb's cgroup-aware memory cap, which otherwise trips
+        # inside the nested dind container and makes memory-limited queries misbehave (the same
+        # flag the parity build and the integration job set).
         run: |
-          docker run --rm -v "$PWD:/app" -w /app sobs-ci-python:local bash -c '
+          docker run --rm -e SOBS_CHDB_MAX_SERVER_MB=0 -v "$PWD:/app" -w /app sobs-ci-python:local bash -c '
             set -euo pipefail
             git config --global --add safe.directory /app
             echo "SOBS/chDB env snapshot"; env | sort | grep -E "^(SOBS_|CHDB_)" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,40 +295,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Docker Buildx (in-cluster registry mirror + buildcache)
+        uses: docker/setup-buildx-action@v4
         with:
-          python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-integration.txt
-            pyproject.toml
-            .github/workflows/ci.yml
-            .github/cache-key-runtime.txt
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["registry-mirror.ci-cache.svc.cluster.local:5000"]
+            [registry."registry-mirror.ci-cache.svc.cluster.local:5000"]
+              http = true
+            [registry."registry-cache.ci-cache.svc.cluster.local:5000"]
+              http = true
 
-      - name: Install dependencies
-        # Retry: the ~157 MB chdb_core wheel download intermittently drops mid-stream (urllib3
-        # IncompleteRead), which pip does not resume; a fresh attempt usually completes and then
-        # caches. Retry up to 3x, then a final attempt whose exit code determines the step result.
+      - name: Build the Python CI deps image (chdb + browsers baked into cached layers)
         run: |
-          for attempt in 1 2 3; do
-            pip install -r requirements.txt -r requirements-integration.txt && break
-            echo "::warning::pip install failed (attempt ${attempt}/3); retrying in 5s" && sleep 5
-          done
-          pip install -r requirements.txt -r requirements-integration.txt
+          docker buildx build -f Dockerfile.ci-python \
+            --cache-from type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-python:buildcache \
+            --cache-to type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-python:buildcache,mode=max \
+            --load -t sobs-ci-python:local .
 
-      - name: Run unit tests with coverage
+      - name: Run unit tests with coverage + diff-cover gate
+        # Runs inside the deps image (chdb baked in) against the bind-mounted workspace, so
+        # coverage.xml and .git stay on the shared runner/dind volume for the gate + artifact.
         run: |
-          echo "SOBS/chDB env snapshot"
-          env | sort | grep -E '^(SOBS_|CHDB_)' || true
-          pytest tests --ignore=tests/test_integration.py -x --maxfail=1 -vv \
-            --cov=app --cov=masking --cov=mcp \
-            --cov-report=term-missing \
-            --cov-report=xml:coverage.xml
-
-      - name: Diff coverage gate
-        run: diff-cover coverage.xml --compare-branch=origin/main --fail-under=90
+          docker run --rm -v "$PWD:/app" -w /app sobs-ci-python:local bash -c '
+            set -euo pipefail
+            git config --global --add safe.directory /app
+            echo "SOBS/chDB env snapshot"; env | sort | grep -E "^(SOBS_|CHDB_)" || true
+            pytest tests --ignore=tests/test_integration.py -x --maxfail=1 -vv \
+              --cov=app --cov=masking --cov=mcp \
+              --cov-report=term-missing \
+              --cov-report=xml:coverage.xml
+            diff-cover coverage.xml --compare-branch=origin/main --fail-under=90'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
@@ -345,51 +343,38 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Docker Buildx (in-cluster registry mirror + buildcache)
+        uses: docker/setup-buildx-action@v4
         with:
-          python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-integration.txt
-            pyproject.toml
-            .github/workflows/ci.yml
-            .github/cache-key-runtime.txt
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["registry-mirror.ci-cache.svc.cluster.local:5000"]
+            [registry."registry-mirror.ci-cache.svc.cluster.local:5000"]
+              http = true
+            [registry."registry-cache.ci-cache.svc.cluster.local:5000"]
+              http = true
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements-integration.txt', '.github/workflows/ci.yml', '.github/cache-key-runtime.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install dependencies
-        # Retry: the ~157 MB chdb_core wheel download intermittently drops mid-stream (urllib3
-        # IncompleteRead), which pip does not resume; a fresh attempt usually completes and then
-        # caches. Retry up to 3x, then a final attempt whose exit code determines the step result.
+      - name: Build the Python CI deps image (chdb + browsers baked into cached layers)
         run: |
-          for attempt in 1 2 3; do
-            pip install -r requirements.txt -r requirements-integration.txt && break
-            echo "::warning::pip install failed (attempt ${attempt}/3); retrying in 5s" && sleep 5
-          done
-          pip install -r requirements.txt -r requirements-integration.txt
-
-      - name: Install Playwright browsers
-        run: playwright install --with-deps chromium
+          docker buildx build -f Dockerfile.ci-python \
+            --cache-from type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-python:buildcache \
+            --cache-to type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-python:buildcache,mode=max \
+            --load -t sobs-ci-python:local .
 
       - name: Run integration tests
-        env:
-          SOBS_UIQA_SEED_TOTAL: "64"
-          SOBS_UIQA_SEED_WORKERS: "8"
-          SOBS_SCREENSHOT_SEED_TOTAL: "240"
-          SOBS_SCREENSHOT_SEED_WORKERS: "24"
-          # Disable the chDB server memory cap in CI. The limit is a production
-          # safeguard for constrained containers; the CI runner has ample RAM and
-          # enforcing it only causes false failures as baseline RSS varies.
-          SOBS_CHDB_MAX_SERVER_MB: "0"
-        run: pytest tests/test_integration.py -v
+        # Runs inside the deps image (chdb + chromium baked in) against the bind-mounted workspace;
+        # tests/screenshots land on the shared runner/dind volume for the artifact upload below.
+        # --shm-size lifts the default 64 MB /dev/shm so headless chromium does not crash.
+        run: |
+          docker run --rm --shm-size=2g \
+            -e SOBS_UIQA_SEED_TOTAL=64 \
+            -e SOBS_UIQA_SEED_WORKERS=8 \
+            -e SOBS_SCREENSHOT_SEED_TOTAL=240 \
+            -e SOBS_SCREENSHOT_SEED_WORKERS=24 \
+            -e SOBS_CHDB_MAX_SERVER_MB=0 \
+            -v "$PWD:/app" -w /app sobs-ci-python:local \
+            pytest tests/test_integration.py -v
 
       - name: Upload screenshots
         if: always()

--- a/Dockerfile.ci-python
+++ b/Dockerfile.ci-python
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+# CI dependency image for the Python oracle test suites (the `Tests` and `Integration Tests` jobs).
+# The heavy inputs — the ~157 MB chdb_core wheel and the Playwright chromium browser + its OS
+# libraries — are baked into cached layers pulled from the in-cluster registry buildcache, so they
+# are fetched ONLY when requirements change, never per run. This removes the recurring chdb_core
+# mid-download flake (urllib3 IncompleteRead) and makes the jobs faster.
+#
+# The suites run via `docker run` against the workspace bind-mounted from the shared runner/dind
+# _work volume (see .github/workflows/ci.yml), so coverage.xml / screenshots and the .git history
+# stay visible to the runner for the diff-cover gate and artifact upload.
+FROM python:3.14-slim
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+
+# --- layer: OS packages (git is needed by diff-cover's --compare-branch) ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+# --- layer: Python deps (busts only when requirements change) — this bakes the chdb_core wheel ---
+# Retry the install so the one-time layer build survives the chdb_core mid-download flake; once the
+# layer is cached it is never re-fetched.
+COPY requirements.txt requirements-integration.txt ./
+RUN for a in 1 2 3; do \
+        pip install -r requirements.txt -r requirements-integration.txt && break; \
+        echo "pip install attempt ${a}/3 failed; retrying in 5s"; sleep 5; \
+    done; \
+    pip install -r requirements.txt -r requirements-integration.txt
+
+# --- layer: Playwright chromium + its apt deps (busts only when the deps layer changes) ---
+# Made world-readable so a non-root `docker run --user` would still find the baked browsers.
+RUN playwright install --with-deps chromium \
+    && chmod -R a+rX "$PLAYWRIGHT_BROWSERS_PATH"

--- a/Dockerfile.ci-python
+++ b/Dockerfile.ci-python
@@ -5,33 +5,40 @@
 # are fetched ONLY when requirements change, never per run. This removes the recurring chdb_core
 # mid-download flake (urllib3 IncompleteRead) and makes the jobs faster.
 #
+# Base = ubuntu:26.04 (ships Python 3.14, which app.py requires) — deliberately the SAME base +
+# CPython build the parity build (Dockerfile.parity-ci) and the bare ARC runner use, so chdb and
+# the app behave identically to the validated oracle environment (a Debian python:3.x-slim CPython
+# build shifted a chdb execution edge and broke an AI-trace filter test).
+#
 # The suites run via `docker run` against the workspace bind-mounted from the shared runner/dind
 # _work volume (see .github/workflows/ci.yml), so coverage.xml / screenshots and the .git history
 # stay visible to the runner for the diff-cover gate and artifact upload.
-FROM python:3.14-slim
-ENV PYTHONUNBUFFERED=1 \
+FROM ubuntu:26.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+    PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright \
+    SOBS_CHDB_MAX_SERVER_MB=0
 
-# --- layer: OS packages (git is needed by diff-cover's --compare-branch) ---
+# --- layer: OS packages incl. Python 3.14 (Ubuntu 26.04 default), git for diff-cover ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git curl ca-certificates \
+        python3 python3-pip python3-venv git curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 # --- layer: Python deps (busts only when requirements change) — this bakes the chdb_core wheel ---
-# Retry the install so the one-time layer build survives the chdb_core mid-download flake; once the
-# layer is cached it is never re-fetched.
+# Retry so the one-time layer build survives the chdb_core mid-download flake; once cached it is
+# never re-fetched. --break-system-packages: Ubuntu's pip is PEP-668 externally-managed (as the
+# parity build also does).
 COPY requirements.txt requirements-integration.txt ./
 RUN for a in 1 2 3; do \
-        pip install -r requirements.txt -r requirements-integration.txt && break; \
+        python3 -m pip install --no-cache-dir --break-system-packages \
+            -r requirements.txt -r requirements-integration.txt && break; \
         echo "pip install attempt ${a}/3 failed; retrying in 5s"; sleep 5; \
     done; \
-    pip install -r requirements.txt -r requirements-integration.txt
+    python3 -m pip install --no-cache-dir --break-system-packages \
+        -r requirements.txt -r requirements-integration.txt
 
 # --- layer: Playwright chromium + its apt deps (busts only when the deps layer changes) ---
-# Made world-readable so a non-root `docker run --user` would still find the baked browsers.
-RUN playwright install --with-deps chromium \
+RUN python3 -m playwright install --with-deps chromium \
     && chmod -R a+rX "$PLAYWRIGHT_BROWSERS_PATH"

--- a/Dockerfile.ci-python.dockerignore
+++ b/Dockerfile.ci-python.dockerignore
@@ -1,0 +1,5 @@
+# The image only needs the two requirements files (the test code is bind-mounted at run time),
+# so send a minimal build context — not the whole repo / .git history.
+*
+!requirements.txt
+!requirements-integration.txt


### PR DESCRIPTION
Extends the buildx + registry-buildcache layering the **Go jobs** already use to the two **Python** jobs — the ones that were still pip-installing on the bare runner and hitting the recurring chdb_core 157 MB mid-download flake.

**How**
- New `Dockerfile.ci-python`: a shared deps image (`python:3.14-slim`) that bakes `requirements.txt` + `requirements-integration.txt` (the chdb_core wheel) and the Playwright chromium browser + OS libs into **cached layers**, pulled from `registry-cache`. Re-fetched only when requirements change. A retry wraps the one-time pip layer for first-build resilience.
- **Tests** and **Integration Tests** now: set up buildx → build the deps image (cache hit after the first run) → `docker run` the suite against the **bind-mounted workspace**. The runner↔dind shared `_work` volume (verified: both mount `work` at `/home/runner/_work`) makes the mount visible to the daemon, so `coverage.xml` / `tests/screenshots` and `.git` stay on the runner for the diff-cover gate and artifact uploads.
- Integration runs with `--shm-size=2g` so headless chromium doesn't crash.

**Why** — kills the flake at the root (no per-run download) and speeds both jobs up after the first cached build, matching why the Go jobs are fast + flake-free. Supersedes the per-step pip retry (#418), which stays harmless.

Note: the **first** run on this PR builds the image fresh (one-time chdb + chromium download, slower); subsequent runs are cache hits.