### PR TITLE
test: add unit tests for coverage gaps found in a fresh audit

### DIFF
--- a/go/cmd/sobs/coverage_ai_helper_stream_gaps_test.go
+++ b/go/cmd/sobs/coverage_ai_helper_stream_gaps_test.go
@@ -1,0 +1,181 @@
+package main
+
+// coverage_ai_helper_stream_gaps_test.go — fault-injection / data-variety tests for
+// streamLLMEndpoint and streamLLMEndpointWithCallbacks. The golden corpus only ever replays a
+// fixed, always-200, always-well-formed set of AI conversation fixtures, so the upstream-error
+// early return, tool-call-delta accumulation, and callback-forwarding branches were never
+// exercised at the unit level. These use the SAME SOBS_UPSTREAM_FIXTURES seam the corpus harness
+// itself relies on for the AI surface (a canned JSON file keyed by request URL) — no live network,
+// no new dependency.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+func newAIStreamTestServer() *server {
+	return &server{
+		db: &storetest.FakeDB{},
+		wq: &writeQueue{ch: make(chan *writeTask, 64), batchMax: 200, batchWaitMs: 20},
+	}
+}
+
+// writeLLMFixture writes a canned upstream response for the chat-completions URL the given
+// llmRequest resolves to (fixture files are keyed by request URL, matching the parity harness).
+func writeLLMFixture(t *testing.T, dir string, endpoint string, status int, content string) {
+	t.Helper()
+	url := chatCompletionsURL(endpoint)
+	stem := upstreamFixtureKey("POST", url)
+	raw, err := json.Marshal(map[string]any{"status": status, "content": content})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, stem+".json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStreamLLMEndpoint_UpstreamError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir) // no fixture written -> upstreamFixture returns 404
+	s := newAIStreamTestServer()
+	req := llmRequest{endpoint: "http://mock-llm.test", model: "test-model", messages: []any{}}
+	content, calls, stats := s.streamLLMEndpoint(req)
+	if content != "" || calls != nil || stats != (llmStats{}) {
+		t.Errorf("upstream error: content=%q calls=%v stats=%v, want all zero values", content, calls, stats)
+	}
+}
+
+func TestStreamLLMEndpoint_ContentAndUsage(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir)
+	sse := "data: " + `{"choices":[{"index":0,"delta":{"content":"Hello "}}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{"content":"world"}}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"reasoning_tokens":2}}` + "\n\n" +
+		"data: [DONE]\n\n"
+	writeLLMFixture(t, dir, "http://mock-llm.test", 200, sse)
+	s := newAIStreamTestServer()
+	req := llmRequest{endpoint: "http://mock-llm.test", model: "test-model", messages: []any{}}
+	content, calls, stats := s.streamLLMEndpoint(req)
+	if content != "Hello world" {
+		t.Errorf("content = %q, want %q", content, "Hello world")
+	}
+	if len(calls) != 0 {
+		t.Errorf("calls = %v, want none", calls)
+	}
+	if stats.prompt != 10 || stats.completion != 5 || stats.thinking != 2 {
+		t.Errorf("stats = %+v, want prompt=10 completion=5 thinking=2 (reasoning_tokens fallback)", stats)
+	}
+}
+
+func TestStreamLLMEndpoint_ToolCallAccumulation(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir)
+	// Arguments arrive split across two deltas for the same tool-call index, then a
+	// finish_reason of "tool_calls" flushes the accumulated call.
+	sse := "data: " + `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"search","arguments":"{\"q\":"}}]}}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"cats\"}"}}]}}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	writeLLMFixture(t, dir, "http://mock-llm.test", 200, sse)
+	s := newAIStreamTestServer()
+	req := llmRequest{endpoint: "http://mock-llm.test", model: "test-model", messages: []any{}}
+	content, calls, _ := s.streamLLMEndpoint(req)
+	if content != "" {
+		t.Errorf("content = %q, want empty (tool-call-only stream)", content)
+	}
+	if len(calls) != 1 || calls[0].name != "search" {
+		t.Fatalf("calls = %+v, want one 'search' call", calls)
+	}
+	q, _ := calls[0].args.Get("q")
+	if q != "cats" {
+		t.Errorf("tool call args[q] = %v, want %q", q, "cats")
+	}
+}
+
+// TestStreamLLMEndpoint_UnflushedToolCallAtStreamEnd covers the "tool call accumulated but the
+// stream ends (via [DONE]) without a tool_calls finish_reason" flush branch
+// (streamLLMEndpoint's trailing `if len(toolAccum) > 0 { flush() }`).
+func TestStreamLLMEndpoint_UnflushedToolCallAtStreamEnd(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir)
+	sse := "data: " + `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"lookup","arguments":"{}"}}]}}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	writeLLMFixture(t, dir, "http://mock-llm.test", 200, sse)
+	s := newAIStreamTestServer()
+	req := llmRequest{endpoint: "http://mock-llm.test", model: "test-model", messages: []any{}}
+	_, calls, _ := s.streamLLMEndpoint(req)
+	if len(calls) != 1 || calls[0].name != "lookup" {
+		t.Fatalf("calls = %+v, want one unflushed 'lookup' call surfaced at stream end", calls)
+	}
+}
+
+func TestStreamLLMEndpointWithCallbacks_Forwarding(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir)
+	sse := "data: " + `{"choices":[{"index":0,"delta":{"content":"chunk1"}}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"act","arguments":"{}"}}]}}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: " + `{"choices":[{"index":0,"delta":{"content":"chunk2"}}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	writeLLMFixture(t, dir, "http://mock-llm.test", 200, sse)
+	s := newAIStreamTestServer()
+	req := llmRequest{endpoint: "http://mock-llm.test", model: "test-model", messages: []any{}}
+
+	var deltas []string
+	var toolNames []string
+	stats := s.streamLLMEndpointWithCallbacks(req,
+		func(d string) { deltas = append(deltas, d) },
+		func(tc aiToolCall) { toolNames = append(toolNames, tc.name) },
+	)
+	if strings.Join(deltas, "") != "chunk1chunk2" {
+		t.Errorf("deltas = %v, want [chunk1 chunk2]", deltas)
+	}
+	if len(toolNames) != 1 || toolNames[0] != "act" {
+		t.Errorf("toolNames = %v, want [act]", toolNames)
+	}
+	_ = stats
+}
+
+func TestStreamLLMEndpointWithCallbacks_UpstreamError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir)
+	s := newAIStreamTestServer()
+	req := llmRequest{endpoint: "http://mock-llm.test", model: "test-model", messages: []any{}}
+	called := false
+	stats := s.streamLLMEndpointWithCallbacks(req, func(string) { called = true }, nil)
+	if called {
+		t.Error("onDelta should not be called on an upstream error")
+	}
+	if stats != (llmStats{}) {
+		t.Errorf("stats = %+v, want zero value", stats)
+	}
+}
+
+// TestCoerceLLMContent covers the []any content-list coercion branch (string items + {"text":...}
+// object items), which the corpus's fixed conversation fixtures never happen to send.
+func TestCoerceLLMContent_ListForm(t *testing.T) {
+	items := []any{
+		"plain ",
+		mustJSONObject(t, `{"text":"from-object"}`),
+		mustJSONObject(t, `{"other":"ignored"}`),
+	}
+	got := coerceLLMContent(items)
+	if got != "plain from-object" {
+		t.Errorf("coerceLLMContent(list) = %q, want %q", got, "plain from-object")
+	}
+}
+
+func mustJSONObject(t *testing.T, raw string) any {
+	t.Helper()
+	v, err := parseJSONValue([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}

--- a/go/cmd/sobs/coverage_chart_binding_gaps_test.go
+++ b/go/cmd/sobs/coverage_chart_binding_gaps_test.go
@@ -1,0 +1,184 @@
+package main
+
+// coverage_chart_binding_gaps_test.go — direct unit tests for chart_render_binding.go's pure
+// helper functions. The golden corpus only ever renders charts with well-formed, in-range,
+// all-numeric fixture data, so the validation/error branches (unknown template, column-count
+// caps, role-map errors, out-of-range indices) and several data-shape branches (non-numeric
+// heatmap values, missing box-plot dimension, unrecognized anomaly state) were never reached.
+// All of this is testable directly — no HTTP layer, no store — since these are plain functions
+// of columns/rows/bindings.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderChartFromTemplate_UnknownTemplate(t *testing.T) {
+	s := &server{}
+	_, errMsg := s.renderChartFromTemplate("no_such_template", []any{"a"}, nil, nil)
+	if !strings.Contains(errMsg, "Unknown template") {
+		t.Errorf("errMsg = %q, want it to mention Unknown template", errMsg)
+	}
+}
+
+func TestRenderChartFromTemplate_TooManyColumns(t *testing.T) {
+	s := &server{}
+	columns := []any{"x", "y", "value", "extra"}
+	rows := []map[string]any{{"x": "a", "y": "b", "value": 1.0, "extra": "z"}}
+	_, errMsg := s.renderChartFromTemplate("heatmap", columns, rows, nil)
+	if !strings.Contains(errMsg, "accepts maximum") {
+		t.Errorf("errMsg = %q, want it to mention the max-column cap", errMsg)
+	}
+}
+
+func TestRenderChartFromTemplate_TooFewColumns(t *testing.T) {
+	s := &server{}
+	columns := []any{"x", "y"}
+	rows := []map[string]any{{"x": "a", "y": "b"}}
+	_, errMsg := s.renderChartFromTemplate("heatmap", columns, rows, nil)
+	if !strings.Contains(errMsg, "requires at least") {
+		t.Errorf("errMsg = %q, want it to mention the min-column requirement", errMsg)
+	}
+}
+
+func TestRenderChartFromTemplate_NoRows(t *testing.T) {
+	s := &server{}
+	_, errMsg := s.renderChartFromTemplate("heatmap", []any{"x", "y", "value"}, nil, nil)
+	if errMsg != "" {
+		t.Errorf("errMsg = %q, want empty (no-data placeholder, not an error)", errMsg)
+	}
+}
+
+// TestExtractBindings_OutOfRangeRoleIndexSkipped covers the bounds check that drops a role
+// whose index falls outside the columns slice (extractBindings never crashes on it).
+func TestExtractBindings_OutOfRangeRoleIndexSkipped(t *testing.T) {
+	columns := []any{"a", "b"}
+	rows := []map[string]any{{"a": 1, "b": 2}}
+	bindings, err := extractBindings("heatmap", columns, rows, map[string]int{"x_category": 99})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, present := bindings["x_category"]; present {
+		t.Errorf("bindings[x_category] should be absent for an out-of-range role index, got %v", bindings["x_category"])
+	}
+}
+
+// TestExtractBindings_Heatmap_NonNumericValues covers the "no numeric values found" fallback
+// (value_min=0, value_max=1) as well as the min/max tracking branches when values ARE numeric.
+func TestExtractBindings_Heatmap_NonNumericValues(t *testing.T) {
+	columns := []any{"x", "y", "value"}
+	rows := []map[string]any{
+		{"x": "a", "y": "p", "value": "not-a-number"},
+		{"x": "b", "y": "q", "value": "also-not-a-number"},
+	}
+	roleIdx := map[string]int{"x_category": 0, "y_category": 1, "value": 2}
+	bindings, err := extractBindings("heatmap", columns, rows, roleIdx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bindings["value_min"] != 0 || bindings["value_max"] != 1 {
+		t.Errorf("all-non-numeric values: value_min/max = %v/%v, want 0/1", bindings["value_min"], bindings["value_max"])
+	}
+}
+
+func TestExtractBindings_Heatmap_NumericRange(t *testing.T) {
+	columns := []any{"x", "y", "value"}
+	rows := []map[string]any{
+		{"x": "a", "y": "p", "value": 5.0},
+		{"x": "b", "y": "q", "value": 1.0},
+		{"x": "c", "y": "r", "value": 9.0},
+	}
+	roleIdx := map[string]int{"x_category": 0, "y_category": 1, "value": 2}
+	bindings, err := extractBindings("heatmap", columns, rows, roleIdx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bindings["value_min"] != 1.0 || bindings["value_max"] != 9.0 {
+		t.Errorf("value_min/max = %v/%v, want 1/9", bindings["value_min"], bindings["value_max"])
+	}
+}
+
+// TestExtractBindings_BoxPlot_NoDimension covers the "no 'dimension' binding" fallback to an
+// empty dimension_values list.
+func TestExtractBindings_BoxPlot_NoDimension(t *testing.T) {
+	columns := []any{"min", "q1", "median", "q3", "max"}
+	rows := []map[string]any{{"min": 1.0, "q1": 2.0, "median": 3.0, "q3": 4.0, "max": 5.0}}
+	roleIdx := map[string]int{"min": 0, "q1": 1, "median": 2, "q3": 3, "max": 4}
+	bindings, err := extractBindings("box_plot", columns, rows, roleIdx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dv, ok := bindings["dimension_values"].([]any)
+	if !ok || len(dv) != 0 {
+		t.Errorf("dimension_values = %#v, want an empty []any", bindings["dimension_values"])
+	}
+	bp, ok := bindings["boxplot_data"].([]any)
+	if !ok || len(bp) != 1 {
+		t.Fatalf("boxplot_data = %#v, want 1 row", bindings["boxplot_data"])
+	}
+}
+
+// TestExtractBindings_AnomalyState_UnknownFallsBack covers the "unrecognized state" default
+// color/size branch (distinct from the known outlier/warning/normal states).
+func TestExtractBindings_AnomalyState_UnknownFallsBack(t *testing.T) {
+	columns := []any{"time", "value", "baseline_mean", "baseline_lower", "baseline_upper", "anomaly_state"}
+	rows := []map[string]any{
+		{"time": "t1", "value": 1.0, "baseline_mean": 1.0, "baseline_lower": 0.5, "baseline_upper": 1.5, "anomaly_state": "weird_unknown_state"},
+	}
+	roleIdx := map[string]int{"time": 0, "value": 1, "baseline_mean": 2, "baseline_lower": 3, "baseline_upper": 4, "anomaly_state": 5}
+	bindings, err := extractBindings("anomaly_overlay", columns, rows, roleIdx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	colors, _ := bindings["anomaly_point_color"].([]any)
+	sizes, _ := bindings["anomaly_symbol_size"].([]any)
+	if len(colors) != 1 || colors[0] != "#0d6efd" {
+		t.Errorf("anomaly_point_color = %#v, want default #0d6efd", colors)
+	}
+	if len(sizes) != 1 || sizes[0] != 4 {
+		t.Errorf("anomaly_symbol_size = %#v, want default 4", sizes)
+	}
+}
+
+// TestExtractBindings_DerivedSignalOverlay_ErrorPropagates covers the extractBindings ->
+// extractDerivedSignalBindings error-propagation branch: a non-numeric baseline cell makes
+// Python's float() raise, which must surface as an error here too (not silently coerce to 0).
+func TestExtractBindings_DerivedSignalOverlay_ErrorPropagates(t *testing.T) {
+	columns := []any{"time", "value", "baseline_mean", "baseline_lower", "baseline_upper"}
+	rows := []map[string]any{
+		{"time": "t1", "value": 1.0, "baseline_mean": "not-a-number", "baseline_lower": 0.5, "baseline_upper": 1.5},
+	}
+	roleIdx := map[string]int{"time": 0, "value": 1, "baseline_mean": 2, "baseline_lower": 3, "baseline_upper": 4}
+	_, err := extractBindings("derived_signal_overlay", columns, rows, roleIdx)
+	if err == nil {
+		t.Fatal("want an error for a non-numeric baseline_mean cell, got nil")
+	}
+}
+
+// TestSortedUniqueAny covers the numeric-vs-string sort-precedence branches: numbers sort before
+// strings, and within a type ties break by numeric or lexicographic order.
+func TestSortedUniqueAny(t *testing.T) {
+	in := []any{"b", 3.0, "a", 1.0, 3.0, 2.0}
+	got := sortedUniqueAny(in)
+	want := []any{1.0, 2.0, 3.0, "a", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("sortedUniqueAny(%v) = %v, want %v", in, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sortedUniqueAny(%v)[%d] = %v, want %v", in, i, got[i], want[i])
+		}
+	}
+}
+
+func TestAnyEqual_Numeric(t *testing.T) {
+	if !anyEqual(1.0, 1) {
+		t.Errorf("anyEqual(1.0, 1) = false, want true (numeric cross-type equality)")
+	}
+	if anyEqual(1.0, 2) {
+		t.Errorf("anyEqual(1.0, 2) = true, want false")
+	}
+	if !anyEqual("x", "x") {
+		t.Errorf(`anyEqual("x", "x") = false, want true`)
+	}
+}

--- a/go/cmd/sobs/coverage_handlers_pages_gaps_test.go
+++ b/go/cmd/sobs/coverage_handlers_pages_gaps_test.go
@@ -1,0 +1,155 @@
+package main
+
+// coverage_handlers_pages_gaps_test.go — boundary-value tests for handlers_pages.go's
+// input-clamping branches. The golden corpus only ever posts the default form values (hours=24,
+// min_count=30, etc.), so the clamp branches (below-min, above-max, unparseable) were never
+// exercised. These use the existing storetest.FakeDB seam (zero-value = empty result set for
+// every query, matching the corpus's empty fixture) plus the real template directory, the same
+// pattern handlers_incident_test.go already established.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+func newPageTestServer() *server {
+	return &server{cfg: config{TemplateDir: "../../../templates"}, db: &storetest.FakeDB{}}
+}
+
+func TestHandleSettingsTagsAuto_HoursClamp(t *testing.T) {
+	cases := []struct {
+		name      string
+		hours     string
+		wantValue string
+	}{
+		{"below min clamps to 1", "0", `value="1"`},
+		{"negative clamps to 1", "-5", `value="1"`},
+		{"above max clamps to 168", "999", `value="168"`},
+		{"within range unchanged", "48", `value="48"`},
+		{"non-numeric keeps default", "notanumber", `value="24"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newPageTestServer()
+			form := strings.NewReader("hours=" + c.hours)
+			req := httptest.NewRequest(http.MethodPost, "/settings/tags/auto", form)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec := httptest.NewRecorder()
+			s.handleSettingsTagsAuto(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), `name="hours" class="form-control form-control-sm" `+c.wantValue) {
+				t.Errorf("hours=%q: response did not contain %s for the hours input", c.hours, c.wantValue)
+			}
+		})
+	}
+}
+
+func TestHandleSettingsTagsAuto_MinCountClamp(t *testing.T) {
+	cases := []struct {
+		name      string
+		minCount  string
+		wantValue string
+	}{
+		{"below min clamps to 1", "0", `value="1"`},
+		{"above max clamps to 5000", "999999", `value="5000"`},
+		{"within range unchanged", "100", `value="100"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newPageTestServer()
+			form := strings.NewReader("min_count=" + c.minCount)
+			req := httptest.NewRequest(http.MethodPost, "/settings/tags/auto", form)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec := httptest.NewRecorder()
+			s.handleSettingsTagsAuto(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), `name="min_count" class="form-control form-control-sm" `+c.wantValue) {
+				t.Errorf("min_count=%q: response did not contain %s for the min_count input", c.minCount, c.wantValue)
+			}
+		})
+	}
+}
+
+func TestHandleSettingsTagsAuto_WrongMethod(t *testing.T) {
+	s := newPageTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/settings/tags/auto", nil)
+	rec := httptest.NewRecorder()
+	s.handleSettingsTagsAuto(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+}
+
+// TestHandleSettingsTagsAuto_RecordTypesDefault covers the "no auto_record_types selected ->
+// fall back to the full default set" branch (handlers_pages.go:75-77).
+func TestHandleSettingsTagsAuto_RecordTypesDefault(t *testing.T) {
+	s := newPageTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/settings/tags/auto", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.handleSettingsTagsAuto(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSettingsTagsAuto_CreateEmpty covers the "create" action branch
+// (handlers_pages.go:91-132), which the golden corpus's preview-only fixture never triggers:
+// zero candidates -> no insert call, capSuffix stays ".", and a success flash redirect fires.
+func TestHandleSettingsTagsAuto_CreateEmpty(t *testing.T) {
+	fake := &storetest.FakeDB{}
+	s := &server{cfg: config{TemplateDir: "../../../templates"}, db: fake}
+	form := strings.NewReader("action=create")
+	req := httptest.NewRequest(http.MethodPost, "/settings/tags/auto", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.handleSettingsTagsAuto(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status: got %d, want 302 redirect; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(fake.Inserts) != 0 {
+		t.Errorf("Inserts = %v, want none for zero candidates", fake.Inserts)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.Contains(loc, "open_panel=auto-tags") {
+		t.Errorf("Location = %q, want it to contain open_panel=auto-tags", loc)
+	}
+}
+
+// TestHandleMetricsRulesDashboardAuto_WrongMethod covers the sibling handler's 404 branch.
+func TestHandleMetricsRulesDashboardAuto_WrongMethod(t *testing.T) {
+	s := newPageTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/metrics/rules/dashboard/auto", nil)
+	rec := httptest.NewRecorder()
+	s.handleMetricsRulesDashboardAuto(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+}
+
+// TestHandleMetricsRulesDashboardAuto_CreateNoMatches covers the "create with zero candidates"
+// early-exit branch (handlers_pages.go:191-195), which the golden corpus's happy-path create
+// case never triggers.
+func TestHandleMetricsRulesDashboardAuto_CreateNoMatches(t *testing.T) {
+	s := newPageTestServer()
+	form := strings.NewReader("action=create")
+	req := httptest.NewRequest(http.MethodPost, "/metrics/rules/dashboard/auto", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.handleMetricsRulesDashboardAuto(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status: got %d, want 302 redirect; body=%s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.Contains(loc, "open_panel=auto-dashboard") {
+		t.Errorf("Location = %q, want it to contain open_panel=auto-dashboard", loc)
+	}
+}

--- a/go/cmd/sobs/coverage_notify_dispatch_gaps_test.go
+++ b/go/cmd/sobs/coverage_notify_dispatch_gaps_test.go
@@ -1,0 +1,409 @@
+package main
+
+// coverage_notify_dispatch_gaps_test.go — fault-injection tests for notify_dispatch.go's
+// external-I/O error branches. notify_dispatch_test.go already covers the crypto primitives
+// (HKDF, VAPID JWT, push-payload round trip) and the config-validation short-circuits; the
+// golden corpus only ever exercises the webhook channel's happy path, so the SMTP dial/
+// STARTTLS/AUTH failure branches, the VAPID-key-loading parse-failure branches, and the
+// upstream-HTTP error/non-2xx branches were never reached. sendSMTPMessage dials a real
+// net.Conn (not swappable via a package var), so these use a minimal in-process fake SMTP
+// server over a loopback listener — no real network, no mocking framework, just stdlib
+// net/net/textproto — plus the existing SOBS_UPSTREAM_FIXTURES seam the corpus harness itself
+// uses for the HTTP-based channels.
+
+import (
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"net"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+// fakeSMTPServer starts a minimal SMTP server on loopback. cmdOverride maps a command verb
+// (EHLO, STARTTLS, AUTH, MAIL, RCPT, DATA) to a canned response line instead of the default
+// success reply; DATA's override, if set, is sent in place of "354 go ahead" (so the message
+// body is never entered). received captures the full DATA body of the first accepted message.
+func fakeSMTPServer(t *testing.T, cmdOverride map[string]string) (addr string, received *string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var body string
+	received = &body
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				tp := textproto.NewConn(conn)
+				_ = tp.PrintfLine("220 fake smtp ready")
+				for {
+					line, err := tp.ReadLine()
+					if err != nil {
+						return
+					}
+					upper := strings.ToUpper(line)
+					switch {
+					case strings.HasPrefix(upper, "EHLO"), strings.HasPrefix(upper, "HELO"):
+						_ = tp.PrintfLine("250-fake.smtp greets you")
+						_ = tp.PrintfLine("250-STARTTLS")
+						_ = tp.PrintfLine("250 AUTH PLAIN")
+					case strings.HasPrefix(upper, "STARTTLS"):
+						if resp, ok := cmdOverride["STARTTLS"]; ok {
+							_ = tp.PrintfLine(resp)
+							continue
+						}
+						_ = tp.PrintfLine("220 go ahead")
+						return // real TLS handshake unsupported by this fake; tests using it only assert the error path
+					case strings.HasPrefix(upper, "AUTH"):
+						if resp, ok := cmdOverride["AUTH"]; ok {
+							_ = tp.PrintfLine(resp)
+							continue
+						}
+						_ = tp.PrintfLine("235 authenticated")
+					case strings.HasPrefix(upper, "MAIL"):
+						if resp, ok := cmdOverride["MAIL"]; ok {
+							_ = tp.PrintfLine(resp)
+							continue
+						}
+						_ = tp.PrintfLine("250 ok")
+					case strings.HasPrefix(upper, "RCPT"):
+						if resp, ok := cmdOverride["RCPT"]; ok {
+							_ = tp.PrintfLine(resp)
+							continue
+						}
+						_ = tp.PrintfLine("250 ok")
+					case strings.HasPrefix(upper, "DATA"):
+						if resp, ok := cmdOverride["DATA"]; ok {
+							_ = tp.PrintfLine(resp)
+							continue
+						}
+						_ = tp.PrintfLine("354 go ahead")
+						var lines []string
+						for {
+							bline, err := tp.ReadLine()
+							if err != nil || bline == "." {
+								break
+							}
+							lines = append(lines, bline)
+						}
+						body = strings.Join(lines, "\n")
+						_ = tp.PrintfLine("250 ok")
+					case strings.HasPrefix(upper, "QUIT"):
+						_ = tp.PrintfLine("221 bye")
+						return
+					default:
+						_ = tp.PrintfLine("250 ok")
+					}
+				}
+			}()
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().String(), received
+}
+
+func TestSendSMTPMessage_DialError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // nothing listens here now -> connection refused
+	got := sendSMTPMessage(addr, "localhost", false, "", "", "from@x", "to@y", []byte("msg"))
+	if got == "ok" {
+		t.Fatal("want a dial error, got ok")
+	}
+}
+
+func TestSendSMTPMessage_FullSuccess(t *testing.T) {
+	addr, received := fakeSMTPServer(t, nil)
+	got := sendSMTPMessage(addr, "localhost", false, "", "", "from@x.test", "to@y.test", []byte("Subject: hi\r\n\r\nbody text"))
+	if got != "ok" {
+		t.Fatalf("got %q, want ok", got)
+	}
+	if !strings.Contains(*received, "body text") {
+		t.Errorf("server did not receive the message body: %q", *received)
+	}
+}
+
+func TestSendSMTPMessage_AuthError(t *testing.T) {
+	addr, _ := fakeSMTPServer(t, map[string]string{"AUTH": "535 authentication failed"})
+	got := sendSMTPMessage(addr, "localhost", false, "user", "pass", "from@x", "to@y", []byte("msg"))
+	if got == "ok" {
+		t.Fatal("want an auth error, got ok")
+	}
+}
+
+func TestSendSMTPMessage_StartTLSError(t *testing.T) {
+	addr, _ := fakeSMTPServer(t, map[string]string{"STARTTLS": "502 not supported"})
+	got := sendSMTPMessage(addr, "localhost", true, "", "", "from@x", "to@y", []byte("msg"))
+	if got == "ok" {
+		t.Fatal("want a STARTTLS error, got ok")
+	}
+}
+
+func TestSendSMTPMessage_MailRcptDataErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		override map[string]string
+	}{
+		{"MAIL rejected", map[string]string{"MAIL": "550 sender rejected"}},
+		{"RCPT rejected", map[string]string{"RCPT": "550 recipient rejected"}},
+		{"DATA rejected", map[string]string{"DATA": "550 no data allowed"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			addr, _ := fakeSMTPServer(t, c.override)
+			got := sendSMTPMessage(addr, "localhost", false, "", "", "from@x", "to@y", []byte("msg"))
+			if got == "ok" {
+				t.Fatalf("%s: want an error, got ok", c.name)
+			}
+		})
+	}
+}
+
+// TestDispatchEmailChannel_SubjectTruncationAndSuccess drives dispatchEmailChannel end to end
+// (config -> SMTP send) to cover its subject-truncation branch (notify_dispatch.go:95-97) and
+// the wrapper's message-construction glue, which sendSMTPMessage's direct tests above don't
+// reach on their own.
+func TestDispatchEmailChannel_SubjectTruncationAndSuccess(t *testing.T) {
+	host, port, found := strings.Cut(mustFakeSMTPHostPort(t), ":")
+	_ = found
+	s := &server{}
+	longSummary := strings.Repeat("x", 250)
+	config := jsonenc.NewObject().
+		Set("smtp_host", host).Set("smtp_port", port).
+		Set("to_addr", "to@example.com").Set("from_addr", "from@example.com").
+		Set("use_tls", "0")
+	payload := jsonenc.NewObject().Set("summary", longSummary)
+	got := s.dispatchEmailChannel(config, payload)
+	if got != "ok" {
+		t.Fatalf("dispatchEmailChannel = %q, want ok", got)
+	}
+}
+
+// mustFakeSMTPHostPort starts a fake SMTP server (default success script) and returns its
+// "host:port" address, for tests that go through dispatchEmailChannel's host/port config split.
+func mustFakeSMTPHostPort(t *testing.T) string {
+	t.Helper()
+	addr, _ := fakeSMTPServer(t, nil)
+	return addr
+}
+
+// ---- loadVapidPrivateKey ----------------------------------------------------------------
+
+func TestLoadVapidPrivateKey_Unconfigured(t *testing.T) {
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", "")
+	s := &server{db: &storetest.FakeDB{}}
+	priv, source, err := s.loadVapidPrivateKey()
+	if err != nil || priv != nil || source != "" {
+		t.Errorf("unconfigured: priv=%v source=%q err=%v, want nil/\"\"/nil", priv, source, err)
+	}
+}
+
+func TestLoadVapidPrivateKey_InvalidBase64(t *testing.T) {
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", "not-valid-base64!!!")
+	s := &server{db: &storetest.FakeDB{}}
+	_, _, err := s.loadVapidPrivateKey()
+	if err == nil {
+		t.Fatal("want a base64 decode error, got nil")
+	}
+}
+
+func TestLoadVapidPrivateKey_UnparseableShortDER(t *testing.T) {
+	// Fewer than 32 bytes and not valid PKCS8/SEC1 DER -> falls through every branch to the
+	// final "could not parse" error (notify_dispatch.go:243).
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", base64.RawURLEncoding.EncodeToString([]byte("short")))
+	s := &server{db: &storetest.FakeDB{}}
+	_, _, err := s.loadVapidPrivateKey()
+	if err == nil || !strings.Contains(err.Error(), "could not parse VAPID private key") {
+		t.Fatalf("err = %v, want the could-not-parse message", err)
+	}
+}
+
+func TestLoadVapidPrivateKey_RawScalarFallback(t *testing.T) {
+	// >= 32 bytes that aren't valid DER at all -> raw-scalar fallback path (notify_dispatch.go:238-241).
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = byte(i + 1)
+	}
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", base64.RawURLEncoding.EncodeToString(raw))
+	s := &server{db: &storetest.FakeDB{}}
+	priv, source, err := s.loadVapidPrivateKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv == nil || source != "env" {
+		t.Fatalf("priv=%v source=%q, want a key from env", priv, source)
+	}
+}
+
+func TestLoadVapidPrivateKey_PKCS8(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", base64.RawURLEncoding.EncodeToString(der))
+	s := &server{db: &storetest.FakeDB{}}
+	priv, source, err := s.loadVapidPrivateKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv == nil || !priv.Equal(key) || source != "env" {
+		t.Fatalf("priv=%v source=%q, want the original PKCS8 key", priv, source)
+	}
+}
+
+func TestLoadVapidPrivateKey_SEC1(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", base64.RawURLEncoding.EncodeToString(der))
+	s := &server{db: &storetest.FakeDB{}}
+	priv, source, err := s.loadVapidPrivateKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv == nil || !priv.Equal(key) || source != "env" {
+		t.Fatalf("priv=%v source=%q, want the original SEC1 key", priv, source)
+	}
+}
+
+func TestLoadVapidPrivateKey_DBFallback(t *testing.T) {
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", "")
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b64 := base64.RawURLEncoding.EncodeToString(der)
+	s := &server{db: storetest.SettingsDB(map[string]string{"vapid_private_key": b64})}
+	priv, source, err := s.loadVapidPrivateKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if priv == nil || source != "db" {
+		t.Fatalf("priv=%v source=%q, want a key with source=db", priv, source)
+	}
+}
+
+// ---- dispatchSlackChannel / dispatchBrowserPushChannel upstream branches ------------------
+
+func TestDispatchSlackChannel_NonOKStatus(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir) // no fixture file written -> upstreamFixture returns 404
+	s := &server{}
+	config := jsonenc.NewObject().Set("webhook_url", "http://sobs-slack.mock/hooks/x")
+	got := s.dispatchSlackChannel(config, jsonenc.NewObject().Set("summary", "hi"))
+	if !strings.Contains(got, "HTTP 404") {
+		t.Errorf("got %q, want it to mention HTTP 404", got)
+	}
+}
+
+func TestDispatchSlackChannel_UpstreamError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir)
+	url := "http://sobs-slack.mock/hooks/bad-json"
+	stem := upstreamFixtureKey("POST", url)
+	if err := os.WriteFile(filepath.Join(dir, stem+".json"), []byte("not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &server{}
+	config := jsonenc.NewObject().Set("webhook_url", url)
+	got := s.dispatchSlackChannel(config, jsonenc.NewObject().Set("summary", "hi"))
+	if got == "ok" {
+		t.Fatal("want an error from the malformed fixture, got ok")
+	}
+}
+
+func TestDispatchBrowserPushChannel_NonOKStatus(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", base64.RawURLEncoding.EncodeToString(der))
+	dir := t.TempDir()
+	t.Setenv("SOBS_UPSTREAM_FIXTURES", dir) // no fixture -> 404, hits the "default" non-2xx branch
+	s := &server{db: &storetest.FakeDB{}}
+	subPriv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := jsonenc.NewObject().
+		Set("endpoint", "http://sobs-push.mock/endpoint/abc").
+		Set("p256dh", base64.RawURLEncoding.EncodeToString(subPriv.PublicKey().Bytes())).
+		Set("auth", base64.RawURLEncoding.EncodeToString(make([]byte, 16)))
+	got := s.dispatchBrowserPushChannel(config, jsonenc.NewObject().Set("summary", "hi"))
+	if !strings.Contains(got, "HTTP 404") {
+		t.Errorf("got %q, want it to mention HTTP 404", got)
+	}
+}
+
+func TestDispatchBrowserPushChannel_InvalidP256dhAndAuth(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", base64.RawURLEncoding.EncodeToString(der))
+	s := &server{db: &storetest.FakeDB{}}
+
+	badP256dh := jsonenc.NewObject().
+		Set("endpoint", "http://x").Set("p256dh", "not base64!!").Set("auth", base64.RawURLEncoding.EncodeToString(make([]byte, 16)))
+	if got := s.dispatchBrowserPushChannel(badP256dh, jsonenc.NewObject()); got != "invalid p256dh" {
+		t.Errorf("bad p256dh: got %q, want %q", got, "invalid p256dh")
+	}
+
+	badAuth := jsonenc.NewObject().
+		Set("endpoint", "http://x").Set("p256dh", base64.RawURLEncoding.EncodeToString(make([]byte, 65))).Set("auth", "not base64!!")
+	if got := s.dispatchBrowserPushChannel(badAuth, jsonenc.NewObject()); got != "invalid auth" {
+		t.Errorf("bad auth: got %q, want %q", got, "invalid auth")
+	}
+}
+
+func TestDispatchBrowserPushChannel_NoVapidKeyConfigured(t *testing.T) {
+	t.Setenv("SOBS_VAPID_PRIVATE_KEY", "")
+	s := &server{db: &storetest.FakeDB{}}
+	config := jsonenc.NewObject().
+		Set("endpoint", "http://x").
+		Set("p256dh", base64.RawURLEncoding.EncodeToString(make([]byte, 65))).
+		Set("auth", base64.RawURLEncoding.EncodeToString(make([]byte, 16)))
+	got := s.dispatchBrowserPushChannel(config, jsonenc.NewObject())
+	if !strings.Contains(got, "VAPID private key is not configured") {
+		t.Errorf("got %q, want the not-configured message", got)
+	}
+}

--- a/go/internal/render/coverage_eval_gaps_test.go
+++ b/go/internal/render/coverage_eval_gaps_test.go
@@ -1,0 +1,317 @@
+package render
+
+// coverage_eval_gaps_test.go — table-driven tests for eval.go branches that were never
+// exercised: the golden corpus only ever feeds evalExpr the fixed set of expressions the
+// real templates contain, so operators/tests/filters that no template happens to use in a
+// given shape (floor division, ordering comparisons, `is`/`in` tests, error propagation
+// from a failing sub-expression, several filter edge cases) were never reached. These are
+// all pure functions of the expression string + context — no mocking needed, just more
+// input variety than the frozen corpus provides.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+func evalOK(t *testing.T, eng *Engine, ctx *scope, expr string) any {
+	t.Helper()
+	got, err := eng.evalExpr(expr, ctx)
+	if err != nil {
+		t.Fatalf("evalExpr(%q) unexpected error: %v", expr, err)
+	}
+	return got
+}
+
+func evalErr(t *testing.T, eng *Engine, ctx *scope, expr string) error {
+	t.Helper()
+	got, err := eng.evalExpr(expr, ctx)
+	if err == nil {
+		t.Fatalf("evalExpr(%q) = %#v, want an error", expr, got)
+	}
+	return err
+}
+
+// TestTernary_NoElseFalse pins Jinja's inline-conditional with no `else`: a false
+// condition evaluates to undefined -> empty string (eval.go:45).
+func TestTernary_NoElseFalse(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	if got := evalOK(t, eng, ctx, "'a' if false"); got != "" {
+		t.Errorf(`evalExpr("'a' if false") = %#v, want ""`, got)
+	}
+}
+
+// TestTernary_CondError propagates a failing condition expression (eval.go:39).
+func TestTernary_CondError(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "'a' if no_such_func() else 'b'")
+}
+
+// TestOr_ErrorPropagation / TestAnd_ErrorPropagation / TestNot_ErrorPropagation cover the
+// error-propagation branches of evalOr/evalAnd/evalNot (eval.go:59,78,93) — a failing
+// operand must surface, not be silently swallowed.
+func TestOr_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() or true")
+}
+
+func TestAnd_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() and true")
+}
+
+func TestNot_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "not no_such_func()")
+}
+
+// TestMembership_NotIn covers the `not in` operator (eval.go:111), the case-safeString
+// branch of membership (eval.go:234, via a |safe-produced value), and error propagation
+// from both sides (eval.go:222,226).
+func TestMembership_NotIn(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	if got := evalOK(t, eng, ctx, "'q' not in 'xyz'"); got != true {
+		t.Errorf(`"'q' not in 'xyz'" = %#v, want true`, got)
+	}
+	if got := evalOK(t, eng, ctx, "'x' not in 'xyz'"); got != false {
+		t.Errorf(`"'x' not in 'xyz'" = %#v, want false`, got)
+	}
+}
+
+func TestMembership_SafeStringSubstring(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["html"] = "xabcz"
+	if got := evalOK(t, eng, ctx, "'abc' in (html|safe)"); got != true {
+		t.Errorf(`"'abc' in (html|safe)" = %#v, want true`, got)
+	}
+}
+
+func TestMembership_ListMembership(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	if got := evalOK(t, eng, ctx, "5 in [1, 2, 5]"); got != true {
+		t.Errorf(`"5 in [1, 2, 5]" = %#v, want true`, got)
+	}
+	if got := evalOK(t, eng, ctx, "9 in [1, 2, 5]"); got != false {
+		t.Errorf(`"9 in [1, 2, 5]" = %#v, want false`, got)
+	}
+}
+
+func TestMembership_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["x"] = 1
+	evalErr(t, eng, ctx, "no_such_func() in x")
+	evalErr(t, eng, ctx, "x in no_such_func()")
+}
+
+// TestCompareOrd covers every ordering operator (>=, <=, >, <) over both numeric operands
+// and (via orderString, including its safeString branch) string operands, plus the
+// non-comparable fallback to false (eval.go:147-174,182).
+func TestCompareOrd_Numeric(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{"3 <= 4", true},
+		{"4 <= 4", true},
+		{"5 <= 4", false},
+		{"4 >= 4", true},
+		{"3 >= 4", false},
+		{"5 > 4", true},
+		{"4 > 4", false},
+		{"3 < 4", true},
+		{"4 < 4", false},
+	}
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			if got := evalOK(t, eng, ctx, c.expr); got != c.want {
+				t.Errorf("evalExpr(%q) = %#v, want %v", c.expr, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCompareOrd_StringOrdering(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	if got := evalOK(t, eng, ctx, "'b' >= 'a'"); got != true {
+		t.Errorf(`"'b' >= 'a'" = %#v, want true`, got)
+	}
+	if got := evalOK(t, eng, ctx, "'a' < 'b'"); got != true {
+		t.Errorf(`"'a' < 'b'" = %#v, want true`, got)
+	}
+	// safeString on the left (produced by |safe) compared against a plain string literal —
+	// exercises orderString's safeString case (eval.go:182).
+	ctx.vars["html"] = "b"
+	if got := evalOK(t, eng, ctx, "(html|safe) >= 'a'"); got != true {
+		t.Errorf(`"(html|safe) >= 'a'" = %#v, want true`, got)
+	}
+}
+
+func TestCompareOrd_NonComparableFallsToFalse(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	// nil is neither numeric nor string-like on either side, so compareOrd's final
+	// fallback (eval.go:174) applies rather than a panic or type-assertion error.
+	if got := evalOK(t, eng, ctx, "none <= 5"); got != false {
+		t.Errorf(`"none <= 5" = %#v, want false`, got)
+	}
+}
+
+func TestCompareOrd_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() <= 3")
+	evalErr(t, eng, ctx, "3 <= no_such_func()")
+}
+
+// TestIsTest covers the Jinja `is`/`is not` test forms (eval.go:189-218): none, defined,
+// string, mapping (both map[string]any and *jsonenc.Object), iterable/sequence, the
+// unrecognized-test default (truthiness), and error propagation from the tested operand.
+func TestIsTest(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["nilv"] = nil
+	ctx.vars["strv"] = "hello"
+	ctx.vars["intv"] = 5
+	ctx.vars["mapv"] = map[string]any{"a": 1}
+	obj := jsonenc.NewObject()
+	obj.Set("a", 1)
+	ctx.vars["objv"] = obj
+	ctx.vars["listv"] = []any{1, 2}
+
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{"nilv is none", true},
+		{"intv is none", false},
+		{"nilv is not none", false},
+		{"intv is defined", true},
+		{"nilv is defined", false},
+		{"strv is string", true},
+		{"intv is string", false},
+		{"mapv is mapping", true},
+		{"objv is mapping", true},
+		{"strv is mapping", false},
+		{"listv is iterable", true},
+		{"strv is iterable", true},
+		{"intv is iterable", false},
+		{"listv is sequence", true},
+		// unrecognized test name falls through to the default (truthiness) case.
+		{"intv is odd", true},
+		{"nilv is odd", false},
+	}
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			if got := evalOK(t, eng, ctx, c.expr); got != c.want {
+				t.Errorf("evalExpr(%q) = %#v, want %v", c.expr, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsTest_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() is none")
+}
+
+// TestCompareEq_ErrorPropagation covers eval.go:249,253.
+func TestCompareEq_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() == 1")
+	evalErr(t, eng, ctx, "1 == no_such_func()")
+}
+
+// TestEvalFiltered_ErrorPropagation covers the filter-application error branch
+// (eval.go:271): an unsupported filter must surface as an error, not silently pass
+// the value through.
+func TestEvalFiltered_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	err := evalErr(t, eng, ctx, "5 | no_such_filter")
+	if !strings.Contains(err.Error(), "unsupported filter") {
+		t.Errorf("error = %q, want it to mention the unsupported filter", err.Error())
+	}
+}
+
+// TestEvalAddSub_ErrorPropagation covers both the first-term and later-term error
+// branches (eval.go:288,293).
+func TestEvalAddSub_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() + 1") // first term fails
+	evalErr(t, eng, ctx, "1 + no_such_func()") // later term fails
+}
+
+// TestEvalConcat covers the `~` string-concat operator, including pyStr() coercion of
+// non-string operands and error propagation from a failing part (eval.go:316).
+func TestEvalConcat(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["n"] = 7
+	if got := evalOK(t, eng, ctx, "'g' ~ n ~ 'i'"); got != "g7i" {
+		t.Errorf(`"'g' ~ n ~ 'i'" = %#v, want "g7i"`, got)
+	}
+}
+
+func TestEvalConcat_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "'a' ~ no_such_func() ~ 'b'")
+}
+
+// TestFloorDiv covers Jinja's `//` operator end to end (eval.go:327-345): the golden
+// corpus's known templates never use `//`, so none of this branch (including its error
+// propagation and zero-guard) was previously exercised at all.
+func TestFloorDiv(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	cases := []struct {
+		expr string
+		want int
+	}{
+		{"7 // 2", 3},
+		{"6 // 3", 2},
+		{"7 // 0", 0},   // zero guard
+		{"-7 // 2", -4}, // Python floor division rounds toward -inf, not toward zero
+		{"-6 // 3", -2}, // evenly divides -> no extra decrement
+	}
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			if got := evalOK(t, eng, ctx, c.expr); got != c.want {
+				t.Errorf("evalExpr(%q) = %#v, want %d", c.expr, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFloorDiv_ErrorPropagation(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	evalErr(t, eng, ctx, "no_such_func() // 2")
+	evalErr(t, eng, ctx, "2 // no_such_func()")
+}
+
+// TestModulo_ZeroGuard covers the `%` operator's zero-denominator guard (eval.go:378),
+// separate from the `//` guard above.
+func TestModulo_ZeroGuard(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	if got := evalOK(t, eng, ctx, "5 % 0"); got != 0 {
+		t.Errorf("modulo by zero = %#v, want 0", got)
+	}
+}

--- a/go/internal/render/coverage_filters_gaps_test.go
+++ b/go/internal/render/coverage_filters_gaps_test.go
@@ -1,0 +1,239 @@
+package render
+
+// coverage_filters_gaps_test.go — fills in filter/method branches the golden corpus never
+// reached because no real template happens to invoke them in a shape that hits these
+// specific paths (selectattr/rejectattr, urlencode of an ordered object, the `default`
+// filter's boolean flag, the `mask` filter, string/object method calls, ceil/floor
+// rounding, and Python str.format() via a method call). All pure functions of
+// expression+context, exercised through the same evalExpr/Render entry points the rest of
+// the render package's tests already use.
+
+import (
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+func TestDefaultFilter_BooleanFlag(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["nilv"] = nil
+	ctx.vars["emptyv"] = ""
+
+	// No boolean flag: substitution only for undefined (nil), not merely falsy.
+	if got := evalOK(t, eng, ctx, "emptyv|default('literal')"); got != "" {
+		t.Errorf(`emptyv|default('literal') = %#v, want "" (empty string is defined)`, got)
+	}
+	if got := evalOK(t, eng, ctx, "nilv|default('literal')"); got != "literal" {
+		t.Errorf(`nilv|default('literal') = %#v, want "literal"`, got)
+	}
+	// boolean=true: substitute on any falsy value, not just undefined.
+	if got := evalOK(t, eng, ctx, "emptyv|default('empty', true)"); got != "empty" {
+		t.Errorf(`emptyv|default('empty', true) = %#v, want "empty"`, got)
+	}
+}
+
+func TestMinMaxFilter_EmptyList(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["empty"] = []any{}
+	if got := evalOK(t, eng, ctx, "empty|min"); got != nil {
+		t.Errorf("empty|min = %#v, want nil", got)
+	}
+	if got := evalOK(t, eng, ctx, "empty|max"); got != nil {
+		t.Errorf("empty|max = %#v, want nil", got)
+	}
+}
+
+func TestSelectRejectAttr(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	mk := func(name string, active bool) *jsonenc.Object {
+		o := jsonenc.NewObject()
+		o.Set("name", name)
+		o.Set("active", active)
+		return o
+	}
+	ctx.vars["items"] = []any{mk("a", true), mk("b", false), mk("c", true)}
+
+	got := evalOK(t, eng, ctx, "(items|selectattr('active'))|length")
+	if got != 2 {
+		t.Errorf("selectattr('active')|length = %#v, want 2", got)
+	}
+	got = evalOK(t, eng, ctx, "(items|rejectattr('active'))|length")
+	if got != 1 {
+		t.Errorf("rejectattr('active')|length = %#v, want 1", got)
+	}
+	got = evalOK(t, eng, ctx, "(items|selectattr('name', 'equalto', 'a'))|length")
+	if got != 1 {
+		t.Errorf("selectattr('name','equalto','a')|length = %#v, want 1", got)
+	}
+	got = evalOK(t, eng, ctx, "(items|selectattr('name', 'ne', 'a'))|length")
+	if got != 2 {
+		t.Errorf("selectattr('name','ne','a')|length = %#v, want 2", got)
+	}
+}
+
+func TestUrlencodeFilter_OrderedObject(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	o := jsonenc.NewObject()
+	o.Set("q", "a b")
+	o.Set("n", 5)
+	ctx.vars["params"] = o
+	got := evalOK(t, eng, ctx, "params|urlencode")
+	if got != "q=a%20b&n=5" {
+		t.Errorf("params|urlencode = %#v, want q=a%%20b&n=5", got)
+	}
+	// Plain-string fallback branch.
+	got = evalOK(t, eng, ctx, "'a b'|urlencode")
+	if got != "a%20b" {
+		t.Errorf("'a b'|urlencode = %#v, want a%%20b", got)
+	}
+}
+
+func TestMaskFilter(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["secret"] = "sensitive"
+	// No mask func installed: identity.
+	if got := evalOK(t, eng, ctx, "secret|mask"); got != "sensitive" {
+		t.Errorf("secret|mask (no maskFunc) = %#v, want unchanged", got)
+	}
+	eng.SetMaskFunc(func(v any) any { return "***" })
+	if got := evalOK(t, eng, ctx, "secret|mask"); got != "***" {
+		t.Errorf("secret|mask (maskFunc set) = %#v, want ***", got)
+	}
+}
+
+func TestStringMethodCalls(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["s"] = "Hello World"
+
+	cases := []struct {
+		expr string
+		want any
+	}{
+		{"s.startswith('Hello')", true},
+		{"s.startswith('bye')", false},
+		{"s.endswith('World')", true},
+		{"s.endswith('bye')", false},
+		{"s.lower()", "hello world"},
+		{"s.upper()", "HELLO WORLD"},
+		{"s.replace('World', 'There')", "Hello There"},
+	}
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			if got := evalOK(t, eng, ctx, c.expr); got != c.want {
+				t.Errorf("evalExpr(%q) = %#v, want %#v", c.expr, got, c.want)
+			}
+		})
+	}
+	ctx.vars["padded"] = "  spaced  "
+	if got := evalOK(t, eng, ctx, "padded.strip()"); got != "spaced" {
+		t.Errorf("padded.strip() = %#v, want %q", got, "spaced")
+	}
+}
+
+func TestStringFormatMethod(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["a"] = 1
+	ctx.vars["b"] = 2
+	if got := evalOK(t, eng, ctx, "'{}-{}'.format(a, b)"); got != "1-2" {
+		t.Errorf(`'{}-{}'.format(a, b) = %#v, want "1-2"`, got)
+	}
+	ctx.vars["n"] = 1234567
+	if got := evalOK(t, eng, ctx, "'{:,}'.format(n)"); got != "1,234,567" {
+		t.Errorf(`'{:,}'.format(n) = %#v, want "1,234,567"`, got)
+	}
+	ctx.vars["f"] = 3.14159
+	if got := evalOK(t, eng, ctx, "'{:.2f}'.format(f)"); got != "3.14" {
+		t.Errorf(`'{:.2f}'.format(f) = %#v, want "3.14"`, got)
+	}
+}
+
+func TestOrderedObjectMethods(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	o := jsonenc.NewObject()
+	o.Set("a", 1)
+	o.Set("b", 2)
+	ctx.vars["o"] = o
+
+	if got := evalOK(t, eng, ctx, "o.keys()|list|length"); got != 2 {
+		t.Errorf("o.keys()|list|length = %#v, want 2", got)
+	}
+	if got := evalOK(t, eng, ctx, "o.values()|length"); got != 2 {
+		t.Errorf("o.values()|length = %#v, want 2", got)
+	}
+	if got := evalOK(t, eng, ctx, "o.items()|length"); got != 2 {
+		t.Errorf("o.items()|length = %#v, want 2", got)
+	}
+	if got := evalOK(t, eng, ctx, "o.get('a')"); got != 1 {
+		t.Errorf("o.get('a') = %#v, want 1", got)
+	}
+	if got := evalOK(t, eng, ctx, "o.get('missing', 'fallback')"); got != "fallback" {
+		t.Errorf("o.get('missing','fallback') = %#v, want fallback", got)
+	}
+}
+
+func TestPlainMapMethods(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["m"] = map[string]any{"x": 1, "y": 2}
+	if got := evalOK(t, eng, ctx, "m.keys()|length"); got != 2 {
+		t.Errorf("m.keys()|length = %#v, want 2", got)
+	}
+	if got := evalOK(t, eng, ctx, "m.get('x')"); got != 1 {
+		t.Errorf("m.get('x') = %#v, want 1", got)
+	}
+	if got := evalOK(t, eng, ctx, "m.get('z', 9)"); got != 9 {
+		t.Errorf("m.get('z',9) = %#v, want 9", got)
+	}
+}
+
+func TestCallMethod_UnsupportedError(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["n"] = 5
+	evalErr(t, eng, ctx, "n.no_such_method()")
+}
+
+func TestJinjaRound_CeilFloorNegativePrecision(t *testing.T) {
+	if got := jinjaRound(2.1, 0, "ceil"); got != 3 {
+		t.Errorf(`jinjaRound(2.1, 0, "ceil") = %v, want 3`, got)
+	}
+	if got := jinjaRound(2.9, 0, "floor"); got != 2 {
+		t.Errorf(`jinjaRound(2.9, 0, "floor") = %v, want 2`, got)
+	}
+	if got := jinjaRound(1234.0, -2, "common"); got != 1200 {
+		t.Errorf(`jinjaRound(1234.0, -2, "common") = %v, want 1200`, got)
+	}
+}
+
+func TestJinjaTruncate_WordBreak(t *testing.T) {
+	// killwords=false (soft break at the last space before the cut point).
+	got := jinjaTruncate("The quick brown fox jumps over", 15, false, "...")
+	if got != "The quick..." {
+		t.Errorf(`jinjaTruncate(..., 15, false, "...") = %q, want "The quick..."`, got)
+	}
+	// No space before the cut point: falls back to the hard cut (cut = length - len(end)).
+	got = jinjaTruncate("Supercalifragilisticexpialidocious", 10, false, "...")
+	if got != "Superca..." {
+		t.Errorf(`jinjaTruncate long single word = %q, want "Superca..."`, got)
+	}
+}
+
+func TestIntFloatFilter_Defaults(t *testing.T) {
+	eng := New(t.TempDir())
+	ctx := newScope(nil)
+	ctx.vars["bad"] = "not-a-number"
+	if got := evalOK(t, eng, ctx, "bad|int(9)"); got != 9 {
+		t.Errorf("bad|int(9) = %#v, want 9", got)
+	}
+	if got := evalOK(t, eng, ctx, "bad|float(1.5)"); got != 1.5 {
+		t.Errorf("bad|float(1.5) = %#v, want 1.5", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fresh audit of Go test coverage (ignoring prior session's documented constraints, per user request) found the ~16-point gap between combined coverage and 100% was mostly branch-level (only 25 fully-untested functions across the codebase) — concentrated in input-validation boundaries, the Jinja interpreter's less-common operators/filters, and external-I/O error paths (SMTP/VAPID/LLM). All of these are testable with plain stdlib Go (`httptest`, hand-rolled fakes, a minimal in-process fake SMTP server) using seams that already exist in the codebase (`storetest.FakeDB`, `SOBS_UPSTREAM_FIXTURES`) — no dependency-policy changes needed.

- **internal/render**: Jinja interpreter operator/comparison/membership/`is`-test branches (floor division `//` was entirely untested) and filter edge cases (`selectattr`, `urlencode`, `mask`, string methods). Pure functions, no mocking. Unit-only coverage: 32.0% → 54.6%.
- **cmd/sobs handlers_pages.go**: hours/min_count boundary clamping, create-with-zero-candidates branch.
- **cmd/sobs chart_render_binding.go**: column-count validation, heatmap/box-plot/anomaly-state data-shape branches, derived-signal-overlay error propagation.
- **cmd/sobs notify_dispatch.go**: SMTP dial/STARTTLS/AUTH/MAIL/RCPT/DATA failure branches via a minimal in-process fake SMTP server (`net` + `net/textproto` only), VAPID-key-loading parse branches (PKCS8/SEC1/raw-scalar/error), upstream non-2xx branches for Slack/push channels.
- **cmd/sobs ai_helper.go**: `streamLLMEndpoint`(`WithCallbacks`) upstream-error, tool-call-delta accumulation/flush, and callback-forwarding branches via `SOBS_UPSTREAM_FIXTURES` canned SSE responses.

## Coverage

Combined (unit + golden-corpus replay), measured natively on macOS: **83.58% → 84.46%**. Still well within `go/COVERAGE_FLOOR`'s 70.0 margin. Not raising the floor here — the 70.0 value was calibrated against Docker CI's observed run-to-run variance (73.74%-84.91%), and this change hasn't been re-validated against that authoritative environment yet in this PR. Will report the CI job's own coverage-gate output once it runs.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` (unit) green
- [x] `go test -tags chdb -run TestGoldenCorpus ./goldenreplay/...` — same GREEN 726/RED 78/EXCLUDED 2 as before these changes (the RED 78 is documented pre-existing macOS-native flakiness, not caused by this PR — Docker is the authoritative gate)
- [ ] CI green (Go Build & Test, Go Image Build & Smoke, lint, dependency audit)