### PR TITLE
fix: combine leading-slash + //\\ rejection into one CodeQL-legible check

### DIFF
--- a/go/cmd/sobs/basepath.go
+++ b/go/cmd/sobs/basepath.go
@@ -36,7 +36,11 @@ func normalizeBasePath(v string) string {
 	if !strings.HasPrefix(v, "/") {
 		v = "/" + v
 	}
-	if len(v) > 1 && v[1] == '\\' {
+	// A leading-slash check alone is an incomplete redirect-target guard (CWE-601): browsers treat
+	// both "//" and "/\" as protocol-relative absolute URLs. repeatedSlashes above already makes
+	// "//" unreachable here, but check both together explicitly so this guard is self-evidently
+	// complete rather than relying on that as an implicit invariant.
+	if len(v) < 2 || v[0] != '/' || v[1] == '/' || v[1] == '\\' {
 		return ""
 	}
 	v = strings.TrimSuffix(v, "/")


### PR DESCRIPTION
Follow-up to #439. CodeQL re-flagged the same `HasPrefix` line on PR #352 after that fix merged — its `go/bad-redirect-check` rule wants the leading-slash guard and the "second char isn't / or \\" rejection in the SAME conditional (matching its own documented remediation example), not a separate follow-up statement even though it's behaviorally identical. Restructured into one combined check.