### PR TITLE
go: OTEL ingest review follow-ups — writeQueue provider seam + trace_id case-fold

### DIFF
--- a/go/cmd/sobs/handlers_pages.go
+++ b/go/cmd/sobs/handlers_pages.go
@@ -2766,7 +2766,12 @@ func (s *server) handleViewTraces(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	selectedServices := queryListNonEmpty(r, "service")
 	service := firstOrEmpty(selectedServices)
-	traceID := strings.TrimSpace(q.Get("trace_id"))
+	// Lower-cased so a trace_id pasted with different casing than the stored (always-lowercase,
+	// see otlpHexID/extractTraceFields) hex still matches — unlike app.py's view_traces, which
+	// compares TraceId verbatim (view_logs, unlike view_traces, does lower(TraceId)=lower(?); this
+	// intentionally applies that same normalization here too, a deliberate Go-only divergence from
+	// the oracle rather than a faithfully-ported quirk).
+	traceID := strings.ToLower(strings.TrimSpace(q.Get("trace_id")))
 	fromTS, toTS, timeError := parseTimeWindowArgs(r)
 	limit := parseLimit(r, 100)
 	offset := parseOffset(r)

--- a/go/cmd/sobs/otlp_ingest.go
+++ b/go/cmd/sobs/otlp_ingest.go
@@ -62,8 +62,8 @@ func jsonDumpsNoEscBytes(v any) []byte {
 
 // OTLP-JSON ingest. The HTTP response is only {"accepted": <count>}, so the per-record row mapping
 // is faithful but never byte-compared; the parity check verifies the count and a successful insert.
-// (The attr-key tracking + tag-rule application side-effects of the Python inserters are deferred —
-// they feed secondary indexes, not the response.)
+// The attr-key tracking + tag-rule application side-effects of the Python inserters feed secondary
+// indexes, not the response; they're implemented alongside each inserter below (logs/traces).
 
 // otlpAnyValue mirrors _proto_any_value_to_python: unwrap an OTLP AnyValue JSON object.
 func otlpAnyValue(v any) any {

--- a/go/cmd/sobs/providers.go
+++ b/go/cmd/sobs/providers.go
@@ -30,3 +30,13 @@ var openStore = func(cfg config) (store.DB, error) {
 var authGate = func(s *server, w http.ResponseWriter, r *http.Request) bool {
 	return s.enforceAuth(w, r)
 }
+
+// newWriteQueue constructs the process's background DB-writer (app.py's _ensure_write_worker),
+// i.e. the queue every ingest route (logs/traces/metrics/rum/errors/ai) enqueues onto via
+// enqueueWrite. The default is the embedded in-process channel+goroutine batcher (writequeue.go).
+// An alternate build can reassign this (e.g. in an init()) to a different writeQueuer backend —
+// for instance one that publishes to an external broker — without touching newServer or
+// enqueueWrite.
+var newWriteQueue = func(cfg config) writeQueuer {
+	return newDefaultWriteQueue()
+}

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -23,7 +23,7 @@ type server struct {
 	db        store.DB
 	sse       *sseBroker
 	auth      authConfig
-	wq        *writeQueue
+	wq        writeQueuer
 	tel       *telemetry
 	rumClient rumClientConfig
 	rumAsset  rumAssetConfig
@@ -76,9 +76,11 @@ func newServer(cfg config) *server {
 	s.applyRawMetricsRetention()
 	// Seed the app/release/artifact registry from SOBS_APP_REGISTRY_SEED_JSON (no-op when unset).
 	s.seedAppRegistry()
-	// Background DB writer (app.py _ensure_write_worker). The writer's ops use s.db, so start it
-	// only after the store is opened. Under parity, ingest writes are awaited (commit-before-ack).
-	s.wq = newWriteQueue()
+	// Background DB writer (app.py _ensure_write_worker), via the newWriteQueue provider seam
+	// (providers.go) — the writeQueuer analog of openStore/authGate. The writer's ops use s.db, so
+	// start it only after the store is opened. Under parity, ingest writes are awaited
+	// (commit-before-ack).
+	s.wq = newWriteQueue(cfg)
 	// Periodic background workers (app.py before_serving asyncio tasks). Real-runtime only — see
 	// background_tasks.go. Currently: the raw-metrics window-copy worker.
 	s.startBackgroundWorkers()

--- a/go/cmd/sobs/writequeue.go
+++ b/go/cmd/sobs/writequeue.go
@@ -8,6 +8,17 @@ import (
 	"time"
 )
 
+// writeQueuer is the interface the server depends on for its background DB-writer, so the default
+// in-process channel+goroutine implementation and a test fake (or an alternate build's own backend —
+// e.g. one fed by an external broker) can be swapped without touching enqueueWrite or any ingest
+// handler. This is the same seam pattern as store.DB / openStore and authGate (see providers.go):
+// the concrete type below satisfies it structurally, and newWriteQueue in providers.go is the single
+// construction point an alternate build reassigns.
+type writeQueuer interface {
+	enqueue(op func() error, wait bool) error
+	depth() int
+}
+
 // writeQueue is a faithful port of app.py's background DB-writer (_write_queue / _write_worker_main
 // / _queue_write / _run_write_batch). chdb is single-process, so a single writer goroutine draining
 // a bounded channel serializes all ingest writes and gives burst backpressure:
@@ -33,7 +44,10 @@ type writeTask struct {
 
 var errWriteQueueFull = errors.New("write queue is full")
 
-func newWriteQueue() *writeQueue {
+// newDefaultWriteQueue constructs the built-in in-process writeQueue. It is the default behind the
+// newWriteQueue provider seam (providers.go); call it directly (as the tests do) to exercise the
+// concrete implementation regardless of what the seam currently points at.
+func newDefaultWriteQueue() *writeQueue {
 	q := &writeQueue{
 		ch:          make(chan *writeTask, max(1, envInt("SOBS_WRITE_QUEUE_MAX", 5000))),
 		batchMax:    max(1, envInt("SOBS_WRITE_BATCH_MAX", 200)),

--- a/go/cmd/sobs/writequeue_test.go
+++ b/go/cmd/sobs/writequeue_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestWriteQueueWaitRunsOpSynchronously(t *testing.T) {
-	q := newWriteQueue()
+	q := newDefaultWriteQueue()
 	var ran int32
 	if err := q.enqueue(func() error { atomic.AddInt32(&ran, 1); return nil }, true); err != nil {
 		t.Fatalf("enqueue(wait): %v", err)
@@ -19,7 +19,7 @@ func TestWriteQueueWaitRunsOpSynchronously(t *testing.T) {
 }
 
 func TestWriteQueueWaitPropagatesError(t *testing.T) {
-	q := newWriteQueue()
+	q := newDefaultWriteQueue()
 	sentinel := errors.New("boom")
 	if err := q.enqueue(func() error { return sentinel }, true); !errors.Is(err, sentinel) {
 		t.Errorf("got %v, want the op error", err)
@@ -27,7 +27,7 @@ func TestWriteQueueWaitPropagatesError(t *testing.T) {
 }
 
 func TestWriteQueueAsyncRuns(t *testing.T) {
-	q := newWriteQueue()
+	q := newDefaultWriteQueue()
 	done := make(chan struct{})
 	if err := q.enqueue(func() error { close(done); return nil }, false); err != nil {
 		t.Fatalf("enqueue(async): %v", err)
@@ -63,7 +63,7 @@ func TestWriteQueueDepthNilSafe(t *testing.T) {
 func TestWriteQueueBatchesMultiple(t *testing.T) {
 	t.Setenv("SOBS_WRITE_BATCH_MAX", "8")
 	t.Setenv("SOBS_WRITE_BATCH_WAIT_MS", "50")
-	q := newWriteQueue()
+	q := newDefaultWriteQueue()
 	var ran int32
 	for i := 0; i < 5; i++ {
 		if err := q.enqueue(func() error { atomic.AddInt32(&ran, 1); return nil }, false); err != nil {


### PR DESCRIPTION
## Summary
Follow-ups from an OTEL-ingest architecture review (batching/non-blocking, HTTP/gRPC, internal-queue-driven metric-calc/rules, cross-signal consistency, trace ID handling, pub/sub pluggability). Full review context in the originating session.

- **Stale comment fix** (`otlp_ingest.go`): removed a comment claiming attr-key tracking + tag-rule application are "deferred" — they're already implemented for logs/traces immediately below it.
- **writeQueue provider seam** (`writequeue.go`, `providers.go`, `server.go`): extracted a `writeQueuer` interface (`enqueue`/`depth`) so the background DB-writer is pluggable the same way `store.DB`/`openStore` and `authGate` already are. Concrete constructor renamed `newDefaultWriteQueue`; new `var newWriteQueue = func(cfg config) writeQueuer {...}` seam. An alternate build can now swap in a different backend (e.g. one fed by an external broker) without touching `newServer`/`enqueueWrite`.
- **`/traces` trace_id case-fold** (`handlers_pages.go`): lowercase the `trace_id` query param at parse time so a pasted trace ID with different casing than the stored (always-lowercase) hex still matches — mirroring what `/logs` already does. **This is an intentional Go-only divergence from `app.py`'s `view_traces`**, which compares `TraceId` verbatim. The golden corpus has no mixed-case `trace_id` case on `/traces`, so parity is unaffected.

## Testing
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- `go test ./...` — all packages GREEN, including updated `writequeue_test.go`

## Notes
- Does not affect DoD-3/DoD-4 gaps tracked in #352 (oracle coverage ceiling, differential fuzz surface count) — this is a narrow ingest-path cleanup, not new corpus/fuzz coverage.