### PR TITLE
chore: pre-cutover cleanup (image naming, CI stage names, dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: "gomod"
+    directory: "/go"
     schedule:
       interval: "daily"
       time: "06:00"
@@ -12,7 +12,7 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
     groups:
-      python-version-updates:
+      go-version-updates:
         patterns:
           - "*"
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
   go-build-test:
-    name: Go Build & Test
+    name: Build & Test
     runs-on: sobs-runners
     permissions:
       contents: read
@@ -96,7 +96,7 @@ jobs:
           cache-to: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-buildcache,mode=max
 
   docker-go-smoke:
-    name: Go Image Build & Smoke
+    name: Image Build & Smoke
     runs-on: sobs-runners
     # Builds its own image from source — independent of go-build-test, so run in parallel.
     permissions:
@@ -112,10 +112,10 @@ jobs:
           docker build --network=host \
             --build-arg GOPROXY="${GOPROXY}" \
             --build-arg GOSUMDB="${GOSUMDB}" \
-            -f Dockerfile.go -t sobs-go:ci .
+            -f Dockerfile.go -t sobs:ci .
 
       - name: Start the container (empty /data — must self-seed its schema)
-        run: docker run -d --name sobs-go -p 4317:4317 sobs-go:ci
+        run: docker run -d --name sobs -p 4317:4317 sobs:ci
 
       - name: Smoke-test the running image
         run: |
@@ -141,7 +141,7 @@ jobs:
 
       - name: Container logs
         if: always()
-        run: docker logs sobs-go || true
+        run: docker logs sobs || true
 
   rum-build:
     name: RUM JS Build & Type Check
@@ -216,7 +216,7 @@ jobs:
         run: npm run lint:examples
 
   docker:
-    name: Build & Push Docker Image (Go)
+    name: Build & Push Docker Image
     runs-on: sobs-runners
     # The published image is the Go server (the cutover artifact). Gate on the Go pipeline —
     # go-build-test includes the golden-corpus replay (former parity job's role) — so a release
@@ -270,7 +270,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
 
-      - name: Build and push multi-arch Docker image (Go)
+      - name: Build and push multi-arch Docker image
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.go.dev
-    image: sobs-go-dev:latest
+    image: sobs-dev:latest
     user: "0:0" # air writes ./go/tmp in the bind-mounted (host-owned) source
     volumes:
       - ./go:/src/go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.go
-    image: ghcr.io/abartrim/sobs-go:latest
+    image: ghcr.io/abartrim/sobs:latest
     container_name: sobs
     user: "10001:10001"
     security_opt:


### PR DESCRIPTION
## Summary

Follow-up from the "what else is needed before merging go-main into main" discussion. Three concrete gaps found and fixed:

1. **Image name**: \`docker-compose.yml\` referenced \`ghcr.io/abartrim/sobs-go:latest\`, but CI's actual \`docker\` job publishes to \`ghcr.io/${{ github.repository }}\` = \`ghcr.io/abartrim/sobs\` (same name as the current Python image, gated to \`main\`/tags). The compose file was stale from mid-migration. Also renamed the local-only dev tag and the smoke-test job's ephemeral local container/tag names for consistency now that there's only one implementation.
2. **CI stage names**: dropped the now-unnecessary "Go"/"(Go)" qualifiers — "Go Build & Test" → "Build & Test", "Go Image Build & Smoke" → "Image Build & Smoke", "Build & Push Docker Image (Go)" → "Build & Push Docker Image". Single sane set of stage names, since there's no more Python pipeline to disambiguate from.
3. **Dependabot**: removed the "pip" ecosystem entry (confirmed no requirements.txt/pyproject.toml manifest exists anywhere for it to track) and added a "gomod" entry (\`directory: /go\`) — Go's actual dependencies (chdb-go, protobuf, regexp2) had zero Dependabot coverage until now.

⚠️ **Reviewer note**: chdb-go version-bump PRs from Dependabot need extra scrutiny before merging — see \`go/CHDB_PIN.md\` on why drifting to a newer/unpinned chdb-core kernel can silently break on-disk compatibility with existing data. This PR doesn't add any guardrail against that beyond documentation; flagging it as a known risk of adding gomod tracking.

## Test plan

- [x] YAML syntax validated (`.github/workflows/ci.yml`, `.github/dependabot.yml`)
- [x] Grepped for stray `sobs-go` references — none remain
- [ ] CI green