### PR TITLE
ci: stop tag pushes from unconditionally moving :latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,9 +265,19 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
+          # flavor.latest defaults to "auto", under which the type=ref,event=tag rule
+          # hardcodes latest=true for ANY tag push (metadata-action's procRefTag: `flavor.latest
+          # == 'auto' ? true : ...`) — this wins over the explicit enable= gate below regardless
+          # of its value, because whichever tag rule runs first (by priority: ref > raw > sha)
+          # sets the shared "should this build also get retagged latest" flag, and the ref rule
+          # always claims it. Confirmed empirically: tagging v0.2.0-beta.3 off go-main (not
+          # main) still produced a `latest` tag. Disable that blanket auto-latest and drive
+          # `latest` from the explicit raw rule alone.
+          flavor: |
+            latest=false
           tags: |
             type=sha,prefix=,format=long
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
             type=ref,event=tag
 
       - name: Build and push multi-arch Docker image


### PR DESCRIPTION
Fixes the `latest`-tag-moves-on-every-beta-tag bug hit repeatedly this session (v0.2.0-beta.1/.2/.3, all cut off `go-main`).

Root cause: `docker/metadata-action`'s `flavor.latest` defaults to `auto`, under which its `type=ref,event=tag` rule (`procRefTag`) hardcodes `latest=true` for **any** tag push — this wins over the explicit `enable={{is_default_branch}}` gate on the raw rule regardless of its value, because whichever tag rule runs first by priority (ref \> raw \> sha) sets the shared "also retag latest" flag. `is_default_branch` itself was a red herring — it's genuinely (and correctly) false for a tag ref; it just was never the actual mechanism producing `latest`.

Fix: `flavor: latest=false` kills the blanket auto-latest, and the explicit raw rule now gates on a real GitHub Actions expression (`github.ref == refs/heads/main || refs/heads/master`) evaluated before the action runs, rather than metadata-action's own always-false-for-tags handlebars variable.

v* tags still get their own version + sha tags unchanged — they just no longer also silently move `:latest`.

No other CI/functional blockers found in a full sweep: `main`'s branch protection has no required status checks configured (so no stale-job-name risk post-merge), and `codeql.yml`/`dependency-review.yml`/`dependabot.yml` are already Go-only and clean.