### PR TITLE
fix: implement reverse-proxy base-path support (X-Forwarded-Prefix)

### DIFF
--- a/go/cmd/sobs/basepath.go
+++ b/go/cmd/sobs/basepath.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// This file ports app.py's BasePathMiddleware (added in "Fix #14: add base-path aware URL
+// generation and routing") — reverse-proxy base-path support was documented in README.md
+// ("For reverse proxies, SOBS also honors X-Forwarded-Prefix for URL generation and prefixed
+// routing") but never actually implemented in the Go rewrite: url_for/redirect targets used
+// only the static SOBS_BASE_PATH env var (see render.go/fix_forms.go's old direct
+// s.cfg.BasePath reads), and incoming requests were never stripped of a proxy-forwarded
+// prefix at all. Caught testing behind pab-admin's reverse proxy: static asset links weren't
+// rewritten to the proxied URL.
+
+var repeatedSlashes = regexp.MustCompile(`/+`)
+
+// normalizeBasePath mirrors app.py's _normalize_base_path: collapse repeated slashes, ensure a
+// single leading slash and no trailing slash; "" and "/" both normalize to "" (no base path).
+func normalizeBasePath(v string) string {
+	v = repeatedSlashes.ReplaceAllString(strings.TrimSpace(v), "/")
+	if v == "" || v == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(v, "/") {
+		v = "/" + v
+	}
+	v = strings.TrimSuffix(v, "/")
+	if v == "" || v == "/" {
+		return ""
+	}
+	return v
+}
+
+// effectiveBasePath resolves the base path to use for THIS request: an X-Forwarded-Prefix
+// header (dynamic, set by a reverse proxy per-request) takes priority over the static
+// SOBS_BASE_PATH the server started with — mirrors app.py's
+// "effective_base = forwarded or BASE_PATH".
+func (s *server) effectiveBasePath(r *http.Request) string {
+	if fwd := normalizeBasePath(r.Header.Get("X-Forwarded-Prefix")); fwd != "" {
+		return fwd
+	}
+	return s.cfg.BasePath // normalized once at startup in loadConfig
+}
+
+// applyBasePath mirrors app.py's BasePathMiddleware.__call__: if the incoming request still
+// carries the base-path prefix (the proxy passed the raw path through unstripped), strip it
+// so the app's own routes — which are only ever registered bare, e.g. "/static/" — match.
+// Requests where the proxy already stripped the prefix before forwarding pass through
+// unchanged: effectiveBasePath(r) (used for OUTBOUND link generation via url_for/redirects)
+// reads X-Forwarded-Prefix directly, independent of what this does to r.URL.Path.
+func (s *server) applyBasePath(r *http.Request) *http.Request {
+	base := s.effectiveBasePath(r)
+	if base == "" {
+		return r
+	}
+	p := r.URL.Path
+	var newPath string
+	switch {
+	case p == base:
+		newPath = "/"
+	case strings.HasPrefix(p, base+"/"):
+		newPath = strings.TrimPrefix(p, base)
+	default:
+		return r // proxy already stripped the prefix; nothing to do for routing
+	}
+	// Same shallow-copy approach as stdlib's http.StripPrefix: clone Request and URL (not a
+	// deep Clone) so concurrent handling of other requests never observes this mutation.
+	r2 := new(http.Request)
+	*r2 = *r
+	r2.URL = new(url.URL)
+	*r2.URL = *r.URL
+	r2.URL.Path = newPath
+	if rp := r.URL.RawPath; rp != "" {
+		if rp == base {
+			r2.URL.RawPath = "/"
+		} else {
+			r2.URL.RawPath = strings.TrimPrefix(rp, base)
+		}
+	}
+	return r2
+}

