### PR TITLE
fix: don't let a k8s service-link SOBS_PORT crash the listener

### DIFF
--- a/go/cmd/sobs/main.go
+++ b/go/cmd/sobs/main.go
@@ -92,7 +92,7 @@ func loadConfig() config {
 	return config{
 		Parity:           os.Getenv("SOBS_PARITY") == "1",
 		DataDir:          envOr("SOBS_DATA_DIR", "./data"),
-		Port:             envOr("SOBS_PORT", envOr("PORT", "44317")),
+		Port:             envPort("44317", "SOBS_PORT", "PORT"),
 		StaticDir:        envOr("SOBS_STATIC_DIR", "static"),
 		TemplateDir:      envOr("SOBS_TEMPLATE_DIR", "templates"),
 		SecretKey:        envOr("SOBS_SECRET_KEY", "sobs-dev-secret-key"),
@@ -111,6 +111,26 @@ func envOr(k, def string) string {
 	return def
 }
 
+// envPort resolves the listen port from the given environment variables in priority order,
+// skipping any value shaped like Kubernetes' auto-injected service-link URL (e.g.
+// "tcp://10.152.183.152:44317") rather than a bare port number. Kubernetes injects
+// "<SVCNAME>_PORT=tcp://<cluster-ip>:<port>" into every pod in a namespace for each Service
+// present when the pod starts (enableServiceLinks defaults to true) — and the reference
+// k8s/deployment.yaml's own Service is named "sobs", so any cluster following it collides
+// directly with SOBS_PORT (caught deploying to the pab canary: the injected URL reached
+// net.Listen verbatim and crashed with "too many colons in address"). A real operator- or
+// platform-supplied SOBS_PORT/PORT is always a bare port number, so a URL-shaped value is
+// never an intentional override — treat it as unset and fall through to the next candidate,
+// then def.
+func envPort(def string, names ...string) string {
+	for _, name := range names {
+		if v := os.Getenv(name); v != "" && !strings.Contains(v, "://") {
+			return v
+		}
+	}
+	return def
+}
+
 // resolveBindAddr mirrors app.py's __main__ bind resolution: HYPERCORN_BIND / GUNICORN_BIND
 // override the full host:port; otherwise SOBS_HOST (default 0.0.0.0, matching app.py's
 // f"0.0.0.0:{port}" default — bind all interfaces) plus the resolved port.
@@ -124,7 +144,7 @@ func resolveBindAddr(port string) string {
 // runHealthcheck probes the local /health endpoint; returns 0 if it answers 200, else 1.
 func runHealthcheck() int {
 	client := http.Client{Timeout: 4 * time.Second}
-	resp, err := client.Get("http://127.0.0.1:" + envOr("SOBS_PORT", envOr("PORT", "44317")) + "/health")
+	resp, err := client.Get("http://127.0.0.1:" + envPort("44317", "SOBS_PORT", "PORT") + "/health")
 	if err != nil {
 		log.Printf("healthcheck: %v", err)
 		return 1

--- a/go/cmd/sobs/main_test.go
+++ b/go/cmd/sobs/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+func TestEnvPort(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "no env set falls back to default",
+			env:  map[string]string{},
+			want: "44317",
+		},
+		{
+			name: "bare PORT used when SOBS_PORT unset",
+			env:  map[string]string{"PORT": "8080"},
+			want: "8080",
+		},
+		{
+			name: "bare SOBS_PORT takes priority over PORT",
+			env:  map[string]string{"SOBS_PORT": "9000", "PORT": "8080"},
+			want: "9000",
+		},
+		{
+			name: "kubernetes service-link SOBS_PORT is ignored, falls through to PORT",
+			env:  map[string]string{"SOBS_PORT": "tcp://10.152.183.152:44317", "PORT": "4317"},
+			want: "4317",
+		},
+		{
+			name: "kubernetes service-link SOBS_PORT with no PORT falls through to default",
+			env:  map[string]string{"SOBS_PORT": "tcp://10.152.183.152:44317"},
+			want: "44317",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, k := range []string{"SOBS_PORT", "PORT"} {
+				t.Setenv(k, tc.env[k])
+			}
+			if got := envPort("44317", "SOBS_PORT", "PORT"); got != tc.want {
+				t.Errorf("envPort() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Caught deploying `v0.2.0-beta.1` to the pab canary cluster: the pod crash-looped immediately with `listen tcp: address tcp://10.152.183.152:44317: too many colons in address`.

**Root cause:** Kubernetes injects `<SVCNAME>_PORT=tcp://<cluster-ip>:<port>` into every pod in a namespace for each Service present when the pod starts (`enableServiceLinks` defaults to true). The reference `k8s/deployment.yaml`'s own Service is named `sobs`, so any cluster following it (pab included) gets `SOBS_PORT` auto-injected as that URL — colliding directly with `loadConfig()`'s `envOr("SOBS_PORT", ...)`, which read it ahead of the deployment's own explicit `PORT=4317` and passed the URL straight to `net.Listen`.

**Fix:** `envPort()` still checks `SOBS_PORT` before `PORT` (an operator explicitly setting a bare `SOBS_PORT` should still win), but skips any value containing `://` as clearly not an intentional port override, falling through to the next candidate. Applied to both the real listener (`loadConfig`) and the container healthcheck probe, since both read the same pair of env vars.

**Verified:**
- New table-driven `TestEnvPort` covers the k8s-injected-URL case plus existing precedence/default behavior.
- `go test ./...` and a full golden-corpus replay (776/776 green) both clean.
- Reproduced live on the pab cluster, rolled back to the last-good digest immediately, will re-roll once this merges + a new tag is cut.