### PR TITLE
Pre-seed MCP API key from SOBS_MCP_API_KEY on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,19 @@ MCP endpoints use a separate key mechanism from the ingest API key.
 Keys are stored as scrypt-derived fingerprints in `sobs_app_settings` (never stored in plain text).
 The scrypt salt is derived from the installation's `SOBS_SECRET_KEY`, so fingerprints are unique per deployment.
 
+#### Pre-seeding a key from the environment
+
+For local dev and CI/agent setups where clicking through **Settings → MCP** isn't practical, set
+`SOBS_MCP_API_KEY` before startup and the server registers it as a valid key automatically:
+
+```bash
+SOBS_MCP_API_KEY=my-local-dev-key sobs
+```
+
+The raw value can be any string — it's fingerprinted with the same scrypt hash as a
+UI-generated key. Seeding is idempotent (restarting with the same value doesn't create a
+duplicate key) and additive (it never replaces or revokes keys created through the UI).
+
 ### VS Code / GitHub Copilot configuration
 
 Add to `.vscode/mcp.json` (or your Copilot agent config):
@@ -544,6 +557,7 @@ The Work Items page is intended to make these decisions visible so operators can
 |-----------------------------|----------------|--------------------------------------------------|
 | `SOBS_DATA_DIR`             | `./data`       | Directory for embedded chDB state                |
 | `SOBS_API_KEY`              | _(empty)_      | Optional auth key for ingest endpoints           |