--- a/go/cmd/sobs/basepath_test.go
+++ b/go/cmd/sobs/basepath_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+func TestNormalizeBasePath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"/", ""},
+		{"   ", ""},
+		{"sobs", "/sobs"},
+		{"/sobs", "/sobs"},
+		{"/sobs/", "/sobs"},
+		{"//sobs//nested//", "/sobs/nested"},
+		{"  /sobs  ", "/sobs"},
+	}
+	for _, c := range cases {
+		if got := normalizeBasePath(c.in); got != c.want {
+			t.Errorf("normalizeBasePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEffectiveBasePath(t *testing.T) {
+	s := &server{cfg: config{BasePath: "/sobs"}}
+
+	// X-Forwarded-Prefix, when present, overrides the static SOBS_BASE_PATH.
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-Prefix", "/insights")
+	if got := s.effectiveBasePath(r); got != "/insights" {
+		t.Errorf("effectiveBasePath with header = %q, want /insights", got)
+	}
+
+	// No header -> falls back to the static config.
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	if got := s.effectiveBasePath(r2); got != "/sobs" {
+		t.Errorf("effectiveBasePath without header = %q, want /sobs", got)
+	}
+
+	// Header present but empty/root -> falls back too (normalizes to "").
+	r3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r3.Header.Set("X-Forwarded-Prefix", "/")
+	if got := s.effectiveBasePath(r3); got != "/sobs" {
+		t.Errorf("effectiveBasePath with root header = %q, want /sobs (fallback)", got)
+	}
+}
+
+func TestApplyBasePath(t *testing.T) {
+	s := &server{cfg: config{BasePath: "/sobs"}}
+
+	cases := []struct {
+		name      string
+		path      string
+		forwarded string // X-Forwarded-Prefix header, if any
+		wantPath  string
+	}{
+		{
+			name:     "no base path configured: path untouched",
+			path:     "/logs",
+			wantPath: "/logs",
+		},
+		{
+			name:     "proxy kept prefix, exact match on root",
+			path:     "/sobs",
+			wantPath: "/",
+		},
+		{
+			name:     "proxy kept prefix on a sub-path: stripped for routing",
+			path:     "/sobs/static/app.css",
+			wantPath: "/static/app.css",
+		},
+		{
+			name:     "proxy already stripped the prefix: path passes through unchanged",
+			path:     "/static/app.css",
+			wantPath: "/static/app.css",
+		},
+		{
+			name:      "X-Forwarded-Prefix overrides the static base for stripping too",
+			path:      "/insights/static/app.css",
+			forwarded: "/insights",
+			wantPath:  "/static/app.css",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := s
+			if c.name == "no base path configured: path untouched" {
+				srv = &server{cfg: config{BasePath: ""}}
+			}
+			r := httptest.NewRequest(http.MethodGet, c.path, nil)
+			if c.forwarded != "" {
+				r.Header.Set("X-Forwarded-Prefix", c.forwarded)
+			}
+			got := srv.applyBasePath(r)
+			if got.URL.Path != c.wantPath {
+				t.Errorf("applyBasePath(%q).URL.Path = %q, want %q", c.path, got.URL.Path, c.wantPath)
+			}
+		})
+	}
+}
+
+// TestRenderPage_ForwardedPrefixRewritesLinks exercises the full chain a reverse-proxy
+// deployment depends on: renderPage -> newEngine(r) -> effectiveBasePath(r) -> url_for,
+// mirroring app.py's test_forwarded_prefix_generates_prefixed_links. Regression test for the
+// bug reported behind pab-admin's reverse proxy: static asset links weren't rewritten to the
+// proxied URL because this whole chain read the request-independent SOBS_BASE_PATH only.
+func TestRenderPage_ForwardedPrefixRewritesLinks(t *testing.T) {
+	s := &server{cfg: config{TemplateDir: "../../../templates"}, db: &storetest.FakeDB{}}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-Prefix", "/sobs")
+	s.renderPage(w, r, "query.html", "view_query", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `href="/sobs/logs"`) {
+		t.Errorf("expected X-Forwarded-Prefix-aware nav link href=\"/sobs/logs\", got body without it:\n%s", body)
+	}
+	if !strings.Contains(body, `src="/sobs/static/bootstrap.bundle.min.js"`) {
+		t.Errorf("expected X-Forwarded-Prefix-aware static asset link, got body without it:\n%s", body)
+	}
+
+	// Root mode (no header, no static config) must still emit unprefixed links — mirrors
+	// app.py's test_root_mode_uses_root_relative_links.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	s.renderPage(w2, r2, "query.html", "view_query", nil)
+	body2 := w2.Body.String()
+	if !strings.Contains(body2, `href="/logs"`) {
+		t.Errorf("expected unprefixed nav link href=\"/logs\" in root mode, got:\n%s", body2)
+	}
+	if strings.Contains(body2, "/sobs/") {
+		t.Errorf("root-mode render leaked a /sobs/ prefixed link from the prior request:\n%s", body2)
+	}
+}

--- a/go/cmd/sobs/cov95_b14_fix_forms_test.go
+++ b/go/cmd/sobs/cov95_b14_fix_forms_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/sobs/sobs/internal/jsonenc"
@@ -144,10 +145,11 @@ func TestChartObjInt(t *testing.T) {
 
 func TestNotifViewRedirect(t *testing.T) {
 	s := &server{cfg: config{BasePath: ""}}
-	if got := s.notifViewRedirect(""); got != "/settings/notifications" {
+	req := httptest.NewRequest("GET", "/", nil)
+	if got := s.notifViewRedirect(req, ""); got != "/settings/notifications" {
 		t.Errorf("no edit id = %q", got)
 	}
-	got := s.notifViewRedirect("rule:1")
+	got := s.notifViewRedirect(req, "rule:1")
 	if got != "/settings/notifications?edit_rule=rule:1" {
 		t.Errorf("edit id with colon = %q", got)
 	}

--- a/go/cmd/sobs/cov95_b15_render_test.go
+++ b/go/cmd/sobs/cov95_b15_render_test.go
@@ -58,7 +58,7 @@ func TestNewEngineFlash_Globals(t *testing.T) {
 
 	s := &server{cfg: config{TemplateDir: dir}, db: &storetest.FakeDB{}}
 	flashes := []any{[]any{"success", "Saved!"}, []any{"error", "Oops"}}
-	eng := s.newEngineFlash(flashes)
+	eng := s.newEngineFlash(httptest.NewRequest(http.MethodGet, "/", nil), flashes)
 
 	out, err := eng.Render("probe.html", map[string]any{})
 	if err != nil {
@@ -89,44 +89,44 @@ func TestUrlFor_StaticAndEndpoints(t *testing.T) {
 	s := &server{cfg: config{BasePath: ""}}
 
 	// static endpoint: filename kwarg -> /static/<filename>.
-	out, err := s.urlFor([]any{"static"}, map[string]any{"filename": "app.css"}, []string{"filename"})
+	out, err := s.urlFor("", []any{"static"}, map[string]any{"filename": "app.css"}, []string{"filename"})
 	if err != nil || out != "/static/app.css" {
 		t.Errorf("urlFor(static) = (%v, %v), want /static/app.css", out, err)
 	}
 
 	// A named endpoint with a path param substituted in, no extra query params.
-	out, err = s.urlFor([]any{"ai_helper_chat_detail"}, map[string]any{"chat_id": "abc-123"}, []string{"chat_id"})
+	out, err = s.urlFor("", []any{"ai_helper_chat_detail"}, map[string]any{"chat_id": "abc-123"}, []string{"chat_id"})
 	if err != nil || out != "/api/ai/helper/chats/abc-123" {
 		t.Errorf("urlFor(chat_detail) = (%v, %v), want /api/ai/helper/chats/abc-123", out, err)
 	}
 
 	// A named endpoint with a path param AND an extra kwarg that becomes a query string.
-	out, err = s.urlFor([]any{"ai_helper_chat_detail"}, map[string]any{"chat_id": "abc", "verbose": "1"},
+	out, err = s.urlFor("", []any{"ai_helper_chat_detail"}, map[string]any{"chat_id": "abc", "verbose": "1"},
 		[]string{"chat_id", "verbose"})
 	if err != nil || out != "/api/ai/helper/chats/abc?verbose=1" {
 		t.Errorf("urlFor(chat_detail+query) = (%v, %v), want with ?verbose=1", out, err)
 	}
 
 	// A kwarg whose value is nil must be OMITTED from the query string entirely.
-	out, err = s.urlFor([]any{"ai_helper_chat_detail"}, map[string]any{"chat_id": "abc", "grouped": nil},
+	out, err = s.urlFor("", []any{"ai_helper_chat_detail"}, map[string]any{"chat_id": "abc", "grouped": nil},
 		[]string{"chat_id", "grouped"})
 	if err != nil || out != "/api/ai/helper/chats/abc" {
 		t.Errorf("urlFor(nil kwarg omitted) = (%v, %v), want no query string", out, err)
 	}
 
 	// Unknown endpoint -> error.
-	if _, err := s.urlFor([]any{"totally_bogus_endpoint"}, nil, nil); err == nil {
+	if _, err := s.urlFor("", []any{"totally_bogus_endpoint"}, nil, nil); err == nil {
 		t.Error("expected an error for an unknown endpoint")
 	}
 
 	// No positional args at all -> error ("url_for requires an endpoint").
-	if _, err := s.urlFor(nil, nil, nil); err == nil {
+	if _, err := s.urlFor("", nil, nil, nil); err == nil {
 		t.Error("expected an error when no endpoint is given")
 	}
 
 	// BasePath is prefixed onto both static and rule paths.
 	sPrefixed := &server{cfg: config{BasePath: "/sobs"}}
-	out, err = sPrefixed.urlFor([]any{"static"}, map[string]any{"filename": "x.js"}, []string{"filename"})
+	out, err = sPrefixed.urlFor("/sobs", []any{"static"}, map[string]any{"filename": "x.js"}, []string{"filename"})
 	if err != nil || out != "/sobs/static/x.js" {
 		t.Errorf("urlFor with BasePath = (%v, %v), want /sobs/static/x.js", out, err)
 	}
@@ -136,7 +136,7 @@ func TestUrlFor_QueryEscaping(t *testing.T) {
 	s := &server{}
 	// Werkzeug-relaxed escaping: sub-delims like ' ( ) , : stay literal in query values, but
 	// space becomes '+' and other reserved chars are percent-escaped.
-	outAny, err := s.urlFor([]any{"ai_helper_chat_detail"},
+	outAny, err := s.urlFor("", []any{"ai_helper_chat_detail"},
 		map[string]any{"chat_id": "abc", "sql": "has_tag('env','prod') a b"},
 		[]string{"chat_id", "sql"})
 	if err != nil {

--- a/go/cmd/sobs/cov95_b1_handlers_pages_test.go
+++ b/go/cmd/sobs/cov95_b1_handlers_pages_test.go
@@ -83,7 +83,7 @@ func TestRenderInto_TemplateError(t *testing.T) {
 	s := cov95B1TestServer()
 	rec := httptest.NewRecorder()
 	// A nonexistent template name forces eng.Render to return an error.
-	s.renderInto(rec, s.newEngine(), "this_template_does_not_exist.html", map[string]any{})
+	s.renderInto(rec, s.newEngine(httptest.NewRequest(http.MethodGet, "/", nil)), "this_template_does_not_exist.html", map[string]any{})
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status: got %d, want 500; body=%s", rec.Code, rec.Body.String())
 	}

--- a/go/cmd/sobs/cov95_b3_handlers_forms_test.go
+++ b/go/cmd/sobs/cov95_b3_handlers_forms_test.go
@@ -1542,7 +1542,7 @@ func TestViewCustomDashboard_GetChartsError(t *testing.T) {
 		ExecuteFunc: func(string, ...any) (*store.Result, error) { return nil, errors.New("boom") },
 	}}
 	w := httptest.NewRecorder()
-	s.viewCustomDashboard(w, map[string]any{"Id": "d1", "Name": "Dash", "Description": "desc"})
+	s.viewCustomDashboard(w, httptest.NewRequest(http.MethodGet, "/", nil), map[string]any{"Id": "d1", "Name": "Dash", "Description": "desc"})
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", w.Code)
 	}
@@ -1551,7 +1551,7 @@ func TestViewCustomDashboard_GetChartsError(t *testing.T) {
 func TestViewCustomDashboard_Success(t *testing.T) {
 	s := &server{cfg: config{TemplateDir: "../../../templates"}, db: &storetest.FakeDB{}}
 	w := httptest.NewRecorder()
-	s.viewCustomDashboard(w, map[string]any{"Id": "d1", "Name": "Dash", "Description": "desc"})
+	s.viewCustomDashboard(w, httptest.NewRequest(http.MethodGet, "/", nil), map[string]any{"Id": "d1", "Name": "Dash", "Description": "desc"})
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}

--- a/go/cmd/sobs/coverage_pure_i_test.go
+++ b/go/cmd/sobs/coverage_pure_i_test.go
@@ -291,7 +291,7 @@ func TestSliceI_notifViewRedirect(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			s := &server{cfg: config{BasePath: c.basePath}}
-			got := s.notifViewRedirect(c.editRuleID)
+			got := s.notifViewRedirect(httptest.NewRequest(http.MethodGet, "/", nil), c.editRuleID)
 			if got != c.want {
 				t.Fatalf("notifViewRedirect(base=%q, id=%q) = %q; want %q",
 					c.basePath, c.editRuleID, got, c.want)

--- a/go/cmd/sobs/fix_forms.go
+++ b/go/cmd/sobs/fix_forms.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,8 +13,8 @@ import (
 // url_for("view_notifications", edit_rule=edit_rule_id) when editing (the tag-regex error path),
 // else url_for("view_notifications"). It mirrors render.go's url_for query encoding byte-for-byte
 // (Werkzeug-style QueryEscape with the %3A->: relaxation) so the redirect Location matches Python.
-func (s *server) notifViewRedirect(editRuleID string) string {
-	base := s.cfg.BasePath + "/settings/notifications"
+func (s *server) notifViewRedirect(r *http.Request, editRuleID string) string {
+	base := s.effectiveBasePath(r) + "/settings/notifications"
 	if editRuleID == "" {
 		return base
 	}

--- a/go/cmd/sobs/handlers_datamgmt.go
+++ b/go/cmd/sobs/handlers_datamgmt.go
@@ -184,7 +184,7 @@ func (s *server) handleDataManagementGet(w http.ResponseWriter, r *http.Request)
 	if flashType == "" {
 		flashType = "success"
 	}
-	s.renderPage(w, "settings_data_management.html", "view_dm_settings", map[string]any{
+	s.renderPage(w, r, "settings_data_management.html", "view_dm_settings", map[string]any{
 		"dm_settings":       dm,
 		"dm_secret_present": dmSecretPresent,
 		"flash_msg":         q.Get("msg"), "flash_type": flashType,

--- a/go/cmd/sobs/handlers_forms.go
+++ b/go/cmd/sobs/handlers_forms.go
@@ -824,7 +824,7 @@ func (s *server) buildNotificationConditions(w http.ResponseWriter, r *http.Requ
 				if _, err := compileUserRegex(tagValue, false); err != nil {
 					// app.py:26002-26006: this error redirects to view_notifications carrying
 					// edit_rule=<id> when editing, else the plain location.
-					flashRedirect(w, "warning", "Invalid tag regex pattern: "+err.Error(), s.notifViewRedirect(editRuleID))
+					flashRedirect(w, "warning", "Invalid tag regex pattern: "+err.Error(), s.notifViewRedirect(r, editRuleID))
 					return nil, false
 				}
 			}
@@ -1002,7 +1002,7 @@ func (s *server) handleDashboardsFormSub(w http.ResponseWriter, r *http.Request)
 	dash := rowMaps(res)[0]
 	switch {
 	case r.Method == http.MethodGet && rest == dashID:
-		s.viewCustomDashboard(w, dash)
+		s.viewCustomDashboard(w, r, dash)
 	case rest == dashID+"/delete":
 		s.deleteDashboard(w, dashID, cStr(dash, "Name"), cStr(dash, "Description"))
 	case rest == dashID+"/charts":
@@ -1021,7 +1021,7 @@ func (s *server) handleDashboardsFormSub(w http.ResponseWriter, r *http.Request)
 // viewCustomDashboard mirrors app.py view_custom_dashboard: render custom_dashboard_view.html
 // with the dashboard, its charts (each carrying a rebuilt chart_spec), and the static chart-
 // template catalog (CHART_TEMPLATES sorted by id + _default_chart_spec, embedded as an asset).
-func (s *server) viewCustomDashboard(w http.ResponseWriter, dash map[string]any) {
+func (s *server) viewCustomDashboard(w http.ResponseWriter, r *http.Request, dash map[string]any) {
 	dashID := cStr(dash, "Id")
 	dashboard := map[string]any{
 		"id":          dashID,
@@ -1038,7 +1038,7 @@ func (s *server) viewCustomDashboard(w http.ResponseWriter, dash map[string]any)
 		s.dbError(w, err)
 		return
 	}
-	s.renderPage(w, "custom_dashboard_view.html", "view_custom_dashboard", map[string]any{
+	s.renderPage(w, r, "custom_dashboard_view.html", "view_custom_dashboard", map[string]any{
 		"dashboard": dashboard,
 		"charts":    charts,
 		"templates": templates,

--- a/go/cmd/sobs/handlers_incident_test.go
+++ b/go/cmd/sobs/handlers_incident_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -59,7 +61,7 @@ func renderIncidentHTML(t *testing.T, traceID, service string) string {
 		"time_error":      "",
 		"error_msg":       "",
 	}
-	out, err := s.newEngine().Render("incident.html", ctx)
+	out, err := s.newEngine(httptest.NewRequest(http.MethodGet, "/", nil)).Render("incident.html", ctx)
 	if err != nil {
 		t.Fatalf("render error: %v", err)
 	}

--- a/go/cmd/sobs/handlers_misc.go
+++ b/go/cmd/sobs/handlers_misc.go
@@ -520,7 +520,7 @@ func (s *server) handleApiAiConversation(w http.ResponseWriter, r *http.Request)
 	ctx["item"] = item
 	ctx["from_ts"] = fromTS
 	ctx["to_ts"] = toTS
-	out, rerr := s.newEngine().Render("_ai_conversation_partial.html", ctx)
+	out, rerr := s.newEngine(r).Render("_ai_conversation_partial.html", ctx)
 	if rerr != nil {
 		textStatus(w, http.StatusInternalServerError,
 			"<p class='text-danger small'>Error loading conversation.</p>")

--- a/go/cmd/sobs/handlers_pages.go
+++ b/go/cmd/sobs/handlers_pages.go
@@ -132,7 +132,7 @@ func (s *server) handleSettingsTagsAuto(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	s.renderPageFlash(w, "settings_tags.html", "auto_tag_rules", "info",
+	s.renderPageFlash(w, r, "settings_tags.html", "auto_tag_rules", "info",
 		fmt.Sprintf("Auto-tag preview: %d candidate(s), %d existing skipped, %d invalid.",
 			len(candidates), stats["existing"], stats["invalid"]),
 		map[string]any{
@@ -273,7 +273,7 @@ func (s *server) handleMetricsRulesDashboardAuto(w http.ResponseWriter, r *http.
 	}
 
 	services, signals, sources := s.listDerivedSignalDimensions()
-	s.renderPageFlash(w, "metrics_rules.html", "auto_metrics_rules_dashboard", "info",
+	s.renderPageFlash(w, r, "metrics_rules.html", "auto_metrics_rules_dashboard", "info",
 		fmt.Sprintf("Auto-dashboard preview: %d candidate chart(s) from %d rule(s).",
 			len(candidates), len(rules)),
 		map[string]any{
@@ -400,7 +400,7 @@ func (s *server) handleMetricsRulesAutoPreview(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	s.renderPageFlash(w, "metrics_rules.html", "auto_metrics_rules", "info",
+	s.renderPageFlash(w, r, "metrics_rules.html", "auto_metrics_rules", "info",
 		fmt.Sprintf("Auto-rule preview: %d candidate(s), %d existing skipped, %d invalid.",
 			len(candidates), stats["existing"], stats["invalid"]),
 		map[string]any{
@@ -424,12 +424,12 @@ func textStatus(w http.ResponseWriter, status int, body string) {
 
 // renderPage renders an HTML template with baseContext merged with extra context vars and
 // writes it with Quart's text/html content type.
-func (s *server) renderPage(w http.ResponseWriter, templateName, endpoint string, extra map[string]any) {
+func (s *server) renderPage(w http.ResponseWriter, r *http.Request, templateName, endpoint string, extra map[string]any) {
 	ctx := s.baseContext(endpoint)
 	for k, v := range extra {
 		ctx[k] = v
 	}
-	s.renderInto(w, s.newEngine(), templateName, ctx)
+	s.renderInto(w, s.newEngine(r), templateName, ctx)
 }
 
 // requestArgsContext mirrors Quart's `request` object for templates that read request.args
@@ -454,17 +454,17 @@ func (s *server) renderPageReq(w http.ResponseWriter, r *http.Request, templateN
 	for k, v := range extra {
 		ctx[k] = v
 	}
-	s.renderInto(w, s.newEngine(), templateName, ctx)
+	s.renderInto(w, s.newEngine(r), templateName, ctx)
 }
 
 // renderPageFlash renders a page with a single pre-seeded flash (category, message) consumed
 // by get_flashed_messages — for handlers that flash() then render rather than redirect.
-func (s *server) renderPageFlash(w http.ResponseWriter, templateName, endpoint, flashCategory, flashMessage string, extra map[string]any) {
+func (s *server) renderPageFlash(w http.ResponseWriter, r *http.Request, templateName, endpoint, flashCategory, flashMessage string, extra map[string]any) {
 	ctx := s.baseContext(endpoint)
 	for k, v := range extra {
 		ctx[k] = v
 	}
-	eng := s.newEngineFlash([]any{[]any{flashCategory, flashMessage}})
+	eng := s.newEngineFlash(r, []any{[]any{flashCategory, flashMessage}})
 	// Consuming the flash empties the session, so Quart clears the session cookie and marks
 	// the response Vary: Cookie (it read the request session).
 	w.Header().Set("Set-Cookie", sessionCookieName+"=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0"+sessionCookieAttrs())
@@ -491,7 +491,7 @@ func (s *server) handleViewQuery(w http.ResponseWriter, r *http.Request) {
 		textStatus(w, http.StatusNotFound, "Query page is unavailable until AI and guard settings are configured.")
 		return
 	}
-	s.renderPage(w, "query.html", "view_query", nil)
+	s.renderPage(w, r, "query.html", "view_query", nil)
 }
 
 // GET /table-explorer — app.py view_table_explorer: 404 string when disabled (fixture).
@@ -500,7 +500,7 @@ func (s *server) handleViewTableExplorer(w http.ResponseWriter, r *http.Request)
 		textStatus(w, http.StatusNotFound, "Table Explorer is unavailable until AI and guard settings are configured.")
 		return
 	}
-	s.renderPage(w, "table_explorer.html", "view_table_explorer", nil)
+	s.renderPage(w, r, "table_explorer.html", "view_table_explorer", nil)
 }
 
 // GET /dashboards — app.py list_dashboards: render custom_dashboards.html with the
@@ -538,7 +538,7 @@ func (s *server) handleListDashboards(w http.ResponseWriter, r *http.Request) {
 			"id": cStr(m, "Id"), "name": cStr(m, "Name"), "description": cStr(m, "Description"),
 		})
 	}
-	s.renderPage(w, "custom_dashboards.html", "list_dashboards", map[string]any{"dashboards": dashboards})
+	s.renderPage(w, r, "custom_dashboards.html", "list_dashboards", map[string]any{"dashboards": dashboards})
 }
 
 // GET /reports — app.py list_reports: render reports.html with all reports (_get_reports).
@@ -556,7 +556,7 @@ func (s *server) handleListReportsPage(w http.ResponseWriter, r *http.Request) {
 			"page_type": cStr(m, "PageType"), "filters": parseReportFiltersNative(cStr(m, "FiltersJson")),
 		})
 	}
-	s.renderPage(w, "reports.html", "list_reports", map[string]any{"reports": reports})
+	s.renderPage(w, r, "reports.html", "list_reports", map[string]any{"reports": reports})
 }
 
 // queryAllowedTablesBuiltin mirrors _QUERY_ALLOWED_TABLES_BUILTIN (app.py), pre-sorted. The
@@ -581,7 +581,7 @@ func (s *server) handleViewSettings(w http.ResponseWriter, r *http.Request) {
 	aiSettings := s.loadAllAISettings()
 	kEnabled, _ := s.appSetting("kubernetes.enabled")
 	backup, _ := s.appSetting("data_management.backup_enabled")
-	s.renderPage(w, "settings.html", "view_settings", map[string]any{
+	s.renderPage(w, r, "settings.html", "view_settings", map[string]any{
 		"tag_rule_count":             cnt("sobs_tag_rules"),
 		"anomaly_rule_count":         cnt("sobs_anomaly_rules"),
 		"agent_rule_count":           cnt("sobs_agent_rules"),
@@ -774,7 +774,7 @@ func (s *server) handleViewMetricsRules(w http.ResponseWriter, r *http.Request) 
 		openPanel = ""
 	}
 	services, signals, sources := s.listDerivedSignalDimensions()
-	s.renderPage(w, "metrics_rules.html", "view_metrics_rules", map[string]any{
+	s.renderPage(w, r, "metrics_rules.html", "view_metrics_rules", map[string]any{
 		"rules":                  s.loadAnomalyRulesCtx(),
 		"services":               services,
 		"signals":                signals,
@@ -919,7 +919,7 @@ func (s *server) handleViewNotifications(w http.ResponseWriter, r *http.Request)
 		vapidKeyAny = vapidPublicKey
 		vapidSourceAny = vapidKeySource
 	}
-	s.renderPage(w, "settings_notifications.html", "view_notifications", map[string]any{
+	s.renderPage(w, r, "settings_notifications.html", "view_notifications", map[string]any{
 		"channels":            s.loadNotificationChannels(),
 		"rules":               rules,
 		"notification_log":    s.loadNotificationLog(50),
@@ -1067,7 +1067,7 @@ func (s *server) handleViewEnrichmentCve(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	s.renderPage(w, "cve.html", "view_enrichment_cve", map[string]any{
+	s.renderPage(w, r, "cve.html", "view_enrichment_cve", map[string]any{
 		"cve_enabled":                  cveEnabled,
 		"cve_last_scan":                cveLastScan,
 		"github_backfill_max_releases": maxRel,
@@ -1161,7 +1161,7 @@ func (s *server) handleViewWorkItemsPage(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	s.renderPage(w, "work_items.html", "view_work_items", map[string]any{
+	s.renderPage(w, r, "work_items.html", "view_work_items", map[string]any{
 		"items": items, "total_items": totalItems, "services": services, "rules": rules,
 		"service_filter": serviceFilter, "rule_filter": ruleFilter,
 		"action_type_filter": actionTypeFilter, "status_filter": statusFilter,
@@ -1637,7 +1637,7 @@ func (s *server) handleViewAi(w http.ResponseWriter, r *http.Request) {
 	// saved/confirmed), NOT a static blob — observed models like claude-opus must appear as inferred.
 	aiPricing, aiPricingSources := s.loadAiPricingWithSources()
 
-	s.renderPage(w, "ai.html", "view_ai", map[string]any{
+	s.renderPage(w, r, "ai.html", "view_ai", map[string]any{
 		"ai_items": aiItems, "total": total, "limit": limit, "offset": offset,
 		"service": service, "selected_services": toAnySlice(selectedServices),
 		"model": model, "selected_models": toAnySlice(selectedModels),
@@ -1740,7 +1740,7 @@ func (s *server) handleViewIncident(w http.ResponseWriter, r *http.Request) {
 
 	// ── No incident reference: empty render (the corpus-tested branch) ──────────
 	if traceID == "" && errorID == "" && rumSession == "" {
-		s.renderPage(w, "incident.html", "view_incident", map[string]any{
+		s.renderPage(w, r, "incident.html", "view_incident", map[string]any{
 			"trace_id": "", "error_id": "", "rum_session": "", "rum_ts": "",
 			"primary_error": nil, "primary_trace": nil, "primary_rum": nil,
 			"service": "", "from_ts": "", "to_ts": "", "window_minutes": windowMinutes,
@@ -2072,7 +2072,7 @@ func (s *server) handleViewIncident(w http.ResponseWriter, r *http.Request) {
 
 	errorMsg := timeError
 
-	s.renderPage(w, "incident.html", "view_incident", map[string]any{
+	s.renderPage(w, r, "incident.html", "view_incident", map[string]any{
 		"trace_id":                 traceID,
 		"error_id":                 errorID,
 		"rum_session":              rumSession,
@@ -2281,7 +2281,7 @@ func (s *server) handleViewMetricsAnomaly(w http.ResponseWriter, r *http.Request
 
 	services, signals, sources := s.listDerivedSignalDimensions()
 
-	s.renderPage(w, "metrics_anomaly.html", "view_metrics_anomaly", map[string]any{
+	s.renderPage(w, r, "metrics_anomaly.html", "view_metrics_anomaly", map[string]any{
 		"rows": rowsToAny(rows), "total": len(rows),
 		"service": service, "metric": metric, "signal": signal, "source": source,
 		"attr_fp": attrFp, "from_ts": fromTs, "to_ts": toTs, "hours": hours, "error_msg": errorMsg,
@@ -2740,7 +2740,7 @@ func (s *server) handleViewMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	services, signals, sources := s.listDerivedSignalDimensions()
-	s.renderPage(w, "metrics.html", "view_metrics", map[string]any{
+	s.renderPage(w, r, "metrics.html", "view_metrics", map[string]any{
 		"rows": rows, "total": total, "limit": limit, "offset": offset,
 		"service": service, "selected_services": strsToAny(selectedServices),
 		"signal": signal, "selected_signals": strsToAny(selectedSignals),
@@ -2869,7 +2869,7 @@ func (s *server) handleViewTraces(w http.ResponseWriter, r *http.Request) {
 		errorMsg = timeError
 	}
 
-	s.renderPage(w, "traces.html", "view_traces", map[string]any{
+	s.renderPage(w, r, "traces.html", "view_traces", map[string]any{
 		"spans": spans, "total": total, "limit": limit, "offset": offset,
 		"service": service, "selected_services": strsToAny(selectedServices), "trace_id": traceID,
 		"from_ts": fromTS, "to_ts": toTS, "error_msg": errorMsg, "q": qParam, "services": services,
@@ -3197,7 +3197,7 @@ func (s *server) handleViewErrors(w http.ResponseWriter, r *http.Request) {
 	}
 	workItemLinks := s.loadWorkItemLinksForRefIDs(refIDs)
 
-	s.renderPage(w, "errors.html", "view_errors", map[string]any{
+	s.renderPage(w, r, "errors.html", "view_errors", map[string]any{
 		"errors": errors, "total": total, "limit": limit, "offset": offset,
 		"service": service, "selected_services": toAnySlice(selectedServices),
 		"from_ts": fromTs, "to_ts": toTs, "error_msg": errorMsg, "q": q, "resolved": resolved,
@@ -3315,7 +3315,7 @@ func (s *server) handleSummary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.renderPage(w, "summary.html", "summary", map[string]any{
+	s.renderPage(w, r, "summary.html", "summary", map[string]any{
 		"stats":         stats,
 		"recent_errors": recentErrors,
 		"recent_logs":   recentLogs,
@@ -3359,7 +3359,7 @@ func (s *server) handleViewWebTraffic(w http.ResponseWriter, r *http.Request) {
 			eventTypes = append(eventTypes, []any{cStr(m, "EventName"), cInt(m, "cnt")})
 		}
 	}
-	s.renderPage(w, "web_traffic.html", "view_web_traffic", map[string]any{
+	s.renderPage(w, r, "web_traffic.html", "view_web_traffic", map[string]any{
 		"total": total, "top_urls": topUrls, "event_types": eventTypes,
 		"from_ts": fromTs, "to_ts": toTs, "error_msg": timeError,
 		"geo_enabled": s.appSettingBool("enrichment.geo_enabled", true),
@@ -3373,7 +3373,7 @@ func (s *server) handleViewAgentRules(w http.ResponseWriter, r *http.Request) {
 		s.createAgentRule(w, r)
 		return
 	}
-	s.renderPage(w, "settings_agents.html", "view_agent_rules", map[string]any{
+	s.renderPage(w, r, "settings_agents.html", "view_agent_rules", map[string]any{
 		"rules":          s.loadAgentRulesCtx(),
 		"runs":           s.loadAgentRunsCtx(20),
 		"anomaly_rules":  s.loadAnomalyRulesCtx(),
@@ -3566,7 +3566,7 @@ func (s *server) handleMcpSettingsPage(w http.ResponseWriter, r *http.Request) {
 	if v, ok := s.appSetting("mcp.enabled"); ok {
 		enabled = v == "1"
 	}
-	s.renderPage(w, "settings_mcp.html", "mcp.mcp_settings_page", map[string]any{
+	s.renderPage(w, r, "settings_mcp.html", "mcp.mcp_settings_page", map[string]any{
 		"mcp_keys": s.mcpSafeKeys(), "mcp_enabled": enabled, "now_iso": "2024-01-02T03:04:05+00:00",
 	})
 }
@@ -3612,10 +3612,10 @@ func (s *server) handleViewTagRules(w http.ResponseWriter, r *http.Request) {
 		"auto_preview":    []any{}, "auto_summary": nil, "auto_open_panel": openPanel,
 	}
 	if editNotFound {
-		s.renderPageFlash(w, "settings_tags.html", "view_tag_rules", "warning", "Tag rule not found for editing", ctx)
+		s.renderPageFlash(w, r, "settings_tags.html", "view_tag_rules", "warning", "Tag rule not found for editing", ctx)
 		return
 	}
-	s.renderPage(w, "settings_tags.html", "view_tag_rules", ctx)
+	s.renderPage(w, r, "settings_tags.html", "view_tag_rules", ctx)
 }
 
 // GET /settings/ai — app.py view_ai_settings. Empty AI settings -> all keys "".
@@ -3720,7 +3720,7 @@ func (s *server) handleViewAiSettings(w http.ResponseWriter, r *http.Request) {
 	expiresAt := strings.TrimSpace(all["ai.github_token_expires_at"])
 	defPricing, _ := parseJSONValue(defaultAiPricingJSON)
 	savedPricing, sources := s.loadAiPricingWithSources()
-	s.renderPage(w, "settings_ai.html", "view_ai_settings", map[string]any{
+	s.renderPage(w, r, "settings_ai.html", "view_ai_settings", map[string]any{
 		"settings":                   settings,
 		"anomaly_rules":              s.loadAnomalyRulesCtx(),
 		"tag_rules":                  s.loadTagRulesCtx(),
@@ -3816,7 +3816,7 @@ func (s *server) handleViewSettingsRepositories(w http.ResponseWriter, r *http.R
 		}
 	}
 	expiresAt := strings.TrimSpace(s.loadAISetting("ai.github_token_expires_at", ""))
-	s.renderPage(w, "settings_repositories.html", "view_settings_repositories", map[string]any{
+	s.renderPage(w, r, "settings_repositories.html", "view_settings_repositories", map[string]any{
 		"apps":                       apps,
 		"github_token_configured":    strings.TrimSpace(s.loadAISetting("ai.github_token", "")) != "",
 		"default_agent_repo":         strings.TrimSpace(s.loadAISetting("ai.github_repo", "")),
@@ -3856,7 +3856,7 @@ func (s *server) handleViewK8sSettings(w http.ResponseWriter, r *http.Request) {
 	if msgType == "" {
 		msgType = "success"
 	}
-	s.renderPage(w, "settings_kubernetes.html", "view_k8s_settings", map[string]any{
+	s.renderPage(w, r, "settings_kubernetes.html", "view_k8s_settings", map[string]any{
 		"k8s_settings": map[string]any{"kubernetes.enabled": val},
 		"flash_msg":    r.URL.Query().Get("msg"),
 		"flash_type":   msgType,
@@ -3899,7 +3899,7 @@ func (s *server) handleViewEnrichmentSettings(w http.ResponseWriter, r *http.Req
 			maxRel = n
 		}
 	}
-	s.renderPage(w, "settings_enrichment.html", "view_enrichment_settings", map[string]any{
+	s.renderPage(w, r, "settings_enrichment.html", "view_enrichment_settings", map[string]any{
 		"geo_enabled":                        s.appSettingBool("enrichment.geo_enabled", true),
 		"cve_enabled":                        s.appSettingBool("enrichment.cve_enabled", true),
 		"cve_last_scan":                      cveLastScan,
@@ -3930,7 +3930,7 @@ func (s *server) handleViewMaskingSettings(w http.ResponseWriter, r *http.Reques
 	for _, k := range customKeys {
 		keySet[k] = true
 	}
-	s.renderPage(w, "settings_masking.html", "view_masking_settings", map[string]any{
+	s.renderPage(w, r, "settings_masking.html", "view_masking_settings", map[string]any{
 		"custom_keys":                strsToAny(customKeys),
 		"custom_patterns":            strsToAny(customPatterns),
 		"default_keys":               strsToAny(defaultKeys),
@@ -3948,13 +3948,13 @@ func (s *server) handleViewKubernetes(w http.ResponseWriter, r *http.Request) {
 		textStatus(w, http.StatusNotFound, "Kubernetes health view is disabled. Enable it in Settings → Kubernetes.")
 		return
 	}
-	s.renderPage(w, "kubernetes.html", "view_kubernetes", nil)
+	s.renderPage(w, r, "kubernetes.html", "view_kubernetes", nil)
 }
 
 // GET /dashboards/new — app.py new_dashboard_form: render custom_dashboards.html with an
 // empty dashboards list and the new-form flag.
 func (s *server) handleNewDashboardForm(w http.ResponseWriter, r *http.Request) {
-	s.renderPage(w, "custom_dashboards.html", "new_dashboard_form", map[string]any{
+	s.renderPage(w, r, "custom_dashboards.html", "new_dashboard_form", map[string]any{
 		"dashboards":    []any{},
 		"show_new_form": true,
 	})

--- a/go/cmd/sobs/handlers_rum.go
+++ b/go/cmd/sobs/handlers_rum.go
@@ -332,7 +332,7 @@ func (s *server) handleViewRum(w http.ResponseWriter, r *http.Request) {
 		toVar = toTS
 	}
 
-	s.renderPage(w, "rum.html", "view_rum", map[string]any{
+	s.renderPage(w, r, "rum.html", "view_rum", map[string]any{
 		"events": events, "session_groups": sessionGroups, "total": total,
 		"limit": limit, "offset": offset, "view_mode": viewMode,
 		"event_type": eventType, "event_types": eventTypes, "error_source": errorSource, "error_sources": errorSources,

--- a/go/cmd/sobs/handlers_rum_asset.go
+++ b/go/cmd/sobs/handlers_rum_asset.go
@@ -225,7 +225,7 @@ func (s *server) handleRumAssetUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	assetURL, _ := s.urlFor([]any{"rum_asset_download"}, map[string]any{"asset_id": assetID}, []string{"asset_id"})
+	assetURL, _ := s.urlFor(s.effectiveBasePath(r), []any{"rum_asset_download"}, map[string]any{"asset_id": assetID}, []string{"asset_id"})
 	writeJSON(w, http.StatusCreated, jsonenc.NewObject().
 		Set("id", assetID).
 		Set("type", assetType).

--- a/go/cmd/sobs/main.go
+++ b/go/cmd/sobs/main.go
@@ -98,7 +98,7 @@ func loadConfig() config {
 		SecretKey:        envOr("SOBS_SECRET_KEY", "sobs-dev-secret-key"),
 		EncryptionSecret: readEnvOrFile("SOBS_SETTINGS_ENCRYPTION_KEY", "SOBS_SETTINGS_ENCRYPTION_KEY_FILE"),
 		BuildVersion:     envOr("SOBS_BUILD_VERSION", "dev"),
-		BasePath:         os.Getenv("SOBS_BASE_PATH"),
+		BasePath:         normalizeBasePath(os.Getenv("SOBS_BASE_PATH")),
 		// app.py: _env_flag("SOBS_ENABLE_FIRST_RUN_TOUR", True) — default ON, {1,true,yes,on}.
 		FirstRunTourEnabled: envFlag("SOBS_ENABLE_FIRST_RUN_TOUR", true),
 	}

--- a/go/cmd/sobs/render.go
+++ b/go/cmd/sobs/render.go
@@ -33,19 +33,22 @@ func pyTitle(s string) string {
 	return strings.Title(strings.ToLower(s)) //nolint:staticcheck
 }
 
-// newEngine builds the template engine with the globals the templates call.
-func (s *server) newEngine() *render.Engine { return s.newEngineFlash(nil) }
+// newEngine builds the template engine with the globals the templates call. r resolves the
+// effective base path (X-Forwarded-Prefix, falling back to SOBS_BASE_PATH — see
+// basepath.go) for this request's url_for/static links.
+func (s *server) newEngine(r *http.Request) *render.Engine { return s.newEngineFlash(r, nil) }
 
 // newEngineFlash is newEngine with pre-seeded flash messages (each []any{category, message})
 // that get_flashed_messages consumes — for handlers that flash() then render a page (rather
 // than redirect), e.g. the auto-rule preview pages.
-func (s *server) newEngineFlash(flashes []any) *render.Engine {
+func (s *server) newEngineFlash(r *http.Request, flashes []any) *render.Engine {
 	e := render.New(s.cfg.TemplateDir)
 	// Custom `mask` filter (app.py _mask_value_for_output): redacts sensitive keys/patterns
 	// per the active DLP rules. Depends on per-request settings, so install it here.
 	e.SetMaskFunc(s.maskValueForOutput)
+	base := s.effectiveBasePath(r)
 	e.AddFunc("url_for", func(pos []any, kw map[string]any) (any, error) {
-		return s.urlFor(pos, kw, e.KWOrder())
+		return s.urlFor(base, pos, kw, e.KWOrder())
 	})
 	// fmt_bytes (app.py _fmt_bytes): human-readable byte count, passed to the DM-stats page.
 	e.AddFunc("fmt_bytes", func(pos []any, kw map[string]any) (any, error) {
@@ -100,15 +103,18 @@ func argStr(pos []any, i int) string {
 }
 
 // urlFor mirrors Quart's url_for for the cases the templates use: a named endpoint
-// (optionally with path params) and the special 'static' endpoint with a filename.
-func (s *server) urlFor(pos []any, kw map[string]any, kwOrder []string) (any, error) {
+// (optionally with path params) and the special 'static' endpoint with a filename. base is
+// the effective base path for the current request (see basepath.go's effectiveBasePath) —
+// NOT s.cfg.BasePath directly, since a reverse proxy's X-Forwarded-Prefix can override it
+// per-request.
+func (s *server) urlFor(base string, pos []any, kw map[string]any, kwOrder []string) (any, error) {
 	if len(pos) == 0 {
 		return "", fmt.Errorf("url_for requires an endpoint")
 	}
 	endpoint, _ := pos[0].(string)
 	if endpoint == "static" {
 		fn, _ := kw["filename"].(string)
-		return s.cfg.BasePath + "/static/" + fn, nil
+		return base + "/static/" + fn, nil
 	}
 	rule, ok := endpointPaths[endpoint]
 	if !ok {
@@ -130,7 +136,7 @@ func (s *server) urlFor(pos []any, kw map[string]any, kwOrder []string) (any, er
 			qs = append(qs, werkzeugQueryEscape(k)+"="+werkzeugQueryEscape(v))
 		}
 	}
-	out := s.cfg.BasePath + rule
+	out := base + rule
 	if len(qs) > 0 {
 		out += "?" + strings.Join(qs, "&")
 	}
@@ -196,7 +202,7 @@ func (s *server) baseContext(endpoint string) map[string]any {
 // endpoint is the Quart endpoint name (used by base.html nav-active logic).
 func (s *server) handleHelpPage(endpoint, templateName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		eng := s.newEngine()
+		eng := s.newEngine(r)
 		out, err := eng.Render(templateName, s.baseContext(endpoint))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -97,6 +97,7 @@ func (s *server) enqueueWrite(op func() error) error {
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r = s.applyBasePath(r)
 	rec := &headerCapture{ResponseWriter: w, req: r, cfg: s.cfg}
 	// Optional auth layers (no-ops unless SOBS_API_KEY / SOBS_BASIC_AUTH_* / SOBS_EXTERNAL_AUTH_URL
 	// are set), written through rec so blocking responses still carry the security headers. Routed


### PR DESCRIPTION
Caught testing behind pab-admin's reverse proxy: static asset links (and other generated URLs) weren't rewritten to the proxied path at all.

README.md has claimed *"For reverse proxies, SOBS also honors `X-Forwarded-Prefix` for URL generation and prefixed routing"* since the Python app (added in "Fix #14: add base-path aware URL generation and routing", commit `2d54345`), but the Go rewrite never actually ported the behavior:

- `url_for`/redirect targets read only the static `SOBS_BASE_PATH` env var (config-load-time, whole-process), never the per-request `X-Forwarded-Prefix` header a proxy sends.
- Inbound routing had no base-path awareness at all: `/static/` was registered bare, so a proxy that forwards the prefix un-stripped (e.g. `GET /insights/static/x.css`) 404'd outright.

**Fix** (`cmd/sobs/basepath.go`) ports `app.py`'s `BasePathMiddleware`:
- `normalizeBasePath` mirrors `_normalize_base_path`.
- `effectiveBasePath(r)` mirrors `effective_base = forwarded or BASE_PATH`: `X-Forwarded-Prefix`, when present, overrides the static `SOBS_BASE_PATH` per request.
- `applyBasePath(r)`, wired into `ServeHTTP` before `authGate`/routing, mirrors the three `PATH_INFO` cases the WSGI middleware handled (exact match -> `/`, prefix+`/...` -> strip it, otherwise pass through untouched — covering both "proxy forwards prefix unstripped" and "proxy already stripped it" deployments).

`url_for`/`newEngine`/`renderPage`/`notifViewRedirect`/`viewCustomDashboard` now thread `*http.Request` through (all had it in scope already) instead of reading `s.cfg.BasePath` directly.

**Verified:**
- New `basepath_test.go`: unit tests for each piece, plus an end-to-end `TestRenderPage_ForwardedPrefixRewritesLinks` that renders a real page with an `X-Forwarded-Prefix` header and asserts the actual rewritten nav/static links in the output (and that root-mode rendering still emits unprefixed links).
- `go test ./...` and a full golden-corpus replay (776/776 green) both clean — no route relies on any proxy header, so this is purely additive.