### PR TITLE
docs: add Go runtime dependencies to NOTICES

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -57,6 +57,13 @@ TABLE OF CONTENTS
     4.1  Terser                  — BSD-2-Clause
     4.2  TypeScript              — Apache-2.0
 
+ 5. Go Runtime Dependencies
+    5.1  chdb-go                 — Apache-2.0
+    5.2  regexp2                 — MIT
+    5.3  purego                  — Apache-2.0    (transitive via chdb-go)
+    5.4  protobuf-go             — BSD-3-Clause
+    5.5  golang.org/x/sys        — BSD-3-Clause  (transitive via chdb-go/purego)
+
 -------------------------------------------------------------------------------
 
 1. PYTHON RUNTIME DEPENDENCIES
@@ -1175,6 +1182,158 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 
 Licensed under the Apache License, Version 2.0; see:
    https://www.apache.org/licenses/LICENSE-2.0
+
+-------------------------------------------------------------------------------
+
+5. GO RUNTIME DEPENDENCIES
+===========================
+
+These are Go modules compiled directly into the `sobs` Go binary (see `go/go.mod`,
+`go/go.sum`, and `go/DEPENDENCIES.md` for the dependency-approval policy).
+
+5.1 chdb-go
+-----------
+Version: 1.11.0
+License: Apache-2.0
+Homepage: https://github.com/chdb-io/chdb-go
+
+Copyright 2023 chDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy
+of the License at:
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+
+-------------------------------------------------------------------------------
+
+5.2 regexp2
+-----------
+Version: 1.12.0
+License: MIT
+Homepage: https://github.com/dlclark/regexp2
+
+Copyright (c) Doug Clark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+5.3 purego
+----------
+Version: 0.8.2
+License: Apache-2.0
+Homepage: https://github.com/ebitengine/purego
+Note: transitive dependency pulled in by chdb-go (cgo-free FFI); not imported directly.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy
+of the License at:
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+
+-------------------------------------------------------------------------------
+
+5.4 protobuf-go
+---------------
+Version: 1.36.11
+License: BSD-3-Clause
+Homepage: https://github.com/protocolbuffers/protobuf-go
+Note: the Go protobuf runtime used directly by go.mod; distinct from the Python
+protobuf package already listed in 1.21.
+
+Copyright (c) 2018 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+
+5.5 golang.org/x/sys
+--------------------
+Version: 0.22.0
+License: BSD-3-Clause
+Homepage: https://github.com/golang/sys
+Note: transitive dependency pulled in by chdb-go/purego; not imported directly.
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
License review of the Go port (root LICENSE is MIT, confirmed unchanged) found that `NOTICES` documented Python and JS/front-end third-party dependencies but was never extended to cover the Go modules actually compiled into the shipped `sobs` binary.

## What's missing today, now added as §5
| Module | License | Direct/indirect |
|---|---|---|
| `github.com/chdb-io/chdb-go` v1.11.0 | Apache-2.0 | direct |
| `github.com/dlclark/regexp2` v1.12.0 | MIT | direct |
| `github.com/ebitengine/purego` v0.8.2 | Apache-2.0 | indirect (via chdb-go) |
| `google.golang.org/protobuf` v1.36.11 | BSD-3-Clause | direct (Go runtime; distinct from the Python protobuf package already in §1.21) |
| `golang.org/x/sys` v0.22.0 | BSD-3-Clause | indirect (via chdb-go/purego) |

All permissive licenses — no GPL/copyleft, no conflict with continuing to ship the project under MIT. `github.com/google/go-cmp` appears in `go.sum` but is not imported anywhere in `go/`, so it's not compiled into the binary and isn't listed.

Also verified: the existing Apache-2.0 you'll see elsewhere in the tree (`go/internal/otlp/genpb/LICENSE`, `static/echarts.min.js`) is already correctly attributed in NOTICES §1.4/§2.3 and is vendored with its own LICENSE + provenance README — no changes needed there.

Doc-only change; no code, build, or license-file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)