+| `SOBS_MCP_API_KEY`          | _(empty)_      | Optional MCP API key pre-seeded into the key store on startup (local dev / agent access, see [MCP Endpoints](#mcp-endpoints-copilot--ai-agent-access)) |
 | `SOBS_BASIC_AUTH_USERNAME`  | _(empty)_      | Optional Basic Auth username for the Web UI      |
 | `SOBS_BASIC_AUTH_PASSWORD`  | _(empty)_      | Optional Basic Auth password for the Web UI      |
 | `SOBS_EXTERNAL_AUTH_URL`    | _(empty)_      | Optional external Bearer validator for the Web UI |

--- a/go/cmd/sobs/mcp_key_seed.go
+++ b/go/cmd/sobs/mcp_key_seed.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/hex"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+)
+
+// mcpAPIKeyEnvVar pre-seeds a usable MCP API key at startup from the environment, so local dev
+// setups and agents can authenticate against X-MCP-API-Key immediately without a manual
+// POST /api/mcp/keys round-trip through the UI.
+const mcpAPIKeyEnvVar = "SOBS_MCP_API_KEY"
+
+// seedMcpAPIKeyFromEnv registers SOBS_MCP_API_KEY (when set) in the mcp.api_keys keystore, using
+// the same descriptor shape and scrypt hash (hashMcpKey) as a key minted via mcpAPIKeysCreate.
+// No-op when the env var is unset. Idempotent across restarts: keyed by the raw key's hash, so
+// re-seeding the same value never appends a duplicate descriptor.
+func (s *server) seedMcpAPIKeyFromEnv() {
+	rawKey := strings.TrimSpace(os.Getenv(mcpAPIKeyEnvVar))
+	if rawKey == "" || s.db == nil {
+		return
+	}
+	keyHash := hashMcpKey(rawKey)
+	keys := s.loadMcpAPIKeys()
+	for _, e := range keys {
+		if o, ok := e.(*jsonenc.Object); ok && objGetStr(o, "key_hash") == keyHash {
+			return
+		}
+	}
+	if len(keys) >= mcpAPIKeyMax {
+		log.Printf("mcp: %s is set but the key cap (%d) is already reached; skipping seed", mcpAPIKeyEnvVar, mcpAPIKeyMax)
+		return
+	}
+	descriptor := jsonenc.NewObject().
+		Set("id", hex.EncodeToString(randBytes(8))).
+		Set("label", "Environment ("+mcpAPIKeyEnvVar+")").
+		Set("key_hash", keyHash).
+		Set("created_at", nowUTC().Format("2006-01-02T15:04:05Z")).
+		Set("expires_at", nil)
+	s.saveMcpAPIKeys(append(keys, any(descriptor)))
+	log.Printf("mcp: seeded API key from %s", mcpAPIKeyEnvVar)
+}

--- a/go/cmd/sobs/mcp_key_seed_test.go
+++ b/go/cmd/sobs/mcp_key_seed_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sobs/sobs/internal/jsonenc"
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+// seedMcpAPIKeyFromEnv only runs when SOBS_MCP_API_KEY is set, which the byte-parity corpus never
+// does — so it is corpus-unreachable. Drive it directly.
+
+func TestSeedMcpAPIKeyFromEnv_UnsetEnv_NoOp(t *testing.T) {
+	fake := storetest.SettingsDB(map[string]string{})
+	(&server{db: fake}).seedMcpAPIKeyFromEnv()
+	if len(fake.Inserts) != 0 {
+		t.Fatalf("unset env: want no inserts, got %v", fake.Inserts)
+	}
+}
+
+func TestSeedMcpAPIKeyFromEnv_SeedsNewKey(t *testing.T) {
+	t.Setenv("SOBS_MCP_API_KEY", "test-raw-key")
+	fake := storetest.SettingsDB(map[string]string{})
+	s := &server{db: fake}
+	s.seedMcpAPIKeyFromEnv()
+
+	if len(fake.Inserts) != 1 {
+		t.Fatalf("want 1 insert, got %d: %v", len(fake.Inserts), fake.Inserts)
+	}
+	saved := fake.Inserts[0].Rows[0]["Value"].(string)
+	v, err := parseJSONValue([]byte(saved))
+	if err != nil {
+		t.Fatalf("saved value not valid JSON: %v", err)
+	}
+	list, ok := v.([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("want a 1-element list, got %v", v)
+	}
+	o, ok := list[0].(*jsonenc.Object)
+	if !ok {
+		t.Fatalf("want a *jsonenc.Object descriptor, got %T", list[0])
+	}
+	if got, want := objGetStr(o, "key_hash"), hashMcpKey("test-raw-key"); got != want {
+		t.Fatalf("key_hash = %q, want %q", got, want)
+	}
+	if objGetStr(o, "id") == "" {
+		t.Fatalf("want a non-empty id")
+	}
+}
+
+func TestSeedMcpAPIKeyFromEnv_AlreadySeeded_NoOp(t *testing.T) {
+	t.Setenv("SOBS_MCP_API_KEY", "test-raw-key")
+	existing := jsonenc.NewObject().
+		Set("id", "abc123").
+		Set("label", "Environment (SOBS_MCP_API_KEY)").
+		Set("key_hash", hashMcpKey("test-raw-key")).
+		Set("created_at", "2026-01-01T00:00:00Z").
+		Set("expires_at", nil)
+	raw := string(jsonenc.Encode([]any{existing}, jsonDumpsDefault))
+	fake := storetest.SettingsDB(map[string]string{"mcp.api_keys": raw})
+	(&server{db: fake}).seedMcpAPIKeyFromEnv()
+
+	if len(fake.Inserts) != 0 {
+		t.Fatalf("already-seeded key: want no inserts, got %v", fake.Inserts)
+	}
+}
+
+func TestSeedMcpAPIKeyFromEnv_AtCap_NoOp(t *testing.T) {
+	t.Setenv("SOBS_MCP_API_KEY", "test-raw-key")
+	var keys []any
+	for i := 0; i < mcpAPIKeyMax; i++ {
+		keys = append(keys, any(jsonenc.NewObject().
+			Set("id", "id").
+			Set("label", "l").
+			Set("key_hash", "not-the-seed-hash").
+			Set("created_at", "2026-01-01T00:00:00Z").
+			Set("expires_at", nil)))
+	}
+	raw := string(jsonenc.Encode(keys, jsonDumpsDefault))
+	fake := storetest.SettingsDB(map[string]string{"mcp.api_keys": raw})
+	(&server{db: fake}).seedMcpAPIKeyFromEnv()
+
+	if len(fake.Inserts) != 0 {
+		t.Fatalf("at cap: want no inserts, got %v", fake.Inserts)
+	}
+}
+
+func TestSeedMcpAPIKeyFromEnv_NilDB_NoOp(t *testing.T) {
+	t.Setenv("SOBS_MCP_API_KEY", "test-raw-key")
+	(&server{}).seedMcpAPIKeyFromEnv() // must not panic on a nil s.db
+}

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -76,6 +76,9 @@ func newServer(cfg config) *server {
 	s.applyRawMetricsRetention()
 	// Seed the app/release/artifact registry from SOBS_APP_REGISTRY_SEED_JSON (no-op when unset).
 	s.seedAppRegistry()
+	// Pre-seed an MCP API key from SOBS_MCP_API_KEY (no-op when unset) — local dev / agent access
+	// without a manual POST /api/mcp/keys round-trip.
+	s.seedMcpAPIKeyFromEnv()
 	// Background DB writer (app.py _ensure_write_worker), via the newWriteQueue provider seam
 	// (providers.go) — the writeQueuer analog of openStore/authGate. The writer's ops use s.db, so
 	// start it only after the store is opened. Under parity, ingest writes are awaited


### PR DESCRIPTION
## Summary
- Adds `seedMcpAPIKeyFromEnv`, called from `newServer` on startup: when `SOBS_MCP_API_KEY` is set, it's scrypt-hashed via the same `hashMcpKey` path used by the `POST /api/mcp/keys` UI flow and registered in the `mcp.api_keys` keystore.
- Purpose: local dev setups and agents get a working `X-MCP-API-Key` immediately, without a manual key-creation round-trip through Settings → MCP.
- No-op when the env var is unset. Idempotent across restarts (keyed by the raw key's hash, so re-seeding the same value never duplicates the descriptor). Additive — never replaces or revokes UI-created keys. Respects the existing 20-key cap.
- Documented in README.md's MCP Endpoints section and the config table.

## Testing
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- `go test ./...` — full suite green, including 5 new unit tests covering unset/no-op, fresh seed, already-seeded no-op, at-cap no-op, and nil-DB safety.
- Manual end-to-end verification with a real running binary (macOS libchdb):
  - seeded key authenticates against `POST /mcp` (`tools/list`)
  - wrong key gets `401`
  - `GET /api/mcp/keys` shows the descriptor labeled `Environment (SOBS_MCP_API_KEY)`
  - restarting with the same env value preserves the same key id (no duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)