### PR TITLE
fix: reject a leading /\ in normalizeBasePath (CWE-601 open redirect)

### DIFF
--- a/go/cmd/sobs/basepath.go
+++ b/go/cmd/sobs/basepath.go
@@ -20,6 +20,14 @@ var repeatedSlashes = regexp.MustCompile(`/+`)
 
 // normalizeBasePath mirrors app.py's _normalize_base_path: collapse repeated slashes, ensure a
 // single leading slash and no trailing slash; "" and "/" both normalize to "" (no base path).
+//
+// This is the single chokepoint both effectiveBasePath (redirects, url_for-generated links) and
+// applyBasePath (inbound routing) go through, so it's also where an X-Forwarded-Prefix value —
+// attacker-controlled if SOBS is ever reached without a trusted proxy overwriting that header —
+// must be rejected as an open-redirect vector (CWE-601) rather than passed through. Collapsing
+// repeated slashes above already defuses the classic "//evil.com" case, but browsers also treat
+// a leading "/\" as protocol-relative (e.g. "/\evil.com" parses like "//evil.com"), so that
+// pattern needs an explicit reject too — CodeQL go/bad-redirect-check flagged exactly this gap.
 func normalizeBasePath(v string) string {
 	v = repeatedSlashes.ReplaceAllString(strings.TrimSpace(v), "/")
 	if v == "" || v == "/" {
@@ -27,6 +35,9 @@ func normalizeBasePath(v string) string {
 	}
 	if !strings.HasPrefix(v, "/") {
 		v = "/" + v
+	}
+	if len(v) > 1 && v[1] == '\\' {
+		return ""
 	}
 	v = strings.TrimSuffix(v, "/")
 	if v == "" || v == "/" {

--- a/go/cmd/sobs/basepath_test.go
+++ b/go/cmd/sobs/basepath_test.go
@@ -19,6 +19,11 @@ func TestNormalizeBasePath(t *testing.T) {
 		{"/sobs/", "/sobs"},
 		{"//sobs//nested//", "/sobs/nested"},
 		{"  /sobs  ", "/sobs"},
+		// CWE-601: a leading "/\" is browser-protocol-relative just like "//" (CodeQL
+		// go/bad-redirect-check) — reject it rather than let it flow into a redirect Location.
+		{"/\\evil.com", ""},
+		{"\\evil.com", ""},
+		{"/\\\\evil.com", ""},
 	}
 	for _, c := range cases {
 		if got := normalizeBasePath(c.in); got != c.want {


### PR DESCRIPTION
Fixes CodeQL [go/bad-redirect-check](https://github.com/abartrim/sobs/security/code-scanning/51), flagged as an unresolved conversation blocking PR #352's merge.

`normalizeBasePath` already collapses `//` (via `repeatedSlashes`), defusing the classic open-redirect pattern, but let a leading `/\\` through unchanged. Some browsers treat `/\\evil.com` as protocol-relative, identically to `//evil.com`. This value flows from `X-Forwarded-Prefix` (attacker-controlled if SOBS is ever reached without a trusted proxy overwriting that header) through `effectiveBasePath` into `notifViewRedirect`'s `Location` header — a genuine CWE-601 gap, not a false positive.

Fixed at the `normalizeBasePath` chokepoint, so it covers both inbound routing (`applyBasePath`) and outbound redirects/links (`effectiveBasePath`, `url_for`) in one place. Added 3 test cases to the existing table-driven `TestNormalizeBasePath`.