### PR TITLE
fix: address CodeQL security findings from the first Go scan

### DIFF
--- a/go/cmd/sobs/chart_builder_mcp_test.go
+++ b/go/cmd/sobs/chart_builder_mcp_test.go
@@ -72,7 +72,7 @@ func TestCompileBuilderSQLGuards(t *testing.T) {
 func TestMcpToInt(t *testing.T) {
 	ok := []struct {
 		in   any
-		want int
+		want int64
 	}{
 		{json.Number("5"), 5},
 		{json.Number("5.9"), 5}, // int(float) truncates toward zero

--- a/go/cmd/sobs/coverage_pure_a_test.go
+++ b/go/cmd/sobs/coverage_pure_a_test.go
@@ -208,7 +208,7 @@ func TestExtractTraceFields(t *testing.T) {
 		event     map[string]any
 		wantTrace string
 		wantSpan  string
-		wantFlags int
+		wantFlags int64
 	}{
 		{
 			"empty event",

--- a/go/cmd/sobs/dbutil.go
+++ b/go/cmd/sobs/dbutil.go
@@ -53,14 +53,20 @@ func cStr(m map[string]any, key string) string {
 }
 
 // cInt mirrors Python int(row[key]). UInt64/COUNT() columns arrive as strings (ClickHouse
-// FORMAT JSON stringifies 64-bit ints); small ints arrive as float64.
+// FORMAT JSON stringifies 64-bit ints); small ints arrive as float64. Narrows int64 -> int:
+// this is a theoretical concern only on a 32-bit platform (every SOBS deployment target is
+// amd64/arm64, where int is 64-bit, per Dockerfile.go), and strconv.ParseInt already clamps
+// an out-of-range string to +/-MaxInt64 rather than wrapping. cInt has ~120 call sites across
+// the handler package, many feeding pagination/slice-index int params directly, so widening
+// its return type is a much larger, riskier change than the low practical severity here
+// justifies — see [[go-security-findings]] memory for the fuller writeup.
 func cInt(m map[string]any, key string) int {
 	switch v := m[key].(type) {
 	case float64:
 		return int(v)
 	case string:
 		n, _ := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
-		return int(n)
+		return int(n) // codeql[go/incorrect-integer-conversion] -- see comment above
 	default:
 		return 0
 	}

--- a/go/cmd/sobs/fix_mcp_helpers.go
+++ b/go/cmd/sobs/fix_mcp_helpers.go
@@ -27,40 +27,41 @@ func mcpClampArg(o *jsonenc.Object, key string, lo, hi, def int) int {
 	if !ok {
 		return def // mirrors int(value) raising ValueError/TypeError -> default
 	}
-	if n < lo {
-		return lo
-	}
-	if n > hi {
-		return hi
-	}
-	return n
+	// Clamp at int64 width before narrowing to int: an MCP tool arg is caller-supplied and
+	// mcpToInt's Python int() semantics have no upper bound, so clamping first means an
+	// out-of-range value can't be silently truncated by the final int(...) conversion —
+	// lo/hi are always small literal bounds, so the clamped result is always int-safe.
+	return int(clampInt64(n, int64(lo), int64(hi)))
 }
 
-// mcpToInt converts a JSON-decoded scalar to an int the way Python's int(value) would, reporting
-// false when int(value) would raise (None, bool-like-via-string, non-numeric text, NaN/Inf).
-func mcpToInt(v any) (int, bool) {
+// mcpToInt converts a JSON-decoded scalar to an int64 the way Python's int(value) would,
+// reporting false when int(value) would raise (None, bool-like-via-string, non-numeric
+// text, NaN/Inf). Returns int64 (not narrowed to int) since args come from an MCP tool
+// call's caller-supplied JSON and Python's int() is arbitrary precision — mcpClampArg
+// clamps this at int64 width before its own final narrowing.
+func mcpToInt(v any) (int64, bool) {
 	switch x := v.(type) {
 	case json.Number:
 		// int(json int) is exact; int(json float) truncates toward zero. Try int first, then float.
 		if i, err := strconv.ParseInt(x.String(), 10, 64); err == nil {
-			return int(i), true
+			return i, true
 		}
 		if f, err := strconv.ParseFloat(x.String(), 64); err == nil {
 			if math.IsNaN(f) || math.IsInf(f, 0) {
 				return 0, false
 			}
-			return int(math.Trunc(f)), true
+			return int64(math.Trunc(f)), true
 		}
 		return 0, false
 	case float64:
 		if math.IsNaN(x) || math.IsInf(x, 0) {
 			return 0, false
 		}
-		return int(math.Trunc(x)), true
+		return int64(math.Trunc(x)), true
 	case int:
-		return x, true
+		return int64(x), true
 	case int64:
-		return int(x), true
+		return x, true
 	case bool:
 		// Python: int(True)==1, int(False)==0 (bool is an int subclass).
 		if x {
@@ -71,7 +72,7 @@ func mcpToInt(v any) (int, bool) {
 		// int("100") works; int("3.9") raises ValueError -> default (we do NOT fall through to float).
 		s := strings.TrimSpace(x)
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return int(i), true
+			return i, true
 		}
 		return 0, false
 	default:

--- a/go/cmd/sobs/fix_rum_helpers.go
+++ b/go/cmd/sobs/fix_rum_helpers.go
@@ -107,8 +107,12 @@ func rumStringifyContentAttr(v any) string {
 
 // rumInt mirrors Python int(payload.get(key, 0) or 0): accepts ints, integral/truncated floats,
 // AND numeric strings like "5" (Python int("5") == 5). A non-numeric / unparseable value yields 0.
-// With UseNumber, numbers arrive as json.Number; without, as float64.
-func rumInt(m map[string]any, key string) int {
+// With UseNumber, numbers arrive as json.Number; without, as float64. Returns int64 (not
+// narrowed to int) since m/key come from an externally-submitted RUM payload and Python's
+// int() has arbitrary precision — an oversized value shouldn't be truncated by the Go
+// conversion itself; jsonenc renders int and int64 identically, so callers that serialize
+// this value are unaffected.
+func rumInt(m map[string]any, key string) int64 {
 	v, ok := m[key]
 	if !ok || v == nil {
 		return 0
@@ -116,18 +120,18 @@ func rumInt(m map[string]any, key string) int {
 	switch x := v.(type) {
 	case json.Number:
 		if i, err := strconv.ParseInt(strings.TrimSpace(string(x)), 10, 64); err == nil {
-			return int(i)
+			return i
 		}
 		if f, err := strconv.ParseFloat(strings.TrimSpace(string(x)), 64); err == nil {
-			return int(f)
+			return int64(f)
 		}
 		return 0
 	case float64:
-		return int(x)
+		return int64(x)
 	case int:
-		return x
+		return int64(x)
 	case int64:
-		return int(x)
+		return x
 	case bool:
 		// Python `False or 0` -> 0; `True` -> int(True) == 1.
 		if x {
@@ -140,7 +144,7 @@ func rumInt(m map[string]any, key string) int {
 			return 0
 		}
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return int(i)
+			return i
 		}
 		// Python int() only parses integer literals; a float-looking string raises ValueError.
 		// The payloads in practice send ints, so a non-integer string maps to 0.
@@ -155,7 +159,12 @@ var traceparentRe = regexp.MustCompile(`^[0-9a-fA-F]{2}-([0-9a-fA-F]{32})-([0-9a
 // extractTraceFields mirrors app.py _extract_trace_fields(event): trim+lowercase traceId/spanId,
 // parse traceFlags (hex when a string, int otherwise), with a W3C traceparent fallback when
 // traceId/spanId are absent.
-func extractTraceFields(event map[string]any) (traceID, spanID string, traceFlags int) {
+// traceFlags is returned as int64 (not narrowed to int): the raw event["traceFlags"] path
+// parses an externally-submitted RUM payload value with no bound (unlike the traceparent
+// fallback below, whose flags are always exactly 2 hex digits, max 0xFF), so keeping the
+// wider type avoids a silent Go-side truncation before chdb's own TraceFlags UInt8 column
+// validates the range on insert.
+func extractTraceFields(event map[string]any) (traceID, spanID string, traceFlags int64) {
 	traceID = strings.ToLower(strings.TrimSpace(rumStrOrEmpty(event["traceId"])))
 	spanID = strings.ToLower(strings.TrimSpace(rumStrOrEmpty(event["spanId"])))
 	traceFlags = 0
@@ -165,16 +174,16 @@ func extractTraceFields(event map[string]any) (traceID, spanID string, traceFlag
 		if strings.TrimSpace(rawStr) != "" {
 			if s, isStr := raw.(string); isStr {
 				if n, err := strconv.ParseInt(strings.TrimSpace(s), 16, 64); err == nil {
-					traceFlags = int(n)
+					traceFlags = n
 				} else {
 					traceFlags = 0
 				}
 			} else {
 				// int(raw) for a numeric value.
 				if n, err := strconv.ParseInt(strings.TrimSpace(rawStr), 10, 64); err == nil {
-					traceFlags = int(n)
+					traceFlags = n
 				} else if f, err := strconv.ParseFloat(strings.TrimSpace(rawStr), 64); err == nil {
-					traceFlags = int(f)
+					traceFlags = int64(f)
 				} else {
 					traceFlags = 0
 				}
@@ -201,7 +210,7 @@ func extractTraceFields(event map[string]any) (traceID, spanID string, traceFlag
 	if parsedSpan == "" {
 		parsedSpan = spanID
 	}
-	return parsedTrace, parsedSpan, int(parsedFlags)
+	return parsedTrace, parsedSpan, parsedFlags
 }
 
 // rumStrOrEmpty mirrors str(x or "") — a falsy value (nil, "", 0, false) yields "".

--- a/go/cmd/sobs/handlers_forms.go
+++ b/go/cmd/sobs/handlers_forms.go
@@ -123,7 +123,7 @@ func plainRedirect(w http.ResponseWriter, location string) {
 	h.Set("Location", location)
 	h.Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusFound)
-	_, _ = w.Write([]byte(body))
+	_, _ = w.Write([]byte(body)) // codeql[go/reflected-xss] -- body embeds `esc`, already HTML-escaped above via htmlEscapeMarkup (all 5 entities); CodeQL doesn't recognize this port's custom escaper as a sanitizer
 }
 
 // flashRedirect reproduces Quart's `flash(message, category); return redirect(location)`: a
@@ -140,7 +140,7 @@ func flashRedirect(w http.ResponseWriter, category, message, location string) {
 	h.Set("Vary", "Cookie")
 	h.Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusFound)
-	_, _ = w.Write([]byte(body))
+	_, _ = w.Write([]byte(body)) // codeql[go/reflected-xss] -- body embeds `esc`, already HTML-escaped above via htmlEscapeMarkup; see plainRedirect
 }
 
 // flashRedirectWithCiKey is flashRedirect plus the one-time CI-push key stashed in the session

--- a/go/cmd/sobs/handlers_misc.go
+++ b/go/cmd/sobs/handlers_misc.go
@@ -530,7 +530,7 @@ func (s *server) handleApiAiConversation(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(body)
+	_, _ = w.Write(body) // codeql[go/reflected-xss] -- out is the render.Engine's Jinja-compatible output, which auto-escapes {{ }} values (internal/render/escape.go); see renderInto in handlers_pages.go
 }
 
 // GET /api/metrics/anomaly — app.py metrics_anomaly. Requires service+metric (400 else);

--- a/go/cmd/sobs/handlers_pages.go
+++ b/go/cmd/sobs/handlers_pages.go
@@ -482,7 +482,7 @@ func (s *server) renderInto(w http.ResponseWriter, eng *render.Engine, templateN
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(body)
+	_, _ = w.Write(body) // codeql[go/reflected-xss] -- out is the render.Engine's Jinja-compatible output, which auto-escapes {{ }} values (internal/render/escape.go's escapeHTML mirrors MarkupSafe); CodeQL doesn't recognize the custom engine as a sanitizer
 }
 
 // GET /query — app.py view_query: 404 string when the query page is disabled (fixture).

--- a/go/cmd/sobs/handlers_pages_logs_errors.go
+++ b/go/cmd/sobs/handlers_pages_logs_errors.go
@@ -173,10 +173,14 @@ func parseTraceFilterValues(traceID string, rawTraceIDs []string) (parsed []stri
 	return parsed, primary
 }
 
-// recordIDForLog mirrors _record_id_for_log(ts, service, trace_id, span_id).
+// recordIDForLog mirrors _record_id_for_log(ts, service, trace_id, span_id). MD5 here is a
+// content-addressing fingerprint for a UI row ID, not a protection for secret/sensitive
+// data, and mirrors app.py's own hashlib.md5() use for this same ID — swapping the
+// algorithm would change every emitted record ID and break parity with the frozen golden
+// corpus.
 func recordIDForLog(ts, service, traceID, spanID string) string {
 	key := service + "|" + ts + "|" + traceID + "|" + spanID
-	sum := md5.Sum([]byte(key))
+	sum := md5.Sum([]byte(key)) // codeql[go/weak-sensitive-data-hashing] -- non-cryptographic ID, see comment above
 	return hex.EncodeToString(sum[:])
 }
 
@@ -463,7 +467,7 @@ func computeAdvancedLogAnalysis(analysisRows []map[string]any, levelStats, servi
 	if total < 1 {
 		total = 1
 	}
-	severe := 0
+	var severe int64
 	severeSet := map[string]bool{"ERROR": true, "FATAL": true, "CRITICAL": true, "ALERT": true, "EMERGENCY": true}
 	for _, level := range levelStats.Keys() {
 		if severeSet[strings.ToUpper(level)] {
@@ -523,15 +527,17 @@ func pyRoundHalfEven(v float64) float64 {
 	return floor + 1
 }
 
-func toIntVal(v any) int {
+// toIntVal returns int64 (not narrowed to int) so a large aggregate count from v can't be
+// silently truncated by the conversion itself.
+func toIntVal(v any) int64 {
 	switch x := v.(type) {
 	case int:
-		return x
+		return int64(x)
 	case float64:
-		return int(x)
+		return int64(x)
 	case string:
 		n, _ := strconv.ParseInt(strings.TrimSpace(x), 10, 64)
-		return int(n)
+		return n
 	default:
 		return 0
 	}

--- a/go/cmd/sobs/handlers_v1_ingest.go
+++ b/go/cmd/sobs/handlers_v1_ingest.go
@@ -178,8 +178,8 @@ func (s *server) handleV1Ai(w http.ResponseWriter, r *http.Request) {
 		"gen_ai.operation.name":      operation,
 		"gen_ai.provider.name":       provider,
 		"gen_ai.request.model":       model,
-		"gen_ai.usage.input_tokens":  strconv.Itoa(rumInt(m, "tokens_in")),
-		"gen_ai.usage.output_tokens": strconv.Itoa(rumInt(m, "tokens_out")),
+		"gen_ai.usage.input_tokens":  strconv.FormatInt(rumInt(m, "tokens_in"), 10),
+		"gen_ai.usage.output_tokens": strconv.FormatInt(rumInt(m, "tokens_out"), 10),
 	}
 	if v, ok := m["input_messages"]; ok && v != nil {
 		attrs["gen_ai.input.messages"] = rumStringifyContentAttr(v)
@@ -541,24 +541,28 @@ func (s *server) handleV1RumClientToken(w http.ResponseWriter, r *http.Request) 
 	}
 	// ttl_raw = payload.get("ttlSec", default); int(ttl_raw) — accepts ints, floats, AND numeric
 	// strings ("3600"); a TypeError/ValueError falls back to the configured default.
-	ttlSec := s.rumClient.ttlSec
+	// ttlSec is parsed as int64 and clamped at that width before narrowing to int — the
+	// payload's ttlSec is untrusted client input and could be an arbitrarily large numeric
+	// string; clamping first (clampInt64) means an out-of-range value can't be silently
+	// truncated by a premature int(...) conversion, unlike clamping after narrowing.
+	ttlSec64 := int64(s.rumClient.ttlSec)
 	if v, ok := m["ttlSec"]; ok {
 		switch t := v.(type) {
 		case float64:
-			ttlSec = int(t)
+			ttlSec64 = int64(t)
 		case json.Number:
 			if i, err := strconv.ParseInt(strings.TrimSpace(string(t)), 10, 64); err == nil {
-				ttlSec = int(i)
+				ttlSec64 = i
 			} else if f, err := strconv.ParseFloat(strings.TrimSpace(string(t)), 64); err == nil {
-				ttlSec = int(f)
+				ttlSec64 = int64(f)
 			}
 		case string:
 			if i, err := strconv.ParseInt(strings.TrimSpace(t), 10, 64); err == nil {
-				ttlSec = int(i)
+				ttlSec64 = i
 			}
 		}
 	}
-	ttlSec = clampInt(ttlSec, 30, 24*60*60)
+	ttlSec := int(clampInt64(ttlSec64, 30, 24*60*60))
 
 	now := nowUTC().Unix()
 	claims := rumClaims{Iss: "sobs-rum", App: appName, Origin: origin, Iat: now, Exp: now + int64(ttlSec), Jti: rumJTI()}

--- a/go/cmd/sobs/mutation_helpers.go
+++ b/go/cmd/sobs/mutation_helpers.go
@@ -134,6 +134,19 @@ func orDefault(v, def string) string {
 	return v
 }
 
+// clampInt64 is clampInt for values parsed from untrusted input that may exceed int's
+// range before being bounded — clamp first at int64 width, then narrow, so an
+// out-of-range input can't be silently truncated by a premature int(...) conversion.
+func clampInt64(n, lo, hi int64) int64 {
+	if n < lo {
+		return lo
+	}
+	if n > hi {
+		return hi
+	}
+	return n
+}
+
 // clampInt mirrors `max(lo, min(hi, n))`.
 func clampInt(n, lo, hi int) int {
 	if n < lo {

--- a/go/cmd/sobs/otlp_ingest.go
+++ b/go/cmd/sobs/otlp_ingest.go
@@ -322,9 +322,13 @@ func (s *server) ingestOTLPTraces(body map[string]any) (int, error) {
 				if endNs > startNs {
 					durationMs = float64(endNs-startNs) / 1_000_000
 				}
-				statusCode := 0
+				// otlpInt returns int64 (parsed from untrusted OTLP ingest JSON, which can be
+				// an arbitrary numeric string) — kept as int64 rather than narrowed to int so
+				// an oversized value can't silently truncate; jsonenc renders int and int64
+				// identically, so this doesn't affect output bytes.
+				var statusCode int64
 				if st, ok := m["status"].(map[string]any); ok {
-					statusCode = int(otlpInt(st["code"]))
+					statusCode = otlpInt(st["code"])
 				}
 				status := "UNSET"
 				if statusCode == 1 {
@@ -493,7 +497,8 @@ func (s *server) ingestOTLPMetrics(body map[string]any) (int, error) {
 					if b, _ := sm["isMonotonic"].(bool); b {
 						mono = 1
 					}
-					temp := int(otlpInt(sm["aggregationTemporality"]))
+					// kept as int64 (not narrowed to int) — see the statusCode comment above.
+					temp := otlpInt(sm["aggregationTemporality"])
 					for _, d := range asList(sm["dataPoints"]) {
 						dp, _ := d.(map[string]any)
 						row := base(dp, otlpDPValue(dp))
@@ -501,7 +506,7 @@ func (s *server) ingestOTLPMetrics(body map[string]any) (int, error) {
 						sum = append(sum, row)
 					}
 				} else if h, ok := m["histogram"].(map[string]any); ok {
-					temp := int(otlpInt(h["aggregationTemporality"]))
+					temp := otlpInt(h["aggregationTemporality"])
 					for _, d := range asList(h["dataPoints"]) {
 						dp, _ := d.(map[string]any)
 						row := base(dp, 0)

--- a/go/cmd/sobs/query_exec.go
+++ b/go/cmd/sobs/query_exec.go
@@ -309,9 +309,13 @@ func (s *server) handleApiDashboardsSpecDryRun(w http.ResponseWriter, r *http.Re
 		Set("rows", rows).Set("named_query_results", s.executeNamedQueries(named, 5)))
 }
 
-// md5Hex16Plus returns the full hex md5 of s (used for query trace ids).
+// md5Hex16Plus returns the full hex md5 of s (used for query trace ids). MD5 here is a
+// content-addressing fingerprint, not a protection for secret/sensitive data — s is a
+// query/question string plus a timestamp, never a credential — and it mirrors app.py's own
+// hashlib.md5() use for the exact same trace/tag IDs; swapping the algorithm would change
+// every trace_id/tag_id byte value and break parity with the frozen golden corpus.
 func md5Hex(s string) string {
-	sum := md5.Sum([]byte(s))
+	sum := md5.Sum([]byte(s)) // codeql[go/weak-sensitive-data-hashing] -- non-cryptographic ID, see comment above
 	return hex.EncodeToString(sum[:])
 }
 

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -318,6 +318,10 @@ func (h *headerCapture) Write(b []byte) (int, error) {
 		h.applySecurityHeaders()
 		h.wroteHeader = true
 	}
+	// codeql[go/reflected-xss] -- generic transport-level passthrough every response body
+	// goes through; content safety is each handler's responsibility (HTML-producing handlers
+	// escape via htmlEscapeMarkup or render.Engine's Jinja-compatible autoescape — see
+	// handlers_forms.go/handlers_pages.go/handlers_misc.go), not this wrapper's.
 	return h.ResponseWriter.Write(b)
 }
 

--- a/go/cmd/sobs/source_map.go
+++ b/go/cmd/sobs/source_map.go
@@ -150,8 +150,15 @@ func (sm *sourceMapper) lookupForFile(jsURL string, line, col int) (string, int,
 	if u != nil {
 		urlPath = u.Path
 	}
-	relPath := strings.TrimPrefix(urlPath, "/")
+	// jsURL comes from a stack-trace frame in externally-submitted RUM/error telemetry, so
+	// urlPath is untrusted input. Reject path traversal exactly like handleStatic does for
+	// /static/ (static.go): prefix with "/" before Clean so any "../" sequences collapse
+	// against the root and can never resolve outside sm.dir once re-joined onto it.
+	relPath := strings.TrimPrefix(filepath.Clean("/"+urlPath), "/")
 	basename := path.Base(urlPath)
+	if basename != "" {
+		basename = strings.TrimPrefix(filepath.Clean("/"+basename), "/")
+	}
 
 	var candidates []string
 	if relPath != "" {

--- a/go/goldenreplay/archive.go
+++ b/go/goldenreplay/archive.go
@@ -3,10 +3,12 @@ package goldenreplay
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 // loadTarGzIndex decompresses a gzip'd tar archive fully into memory, keyed by each
@@ -78,13 +80,29 @@ func extractTarGz(archivePath, destDir string) error {
 		if rel == "." {
 			continue
 		}
-		target := filepath.Join(destDir, filepath.FromSlash(rel))
+		target, err := safeJoin(destDir, rel)
+		if err != nil {
+			return fmt.Errorf("tar entry %q: %w", hdr.Name, err)
+		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0o755); err != nil {
 				return err
 			}
 		case tar.TypeSymlink:
+			// hdr.Linkname is the raw string os.Symlink stores as the link's target — an
+			// absolute linkname (e.g. "/etc/passwd") would create a symlink pointing
+			// straight there regardless of destDir, so only relative linknames are
+			// accepted, and only ones that stay within destDir once resolved against the
+			// symlink's own directory (this archive's only legitimate use, chdb's Atomic
+			// engine, links relative paths like "../../store/<uuid>" — see the comment
+			// above extractTarGz).
+			if filepath.IsAbs(hdr.Linkname) {
+				return fmt.Errorf("tar entry %q: symlink target %q must be relative", hdr.Name, hdr.Linkname)
+			}
+			if _, err := safeJoin(destDir, filepath.Join(filepath.Dir(rel), hdr.Linkname)); err != nil {
+				return fmt.Errorf("tar entry %q: symlink target %q: %w", hdr.Name, hdr.Linkname, err)
+			}
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
@@ -113,4 +131,16 @@ func extractTarGz(archivePath, destDir string) error {
 		}
 	}
 	return nil
+}
+
+// safeJoin joins destDir and rel (a tar entry's cleaned relative path) and rejects the
+// result if it escapes destDir — a "zip slip" guard against a crafted archive entry name
+// like "../../etc/passwd" writing outside the intended extraction directory.
+func safeJoin(destDir, rel string) (string, error) {
+	target := filepath.Join(destDir, filepath.FromSlash(rel))
+	base := filepath.Clean(destDir)
+	if target != base && !strings.HasPrefix(target, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path escapes destination directory: %q", rel)
+	}
+	return target, nil
 }


### PR DESCRIPTION
## Summary

Retargeting the Python-cutover PR (#424) to `go-main` and fixing `codeql.yml` (it was still scoped to `language: [python]`, scanning nothing now that Python is deleted — changed to `go`) surfaced the **first-ever CodeQL analysis of the Go port**: 27 findings.

## Fixed (real code changes)

- **`go/zipslip`, `go/unsafe-unzip-symlink`** (3, `goldenreplay/archive.go`) — the tar extraction written for the testdata-compression work didn't validate entry paths or symlink targets against escaping `destDir`. Added `safeJoin` (standard zip-slip guard) and rejection of absolute/escaping symlink targets.
- **`go/path-injection`** (3, `source_map.go`) — source-map lookups built a filesystem path from a JS stack-trace URL (externally-submitted RUM/error telemetry) without validating it stayed within `SOBS_SOURCE_MAP_DIR`. Applied the same "prefix with `/` before `Clean`" guard `handleStatic` already uses for `/static/`.
- **`go/incorrect-integer-conversion`** (13 of 14) — `otlp_ingest.go`, `handlers_v1_ingest.go`, `handlers_pages_logs_errors.go`, `fix_rum_helpers.go`, `fix_mcp_helpers.go` all narrowed an `int64` parsed from untrusted OTLP/RUM/MCP input to `int` before any bounds check. Fixed by keeping values at `int64` width (`jsonenc` renders `int`/`int64` identically, so output bytes are unaffected) or clamping at `int64` width before narrowing where a bound already exists (new `clampInt64` helper). `dbutil.go`'s `cInt` (1 finding) is suppressed instead — see below.

## Suppressed with inline `// codeql[...]` justification (verified, not just asserted)

- **`go/weak-sensitive-data-hashing`** (2) — MD5 here is a content-addressing fingerprint for trace/record IDs embedded directly in golden-corpus response bytes, mirroring `app.py`'s own `hashlib.md5()` use for the same IDs. Changing the algorithm would break byte-parity, and MD5 isn't protecting secret/sensitive data in this non-cryptographic-ID role.
- **`go/reflected-xss`** (5) — every flagged output already goes through this port's own HTML-escaping: `htmlEscapeMarkup` (redirect confirmation pages) or `render.Engine`'s Jinja-compatible autoescape (`internal/render/escape.go`, mirroring MarkupSafe's `escape()` for every `{{ }}` value). CodeQL's Go query doesn't recognize either as a sanitizer, so it flags the eventual `w.Write` despite the escaping already having happened.
- **`go/incorrect-integer-conversion`** on `dbutil.go`'s `cInt` (1) — ~120 call sites across the handler package make widening it a much larger, riskier change than the finding's practical severity justifies (every deployment target is amd64/arm64, where `int` is 64-bit; `strconv.ParseInt` already clamps rather than wraps on overflow).

## Verification

- `go build/vet/test` clean.
- Full golden-corpus suite still passes 100% (Docker, CI-pinned `libchdb v26.5.0`) — none of these changes affect output bytes for any in-range input.