### PR TITLE
Fix flashRedirect() messages never rendering + sign the session cookie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,12 @@ jobs:
         with:
           python-version: "3.14"
       - name: Install linting dependencies
-        run: pip install black isort flake8 djlint
+        # Pinned: an unpinned `djlint` picked up a new release mid-migration whose H042/T039
+        # checks false-positive on <label for> paired with a <textarea id> and on a nested
+        # empty-dict literal inside a {% set %} tag (see the djlint:off blocks in templates/),
+        # failing CI on PRs that never touched those templates. Pin all four so a future
+        # release can't silently break unrelated PRs again; bump deliberately instead.
+        run: pip install black==26.5.1 isort==8.0.1 flake8==7.3.0 djlint==1.43.2
 
       - name: Run black
         run: black --check scripts/ examples/

--- a/go/cmd/sobs/fix_pages_settings.go
+++ b/go/cmd/sobs/fix_pages_settings.go
@@ -547,35 +547,46 @@ func (s *server) mcpSafeKeys() []any {
 }
 
 // ---------------------------------------------------------------------------
-// Repositories page: one-time CI-push key surfaced from the session cookie
-// (app.py session.pop("ci_push_api_key_plain_by_app")).
+// Session-cookie decoding shared by the CI-push one-time key (repositories page)
+// and the flashRedirect() flash-message round trip (render.go / handlers_pages.go).
 // ---------------------------------------------------------------------------
 
-// sessionCiPushPlainByApp reads the per-app one-time CI-push plaintext keys stashed in the
-// sobs_session cookie by flashRedirectWithCiKey (mirrors session.pop(...)). The cookie is the
-// unsigned base64 payload + ".0.0" tail this port emits; we decode the first segment, JSON-parse
-// it, and return the ci_push_api_key_plain_by_app map. Any parse failure (incl. the empty-corpus
-// no-cookie case) yields an empty map, so this only surfaces a key right after a rotation POST.
-func sessionCiPushPlainByApp(r *http.Request) map[string]string {
-	out := map[string]string{}
+// decodeSessionCookie reads, signature-verifies (verifySessionCookiePayload, handlers_forms.go),
+// and JSON-decodes the sobs_session cookie this port emits (see flashSessionCookie/
+// flashRedirectWithCiKey/sessionCookieHeaderFor). A missing cookie, a bad/missing signature (e.g.
+// a forged or hand-edited cookie value — without sessionSecretKey it cannot be reproduced), or a
+// parse failure all yield (nil, false).
+func decodeSessionCookie(r *http.Request) (*jsonenc.Object, bool) {
 	c, err := r.Cookie(sessionCookieName)
 	if err != nil || c == nil || c.Value == "" {
-		return out
+		return nil, false
 	}
-	payload := c.Value
-	if i := strings.IndexByte(payload, '.'); i >= 0 {
-		payload = payload[:i]
+	payload, ok := verifySessionCookiePayload(c.Value)
+	if !ok {
+		return nil, false
 	}
 	js, err := base64.RawURLEncoding.DecodeString(payload)
 	if err != nil {
-		return out
+		return nil, false
 	}
 	v, err := parseJSONValue(js)
 	if err != nil {
-		return out
+		return nil, false
 	}
 	o, ok := v.(*jsonenc.Object)
 	if !ok {
+		return nil, false
+	}
+	return o, true
+}
+
+// ciPushPlainByAppFromSession extracts the per-app one-time CI-push plaintext keys (mirrors
+// session.pop("ci_push_api_key_plain_by_app")) from an already-decoded session object, so a
+// caller that also needs sessionFlashedMessages/flashesFromSession from the same cookie (e.g.
+// handleViewSettingsRepositories) can decode the cookie once and derive both from it.
+func ciPushPlainByAppFromSession(o *jsonenc.Object) map[string]string {
+	out := map[string]string{}
+	if o == nil {
 		return out
 	}
 	mv, has := o.Get("ci_push_api_key_plain_by_app")
@@ -593,4 +604,101 @@ func sessionCiPushPlainByApp(r *http.Request) map[string]string {
 		}
 	}
 	return out
+}
+
+// sessionCiPushPlainByApp reads the per-app one-time CI-push plaintext keys stashed in the
+// sobs_session cookie by flashRedirectWithCiKey (mirrors session.pop(...)). Any parse failure
+// (incl. the empty-corpus no-cookie case) yields an empty map, so this only surfaces a key right
+// after a rotation POST.
+func sessionCiPushPlainByApp(r *http.Request) map[string]string {
+	o, ok := decodeSessionCookie(r)
+	if !ok {
+		return map[string]string{}
+	}
+	return ciPushPlainByAppFromSession(o)
+}
+
+// flashesFromSession extracts any pending flash messages (app.py's session["_flashes"], set by
+// flashRedirect/flashRedirectWithCiKey) from an already-decoded session object. Each entry is
+// decoded from Flask/Quart's TaggedJSONSerializer tuple tag ({" t": [category, message]}) into the
+// []any{category, message} pair get_flashed_messages (render.go's newEngineFlash) expects.
+//
+// The returned hadFlashes bool reports whether the object carried a "_flashes" key at all — Quart's
+// get_flashed_messages() pops that key unconditionally (session.pop), which is what marks the
+// session modified and makes Quart re-send an updated Set-Cookie in the response, even if every
+// entry in the list failed to decode. Callers should only touch the response cookie when this is
+// true, so requests with no session cookie — the common case — pass through untouched.
+func flashesFromSession(o *jsonenc.Object) (flashes []any, hadFlashes bool) {
+	if o == nil {
+		return nil, false
+	}
+	fv, has := o.Get("_flashes")
+	if !has {
+		return nil, false
+	}
+	arr, ok := fv.([]any)
+	if !ok {
+		return nil, true
+	}
+	out := make([]any, 0, len(arr))
+	for _, item := range arr {
+		tagged, ok := item.(*jsonenc.Object)
+		if !ok {
+			continue
+		}
+		pair, has := tagged.Get(" t")
+		if !has {
+			continue
+		}
+		pairArr, ok := pair.([]any)
+		if !ok || len(pairArr) != 2 {
+			continue
+		}
+		out = append(out, pairArr)
+	}
+	return out, true
+}
+
+// sessionFlashedMessages reads any pending flash messages out of the incoming sobs_session cookie
+// (see flashesFromSession for the decode).
+func sessionFlashedMessages(r *http.Request) (flashes []any, hadFlashes bool) {
+	o, ok := decodeSessionCookie(r)
+	if !ok {
+		return nil, false
+	}
+	return flashesFromSession(o)
+}
+
+// sessionObjectWithoutKey returns a copy of o with the given key removed (insertion order of the
+// remaining keys preserved), for re-serializing a session after popping one entry — mirrors
+// Quart/Flask's session.pop(key), which only drops that key and leaves the rest of the session
+// dict (and so the re-sent cookie) intact.
+func sessionObjectWithoutKey(o *jsonenc.Object, key string) *jsonenc.Object {
+	out := jsonenc.NewObject()
+	if o == nil {
+		return out
+	}
+	for _, k := range o.Keys() {
+		if k == key {
+			continue
+		}
+		if v, has := o.Get(k); has {
+			out.Set(k, v)
+		}
+	}
+	return out
+}
+
+// sessionCookieHeaderFor builds the Set-Cookie header value for the session that remains after
+// popping a key: an empty (or nil) remainder clears the cookie entirely — mirroring Quart, which
+// deletes the cookie once the session dict becomes empty — otherwise it re-encodes the remaining
+// session data the same way flashSessionCookie does (handlers_forms.go), so any other session
+// entry (e.g. flashRedirectWithCiKey's one-time ci_push_api_key_plain_by_app) survives until it is
+// independently popped by its own reader.
+func sessionCookieHeaderFor(remaining *jsonenc.Object) string {
+	if remaining == nil || remaining.Len() == 0 {
+		return sessionCookieName + "=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0" + sessionCookieAttrs()
+	}
+	payload := base64.RawURLEncoding.EncodeToString(jsonenc.Encode(remaining, flaskSessionOpts))
+	return sessionCookieName + "=" + signSessionPayload(payload) + sessionCookieAttrs()
 }

--- a/go/cmd/sobs/flash_session_test.go
+++ b/go/cmd/sobs/flash_session_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sobs/sobs/internal/store/storetest"
+)
+
+// flash_session_test.go covers the flashRedirect() -> subsequent GET round trip: a POST handler
+// flashes a message into the sobs_session cookie and 302s, and the destination page's GET handler
+// (renderPage/renderPageReq/handleHelpPage, via consumeSessionFlashes in handlers_pages.go) must
+// render that message and clear the cookie — mirroring Quart's session-backed flash()/
+// get_flashed_messages(). Regression test for the bug where plain page views only ever built their
+// render engine with nil pre-seeded flashes (newEngine == newEngineFlash(r, nil)) and so never
+// looked at the request's actual session cookie.
+
+// flashProbeTemplate is a self-contained template (no {% extends %}, so it doesn't depend on
+// base.html) that exercises exactly what get_flashed_messages surfaces, in the with_categories
+// form the real base.html uses (see templates/base.html's `{% for category, message in messages %}`).
+const flashProbeTemplate = `flashes=[{% for c, m in get_flashed_messages(with_categories=true) %}{{ c }}:{{ m }};{% endfor %}]`
+
+func newFlashProbeServer(t *testing.T) *server {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "probe.html"), []byte(flashProbeTemplate), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &server{cfg: config{TemplateDir: dir}, db: &storetest.FakeDB{}}
+}
+
+// cookieHeaderValue extracts the "name=value" pair from a Set-Cookie header string (dropping the
+// trailing attributes), suitable for use as a request's Cookie header.
+func cookieHeaderValue(setCookie string) string {
+	return strings.SplitN(setCookie, ";", 2)[0]
+}
+
+func TestRenderPage_FlashRedirectRoundTrip(t *testing.T) {
+	s := newFlashProbeServer(t)
+
+	// A POST handler's flashRedirect() (handlers_forms.go) sets the flash into the session cookie
+	// ahead of the 302 - this is the write side, already covered by existing tests
+	// (TestSliceI_formRequire_MissingFlashesAndRedirects pins flashSessionCookie's exact bytes).
+	redirRec := httptest.NewRecorder()
+	flashRedirect(redirRec, "success", "Notification channel created", "/settings/notifications")
+	setCookie := redirRec.Header().Get("Set-Cookie")
+	if setCookie == "" {
+		t.Fatal("flashRedirect did not set a Set-Cookie header")
+	}
+
+	// The browser follows the redirect, sending that cookie back on the destination page's GET -
+	// this is the read side under test.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/settings/notifications", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(setCookie))
+	s.renderPage(w, r, "probe.html", "view_notifications", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "flashes=[success:Notification channel created;]") {
+		t.Errorf("flash message from the redirect was not rendered on the next page view: %s", body)
+	}
+
+	// Rendering must consume the flash: Quart's get_flashed_messages() pops "_flashes" from the
+	// session, marking it modified, so the response clears the now-empty session cookie.
+	respCookie := w.Header().Get("Set-Cookie")
+	if !strings.HasPrefix(respCookie, sessionCookieName+"=;") || !strings.Contains(respCookie, "Max-Age=0") {
+		t.Errorf("expected the session cookie to be cleared after consuming its flash, got Set-Cookie=%q", respCookie)
+	}
+	if w.Header().Get("Vary") != "Cookie" {
+		t.Errorf("expected Vary: Cookie on a response that read the session cookie, got %q", w.Header().Get("Vary"))
+	}
+
+	// A subsequent view (the cookie has now been cleared client-side) must show no flash and must
+	// not touch Set-Cookie at all - most requests carry no session cookie and should pass through
+	// untouched, not have one spuriously cleared every time.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/settings/notifications", nil)
+	s.renderPage(w2, r2, "probe.html", "view_notifications", nil)
+	if body2 := w2.Body.String(); !strings.Contains(body2, "flashes=[]") {
+		t.Errorf("expected no flash on a clean request, got: %s", body2)
+	}
+	if sc := w2.Header().Get("Set-Cookie"); sc != "" {
+		t.Errorf("expected no Set-Cookie header when there was no pending flash, got %q", sc)
+	}
+}
+
+// TestRenderPageReq_FlashRedirectRoundTrip pins the same behavior for renderPageReq (the
+// request.args-aware sibling renderPage delegates to for filtered pages).
+func TestRenderPageReq_FlashRedirectRoundTrip(t *testing.T) {
+	s := newFlashProbeServer(t)
+
+	redirRec := httptest.NewRecorder()
+	flashRedirect(redirRec, "warning", "Repository entry not found", "/settings/repositories")
+	setCookie := redirRec.Header().Get("Set-Cookie")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/settings/repositories", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(setCookie))
+	s.renderPageReq(w, r, "probe.html", "view_settings_repositories", nil)
+
+	if body := w.Body.String(); !strings.Contains(body, "flashes=[warning:Repository entry not found;]") {
+		t.Errorf("flash message not rendered via renderPageReq: %s", body)
+	}
+	if sc := w.Header().Get("Set-Cookie"); !strings.HasPrefix(sc, sessionCookieName+"=;") {
+		t.Errorf("expected renderPageReq to clear the consumed flash cookie, got Set-Cookie=%q", sc)
+	}
+}
+
+// TestHandleHelpPage_FlashRedirectRoundTrip pins the same behavior for the dynamically-registered
+// help routes (render.go's handleHelpPage), which render full pages extending base.html directly
+// rather than through renderPage.
+func TestHandleHelpPage_FlashRedirectRoundTrip(t *testing.T) {
+	s := &server{cfg: config{TemplateDir: "../../../templates"}, db: &storetest.FakeDB{}}
+
+	redirRec := httptest.NewRecorder()
+	flashRedirect(redirRec, "success", "Masking pattern added", "/settings/masking/help")
+	setCookie := redirRec.Header().Get("Set-Cookie")
+
+	h := s.handleHelpPage("view_masking_help", "masking_help.html")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/settings/masking/help", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(setCookie))
+	h(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "Masking pattern added") {
+		t.Errorf("flash message not rendered by handleHelpPage: missing text in body (%d bytes)", len(body))
+	}
+	if sc := w.Header().Get("Set-Cookie"); !strings.HasPrefix(sc, sessionCookieName+"=;") {
+		t.Errorf("expected handleHelpPage to clear the consumed flash cookie, got Set-Cookie=%q", sc)
+	}
+}
+
+// TestSessionFlashedMessages covers the cookie-decoding helper directly: the tagged-tuple shape
+// flashSessionCookie/flashRedirectWithCiKey emit, malformed cookies, and the no-cookie case.
+func TestSessionFlashedMessages(t *testing.T) {
+	t.Run("decodes a real flash cookie", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Cookie", cookieHeaderValue(flashSessionCookie("danger", "Dashboard not found")))
+		flashes, had := sessionFlashedMessages(r)
+		if !had {
+			t.Fatal("expected hadFlashes=true for a cookie carrying _flashes")
+		}
+		if len(flashes) != 1 {
+			t.Fatalf("expected 1 flash, got %d: %v", len(flashes), flashes)
+		}
+		pair, ok := flashes[0].([]any)
+		if !ok || len(pair) != 2 || pair[0] != "danger" || pair[1] != "Dashboard not found" {
+			t.Errorf("flash pair = %#v, want [danger Dashboard not found]", flashes[0])
+		}
+	})
+
+	t.Run("no cookie at all", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		flashes, had := sessionFlashedMessages(r)
+		if had || flashes != nil {
+			t.Errorf("expected (nil, false) with no cookie, got (%v, %v)", flashes, had)
+		}
+	})
+
+	t.Run("cookie present but not a session cookie this port recognizes", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Cookie", sessionCookieName+"=not-valid-base64!!!")
+		flashes, had := sessionFlashedMessages(r)
+		if had || flashes != nil {
+			t.Errorf("expected (nil, false) for an undecodable cookie, got (%v, %v)", flashes, had)
+		}
+	})
+
+	t.Run("cookie shared with the CI-push key decodes both independently", func(t *testing.T) {
+		// flashRedirectWithCiKey (handlers_forms.go) stashes _flashes and ci_push_api_key_plain_by_app
+		// in the same session cookie; both readers must decode their own field from it.
+		rec := httptest.NewRecorder()
+		flashRedirectWithCiKey(rec, "success", "CI key rotated", "/settings/repositories", "app1", "plain-key")
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Cookie", cookieHeaderValue(rec.Header().Get("Set-Cookie")))
+
+		flashes, had := sessionFlashedMessages(r)
+		if !had {
+			t.Fatal("expected hadFlashes=true: flashRedirectWithCiKey always sets _flashes alongside the ci key")
+		}
+		if len(flashes) != 1 {
+			t.Fatalf("expected 1 flash, got %d: %v", len(flashes), flashes)
+		}
+		if byApp := sessionCiPushPlainByApp(r); byApp["app1"] != "plain-key" {
+			t.Errorf("sessionCiPushPlainByApp = %v, want app1 -> plain-key", byApp)
+		}
+	})
+}
+
+// TestConsumeSessionFlashes_PreservesOtherSessionData is a regression test for consumeSessionFlashes
+// clearing the ENTIRE session cookie whenever "_flashes" was present, instead of popping only that
+// key the way Quart's session.pop("_flashes") does. flashRedirectWithCiKey stashes a one-time
+// ci_push_api_key_plain_by_app entry alongside the flash in the same cookie; if a plain page view
+// (not the repositories page) consumes the flash first, the CI key must still survive in the
+// re-sent cookie for the repositories page to read afterwards.
+func TestConsumeSessionFlashes_PreservesOtherSessionData(t *testing.T) {
+	s := newFlashProbeServer(t)
+
+	rec := httptest.NewRecorder()
+	flashRedirectWithCiKey(rec, "success", "CI key rotated", "/settings/repositories", "app1", "plain-key-xyz")
+	setCookie := rec.Header().Get("Set-Cookie")
+
+	// A different page view (not /settings/repositories) reads this cookie first and consumes the
+	// flash via the generic renderPage path.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/settings/notifications", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(setCookie))
+	s.renderPage(w, r, "probe.html", "view_notifications", nil)
+
+	if body := w.Body.String(); !strings.Contains(body, "flashes=[success:CI key rotated;]") {
+		t.Fatalf("expected the flash to render, got: %s", body)
+	}
+	respCookie := w.Header().Get("Set-Cookie")
+	if respCookie == "" {
+		t.Fatal("expected a re-sent Set-Cookie carrying the surviving ci_push_api_key_plain_by_app entry")
+	}
+	if strings.HasPrefix(respCookie, sessionCookieName+"=;") {
+		t.Fatalf("consumeSessionFlashes cleared the WHOLE session cookie instead of just \"_flashes\" — the "+
+			"one-time CI-push key was destroyed before the repositories page ever read it: %q", respCookie)
+	}
+
+	// The CI-push key must still be readable from the re-sent cookie on the next request...
+	r2 := httptest.NewRequest(http.MethodGet, "/settings/repositories", nil)
+	r2.Header.Set("Cookie", cookieHeaderValue(respCookie))
+	if byApp := sessionCiPushPlainByApp(r2); byApp["app1"] != "plain-key-xyz" {
+		t.Errorf("ci-push key lost after consuming the flash: sessionCiPushPlainByApp = %v, want app1 -> plain-key-xyz", byApp)
+	}
+	// ...and the flash must NOT still be pending (it was already consumed and popped).
+	if flashes, had := sessionFlashedMessages(r2); had || len(flashes) != 0 {
+		t.Errorf("expected the flash to have been fully consumed already, got had=%v flashes=%v", had, flashes)
+	}
+}
+
+// TestRenderPageFlash_MergesPendingSessionFlash is a regression test for renderPageFlash silently
+// discarding a real pending flash (set by an earlier flashRedirect()) whenever the destination GET
+// happens to take a renderPageFlash branch (e.g. handleViewTagRules's "edit_rule not found" path)
+// instead of renderPage. Quart's flash()+get_flashed_messages() would show BOTH the pre-existing
+// and the newly-flashed message; renderPageFlash must do the same.
+func TestRenderPageFlash_MergesPendingSessionFlash(t *testing.T) {
+	s := newFlashProbeServer(t)
+
+	redirRec := httptest.NewRecorder()
+	flashRedirect(redirRec, "success", "Tag rule created", "/settings/tags")
+	setCookie := redirRec.Header().Get("Set-Cookie")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/settings/tags?edit_rule=stale-id", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(setCookie))
+	s.renderPageFlash(w, r, "probe.html", "view_tag_rules", "warning", "Tag rule not found for editing", nil)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "success:Tag rule created;") {
+		t.Errorf("the pending flash from the earlier flashRedirect was discarded, got: %s", body)
+	}
+	if !strings.Contains(body, "warning:Tag rule not found for editing;") {
+		t.Errorf("the explicit renderPageFlash message is missing, got: %s", body)
+	}
+	if sc := w.Header().Get("Set-Cookie"); !strings.HasPrefix(sc, sessionCookieName+"=;") {
+		t.Errorf("expected renderPageFlash to clear the now-empty session cookie, got Set-Cookie=%q", sc)
+	}
+}
+
+// TestConsumeSessionFlashes_MergesVaryHeader confirms consumeSessionFlashes appends "Cookie" to any
+// Vary value already present on the response instead of clobbering it via a raw Set().
+func TestConsumeSessionFlashes_MergesVaryHeader(t *testing.T) {
+	s := newFlashProbeServer(t)
+	w := httptest.NewRecorder()
+	w.Header().Set("Vary", "Origin")
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(flashSessionCookie("info", "hi")))
+
+	s.consumeSessionFlashes(w, r)
+
+	if got := w.Header().Get("Vary"); got != "Origin, Cookie" {
+		t.Errorf("Vary = %q, want \"Origin, Cookie\" (merged, not clobbered)", got)
+	}
+}
+
+// TestSessionCookieSigning covers signSessionPayload/verifySessionCookiePayload directly: this is
+// the fix for the widened attack surface flagged in review — decodeSessionCookie now verifies an
+// HMAC signature (keyed by sessionSecretKey) before trusting ANY session cookie content, so a
+// client without the server's secret key cannot forge a flash message or a ci_push_api_key entry.
+func TestSessionCookieSigning(t *testing.T) {
+	t.Run("valid round trip", func(t *testing.T) {
+		signed := signSessionPayload("cGF5bG9hZA")
+		payload, ok := verifySessionCookiePayload(signed)
+		if !ok || payload != "cGF5bG9hZA" {
+			t.Fatalf("verifySessionCookiePayload(%q) = (%q, %v), want (cGF5bG9hZA, true)", signed, payload, ok)
+		}
+	})
+
+	t.Run("tampered payload is rejected", func(t *testing.T) {
+		signed := signSessionPayload("cGF5bG9hZA")
+		i := strings.LastIndexByte(signed, '.')
+		forged := "ZXZpbC1wYXlsb2Fk" + signed[i:] // attacker's own payload + the ORIGINAL signature
+		if _, ok := verifySessionCookiePayload(forged); ok {
+			t.Error("a payload swapped in under someone else's signature must not verify")
+		}
+	})
+
+	t.Run("tampered signature is rejected", func(t *testing.T) {
+		signed := signSessionPayload("cGF5bG9hZA")
+		if _, ok := verifySessionCookiePayload(signed + "AAAA"); ok {
+			t.Error("an altered signature must not verify")
+		}
+	})
+
+	t.Run("no signature segment at all is rejected", func(t *testing.T) {
+		if _, ok := verifySessionCookiePayload("cGF5bG9hZA"); ok {
+			t.Error("a bare payload with no \".signature\" suffix must not verify")
+		}
+	})
+
+	t.Run("a hand-forged flash cookie (no valid signature) is never trusted", func(t *testing.T) {
+		// Build the exact JSON payload flashSessionCookie would, but WITHOUT going through
+		// signSessionPayload — simulating an attacker who knows the wire format but not the secret.
+		forgedPayload := base64.RawURLEncoding.EncodeToString([]byte(`{"_flashes":[{" t":["danger","you have been hacked"]}]}`))
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Cookie", sessionCookieName+"="+forgedPayload+".0.0") // the OLD placeholder shape
+		if flashes, had := sessionFlashedMessages(r); had || len(flashes) != 0 {
+			t.Errorf("forged cookie without a valid signature was trusted: had=%v flashes=%v", had, flashes)
+		}
+	})
+}
+
+// TestHandleViewSettingsRepositories_CiKeyAndFlashTogether exercises the real handler end to end:
+// a rotation's flashRedirectWithCiKey cookie must still deliver BOTH the one-time CI-push plaintext
+// key AND the flash message on the very next repositories-page GET, now that the handler decodes
+// the session cookie once (decodeSessionCookie) and derives ciPushPlainByAppFromSession/
+// consumeSessionFlashesFrom from that single decode instead of two independent ones.
+func TestHandleViewSettingsRepositories_CiKeyAndFlashTogether(t *testing.T) {
+	s := &server{cfg: config{TemplateDir: "../../../templates"}, db: &storetest.FakeDB{}}
+
+	rec := httptest.NewRecorder()
+	flashRedirectWithCiKey(rec, "success", "CI push key rotated", "/settings/repositories", "app1", "plain-secret-key")
+	setCookie := rec.Header().Get("Set-Cookie")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/settings/repositories", nil)
+	r.Header.Set("Cookie", cookieHeaderValue(setCookie))
+	s.handleViewSettingsRepositories(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "CI push key rotated") {
+		t.Errorf("flash message missing from repositories page render: %d bytes", len(body))
+	}
+	// handleViewSettingsRepositories only READS ciPushPlainByAppFromSession (mirroring app.py's
+	// session.pop, but this port never actually pops it — a pre-existing gap, not introduced here),
+	// so that entry is still in the session after "_flashes" is popped: the cookie must be
+	// RE-SENT with it intact, not fully cleared.
+	sc := w.Header().Get("Set-Cookie")
+	if strings.HasPrefix(sc, sessionCookieName+"=;") {
+		t.Errorf("expected the ci_push_api_key_plain_by_app entry to survive popping \"_flashes\", "+
+			"but the whole cookie was cleared: %q", sc)
+	}
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("Cookie", cookieHeaderValue(sc))
+	if byApp := sessionCiPushPlainByApp(r2); byApp["app1"] != "plain-secret-key" {
+		t.Errorf("ci-push key lost from the re-sent cookie: sessionCiPushPlainByApp = %v, want app1 -> plain-secret-key", byApp)
+	}
+	if flashes, had := sessionFlashedMessages(r2); had || len(flashes) != 0 {
+		t.Errorf("expected the flash to already be consumed in the re-sent cookie, got had=%v flashes=%v", had, flashes)
+	}
+}

--- a/go/cmd/sobs/handlers_forms.go
+++ b/go/cmd/sobs/handlers_forms.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"html"
@@ -92,10 +94,53 @@ func sessionCookieAttrs() string {
 	return a
 }
 
-// flashSessionCookie builds the sobs_session cookie carrying a single flash message. The
-// parity normalizer keeps only the unsigned base64 payload segment (dropping the HMAC
-// timestamp+signature), so a placeholder ".0.0" suffix is sufficient and the payload — the
-// only compared part — is byte-identical to Quart's.
+// sessionSecretKey signs/verifies the sobs_session cookie payload (mirrors Quart's SECRET_KEY-
+// backed itsdangerous session signing), so a client can't forge or tamper with a flash message or
+// the one-time CI-push key. Read once at startup from the same SOBS_SECRET_KEY env var (and the
+// same "sobs-dev-secret-key" default) as cfg.SecretKey in main.go's loadConfig — kept as a
+// package-level var, matching sessionCookieName/sessionCookieSameSite above, because the ~100
+// flashRedirect call sites across the codebase are free functions, not *server methods, so
+// *server.cfg isn't reachable from them without threading it through every one.
+var sessionSecretKey = []byte(envOr("SOBS_SECRET_KEY", "sobs-dev-secret-key"))
+
+// signSessionPayload appends an HMAC-SHA256 signature (keyed by sessionSecretKey) to a session
+// payload, producing the cookie value "payload.signature" — both halves are base64.RawURLEncoding,
+// whose alphabet has no '.', so the two segments split unambiguously. This is a plain signer (no
+// itsdangerous timestamp/max_age check), so verifySessionCookiePayload only rejects a tampered or
+// unsigned payload, not an old-but-genuine one; that's sufficient here since a stolen flash cookie
+// is only ever useful for the single page view it was meant for anyway.
+func signSessionPayload(payload string) string {
+	mac := hmac.New(sha256.New, sessionSecretKey)
+	mac.Write([]byte(payload))
+	return payload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// verifySessionCookiePayload splits a sobs_session cookie's value into its payload and signature
+// (see signSessionPayload) and returns the payload only if the signature verifies — without the
+// server's secret key, a forged or edited payload cannot produce a signature this accepts.
+func verifySessionCookiePayload(cookieVal string) (string, bool) {
+	i := strings.LastIndexByte(cookieVal, '.')
+	if i < 0 {
+		return "", false
+	}
+	payload, sigB64 := cookieVal[:i], cookieVal[i+1:]
+	gotSig, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return "", false
+	}
+	mac := hmac.New(sha256.New, sessionSecretKey)
+	mac.Write([]byte(payload))
+	if !hmac.Equal(gotSig, mac.Sum(nil)) {
+		return "", false
+	}
+	return payload, true
+}
+
+// flashSessionCookie builds the sobs_session cookie carrying a single flash message, signed via
+// signSessionPayload so it can't be forged without sessionSecretKey. goldenreplay/normalize.go's
+// session-cookie normalizer splits the value on "." and, for fewer than 3 segments, canonicalizes
+// just segments[0] — i.e. our payload — before comparison, so the payload stays the byte-identical
+// part parity compares regardless of what the trailing signature bytes are.
 func flashSessionCookie(category, message string) string {
 	sess := jsonenc.NewObject().Set("_flashes", []any{
 		jsonenc.NewObject().Set(" t", []any{category, message}),
@@ -106,7 +151,7 @@ func flashSessionCookie(category, message string) string {
 	// session dict, so the compress/no-compress decision is irrelevant — and CPython's zlib is
 	// a few bytes smaller than Go's at the threshold, so replicating its decision is unreliable.
 	payload := base64.RawURLEncoding.EncodeToString(js)
-	return sessionCookieName + "=" + payload + ".0.0" + sessionCookieAttrs()
+	return sessionCookieName + "=" + signSessionPayload(payload) + sessionCookieAttrs()
 }
 
 // plainRedirect reproduces a bare `return redirect(location)` (no flash): a 302 with
@@ -156,7 +201,7 @@ func flashRedirectWithCiKey(w http.ResponseWriter, category, message, location, 
 	h := w.Header()
 	h.Set("Content-Type", "text/html; charset=utf-8")
 	h.Set("Location", location)
-	h.Set("Set-Cookie", sessionCookieName+"="+payload+".0.0"+sessionCookieAttrs())
+	h.Set("Set-Cookie", sessionCookieName+"="+signSessionPayload(payload)+sessionCookieAttrs())
 	h.Set("Vary", "Cookie")
 	h.Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusFound)

--- a/go/cmd/sobs/handlers_pages.go
+++ b/go/cmd/sobs/handlers_pages.go
@@ -422,14 +422,64 @@ func textStatus(w http.ResponseWriter, status int, body string) {
 	_, _ = w.Write([]byte(body))
 }
 
+// consumeSessionFlashesFrom is consumeSessionFlashes given an already-decoded session object (for
+// a caller like handleViewSettingsRepositories that also needs ciPushPlainByAppFromSession from
+// the very same cookie, so the cookie is only decoded once per request). If the object carried a
+// "_flashes" key, the response's Set-Cookie re-sends the session with just that key removed (any
+// other session entry, e.g. a one-time ci_push_api_key_plain_by_app, survives) — mirroring Quart's
+// session.pop("_flashes"), which only drops that key, not the whole session.
+func (s *server) consumeSessionFlashesFrom(w http.ResponseWriter, obj *jsonenc.Object, decoded bool) []any {
+	if !decoded {
+		return nil
+	}
+	flashes, hadFlashes := flashesFromSession(obj)
+	if !hadFlashes {
+		return nil
+	}
+	w.Header().Set("Set-Cookie", sessionCookieHeaderFor(sessionObjectWithoutKey(obj, "_flashes")))
+	appendVaryHeader(w.Header(), "Cookie")
+	return flashes
+}
+
+// consumeSessionFlashes reads any flash message(s) pending in the request's sobs_session cookie
+// (set by a prior flashRedirect()) and, if the cookie carried a "_flashes" key, arranges for the
+// response to re-send the session cookie with that key consumed — mirroring Quart's
+// get_flashed_messages(), which pops "_flashes" from the session and so marks it modified,
+// regardless of whether every entry decoded cleanly. Call this before writing any response
+// body/headers that depend on it, since it sets Set-Cookie/Vary on w.
+func (s *server) consumeSessionFlashes(w http.ResponseWriter, r *http.Request) []any {
+	obj, ok := decodeSessionCookie(r)
+	return s.consumeSessionFlashesFrom(w, obj, ok)
+}
+
+// renderFlashedInto is the shared tail of renderPage/renderPageReq: consume any pending session
+// flash and render templateName with it wired into get_flashed_messages.
+func (s *server) renderFlashedInto(w http.ResponseWriter, r *http.Request, templateName string, ctx map[string]any) {
+	flashes := s.consumeSessionFlashes(w, r)
+	s.renderInto(w, s.newEngineFlash(r, flashes), templateName, ctx)
+}
+
 // renderPage renders an HTML template with baseContext merged with extra context vars and
-// writes it with Quart's text/html content type.
+// writes it with Quart's text/html content type. Any flash message left by a prior flashRedirect()
+// is rendered here and cleared from the session (see consumeSessionFlashes).
 func (s *server) renderPage(w http.ResponseWriter, r *http.Request, templateName, endpoint string, extra map[string]any) {
 	ctx := s.baseContext(endpoint)
 	for k, v := range extra {
 		ctx[k] = v
 	}
-	s.renderInto(w, s.newEngine(r), templateName, ctx)
+	s.renderFlashedInto(w, r, templateName, ctx)
+}
+
+// renderPageWithFlashes is renderPage for a caller that already decoded the session cookie itself
+// (e.g. to also read ciPushPlainByAppFromSession) and has already consumed/cleared it via
+// consumeSessionFlashesFrom — it renders with the given pre-computed flashes without decoding the
+// cookie a second time.
+func (s *server) renderPageWithFlashes(w http.ResponseWriter, r *http.Request, templateName, endpoint string, flashes []any, extra map[string]any) {
+	ctx := s.baseContext(endpoint)
+	for k, v := range extra {
+		ctx[k] = v
+	}
+	s.renderInto(w, s.newEngineFlash(r, flashes), templateName, ctx)
 }
 
 // requestArgsContext mirrors Quart's `request` object for templates that read request.args
@@ -447,28 +497,41 @@ func requestArgsContext(r *http.Request, endpoint string) map[string]any {
 }
 
 // renderPageReq is renderPage with request.args populated from r (for pages whose templates
-// consult request.args).
+// consult request.args). Any flash message left by a prior flashRedirect() is rendered here and
+// cleared from the session (see consumeSessionFlashes).
 func (s *server) renderPageReq(w http.ResponseWriter, r *http.Request, templateName, endpoint string, extra map[string]any) {
 	ctx := s.baseContext(endpoint)
 	ctx["request"] = requestArgsContext(r, endpoint)
 	for k, v := range extra {
 		ctx[k] = v
 	}
-	s.renderInto(w, s.newEngine(r), templateName, ctx)
+	s.renderFlashedInto(w, r, templateName, ctx)
 }
 
-// renderPageFlash renders a page with a single pre-seeded flash (category, message) consumed
-// by get_flashed_messages — for handlers that flash() then render rather than redirect.
+// renderPageFlash renders a page with an explicit (category, message) flash — for handlers that
+// flash() then render rather than redirect. Like Quart's flash() + get_flashed_messages() in the
+// same request, this also surfaces (and consumes) any flash ALREADY pending in the session cookie
+// ahead of the new one, so a real flashRedirect() message from an earlier request is never
+// silently discarded just because this request's GET happened to take this render path instead of
+// renderPage.
 func (s *server) renderPageFlash(w http.ResponseWriter, r *http.Request, templateName, endpoint, flashCategory, flashMessage string, extra map[string]any) {
 	ctx := s.baseContext(endpoint)
 	for k, v := range extra {
 		ctx[k] = v
 	}
-	eng := s.newEngineFlash(r, []any{[]any{flashCategory, flashMessage}})
-	// Consuming the flash empties the session, so Quart clears the session cookie and marks
-	// the response Vary: Cookie (it read the request session).
-	w.Header().Set("Set-Cookie", sessionCookieName+"=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0"+sessionCookieAttrs())
-	w.Header().Set("Vary", "Cookie")
+	obj, decoded := decodeSessionCookie(r)
+	existing, _ := flashesFromSession(obj)
+	flashes := append(existing, []any{flashCategory, flashMessage})
+	eng := s.newEngineFlash(r, flashes)
+	// flash() always marks the session modified, so Quart re-sends the session cookie regardless
+	// of whether the incoming request had one — cleared unless other session data (e.g. a
+	// still-pending ci_push_api_key_plain_by_app) survives popping "_flashes".
+	var remaining *jsonenc.Object
+	if decoded {
+		remaining = sessionObjectWithoutKey(obj, "_flashes")
+	}
+	w.Header().Set("Set-Cookie", sessionCookieHeaderFor(remaining))
+	appendVaryHeader(w.Header(), "Cookie")
 	s.renderInto(w, eng, templateName, ctx)
 }
 
@@ -3801,7 +3864,10 @@ func (s *server) handleViewSettingsRepositories(w http.ResponseWriter, r *http.R
 	}
 	// app.py: ci_push_plain_by_app = session.pop("ci_push_api_key_plain_by_app", {}) — the
 	// one-time plaintext key shown once right after a rotation. Empty on the corpus (no cookie).
-	apps := s.buildRepositoriesApps(sessionCiPushPlainByApp(r))
+	// Decoded once and shared with consumeSessionFlashesFrom below, since this page reads two
+	// different things (the ci-push key and any pending flash) out of the very same cookie.
+	sessObj, sessDecoded := decodeSessionCookie(r)
+	apps := s.buildRepositoriesApps(ciPushPlainByAppFromSession(sessObj))
 	realtimeEnabled, realtimeConfigured := false, false
 	for _, a := range apps {
 		if m, ok := a.(map[string]any); ok {
@@ -3816,7 +3882,8 @@ func (s *server) handleViewSettingsRepositories(w http.ResponseWriter, r *http.R
 		}
 	}
 	expiresAt := strings.TrimSpace(s.loadAISetting("ai.github_token_expires_at", ""))
-	s.renderPage(w, r, "settings_repositories.html", "view_settings_repositories", map[string]any{
+	flashes := s.consumeSessionFlashesFrom(w, sessObj, sessDecoded)
+	s.renderPageWithFlashes(w, r, "settings_repositories.html", "view_settings_repositories", flashes, map[string]any{
 		"apps":                       apps,
 		"github_token_configured":    strings.TrimSpace(s.loadAISetting("ai.github_token", "")) != "",
 		"default_agent_repo":         strings.TrimSpace(s.loadAISetting("ai.github_repo", "")),

--- a/go/cmd/sobs/render.go
+++ b/go/cmd/sobs/render.go
@@ -199,10 +199,14 @@ func (s *server) baseContext(endpoint string) map[string]any {
 }
 
 // handleHelpPage renders a *_help.html template (the dynamically-registered help routes).
-// endpoint is the Quart endpoint name (used by base.html nav-active logic).
+// endpoint is the Quart endpoint name (used by base.html nav-active logic). Like renderPage, any
+// flash message left by a prior flashRedirect() is rendered here and cleared from the session
+// (see consumeSessionFlashes) — these are full pages extending base.html, so they can be the
+// "next page view" a redirect lands on.
 func (s *server) handleHelpPage(endpoint, templateName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		eng := s.newEngine(r)
+		flashes := s.consumeSessionFlashes(w, r)
+		eng := s.newEngineFlash(r, flashes)
 		out, err := eng.Render(templateName, s.baseContext(endpoint))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/go/cmd/sobs/server.go
+++ b/go/cmd/sobs/server.go
@@ -31,6 +31,13 @@ type server struct {
 }
 
 func newServer(cfg config) *server {
+	// sessionSecretKey (handlers_forms.go) signs flash-message/CI-push-key session cookies; left
+	// at its insecure default, anyone can compute a valid signature and forge one. Parity mode
+	// intentionally never sets SOBS_SECRET_KEY, so skip the warning there.
+	if !cfg.Parity && cfg.SecretKey == "sobs-dev-secret-key" {
+		log.Printf("warning: SOBS_SECRET_KEY is unset (using the insecure default) — session cookies " +
+			"(flash messages, the one-time CI-push key) can be forged; set SOBS_SECRET_KEY to a random secret")
+	}
 	s := &server{cfg: cfg, mux: http.NewServeMux(), sse: newSSEBroker(), auth: loadAuthConfig(), tel: loadTelemetry(), rumClient: loadRumClientConfig(), rumAsset: loadRumAssetConfig(), srcMap: loadSourceMapper()}
 	// Open the shared chdb session, retrying the intermittent embedded-server "recursive_mutex
 	// lock failed" boot error (a chdb-go contention bug seen under many sequential per-profile

--- a/templates/_shared_issue_and_rum_modals.html
+++ b/templates/_shared_issue_and_rum_modals.html
@@ -75,12 +75,13 @@
           <div class="form-text">Copilot will be formally assigned to suggest a fix if no active work already exists.</div>
         </div>
         <div class="mb-3 mt-3">
-          <label for="raiseIssueAdditionalContext" class="form-label small text-secondary mb-1">
+          {# djlint:off — H042 false-positives on <label for> paired with a <textarea id> (it
+             only recognizes <input>/<select>); the for/id pair below is correct. #}<label for="raiseIssueAdditionalContext" class="form-label small text-secondary mb-1">
             Additional context <span class="text-muted">(optional)</span>
           </label>
           <textarea class="form-control form-control-sm" id="raiseIssueAdditionalContext" rows="3"
                     placeholder="Describe what you were doing, any recent changes, or other context that may help analyze this issue…"
-                    maxlength="2000"></textarea>
+                    maxlength="2000"></textarea>{# djlint:on #}
           <div class="form-text">This context is included in the LLM prompt and the generated GitHub issue.</div>
         </div>
         <div class="form-check mt-2">

--- a/templates/traces.html
+++ b/templates/traces.html
@@ -304,7 +304,8 @@
   {% endif %}
 
   {% set mc = trace_detail.metrics_context or {} %}
-  {% set ts_data = mc.timeseries or {'ticks_ms': [], 'by_metric': {}} %}
+  {# djlint:off — T039 false-positives on a nested empty-dict literal ({'k': {}}) inside a set
+     tag below (its brace scanner miscounts nesting); the tag is valid and closes normally. #}{% set ts_data = mc.timeseries or {'ticks_ms': [], 'by_metric': {}} %}{# djlint:on #}
   <div class="card mb-3">
     <div class="card-header py-2" style="cursor:pointer;" data-bs-toggle="collapse" data-bs-target="#trace-metrics-panel">
       <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## What

POST-redirect-GET flows that use `flashRedirect()` (e.g. settings pages:
notifications channels/rules, tags, agents, repositories, masking) set a
flash message into the `sobs_session` cookie before the 302, but the
destination page's GET handler never rendered it — the action still
succeeded, but the success/warning banner silently never appeared.

## Root cause

`renderPage`/`renderPageReq`/`handleHelpPage` (the plain-page-view render
helpers) always built the template engine via `newEngine(r)` ==
`newEngineFlash(r, nil)` — i.e. **nil** pre-seeded flashes — so
`get_flashed_messages()` never looked at the request's actual session
cookie. Only `renderPageFlash` (used when a handler flashes and renders
directly in the same request, e.g. auto-rule previews) ever populated it.

## Fix

- Added `sessionFlashedMessages`/`consumeSessionFlashes`
  (fix_pages_settings.go / handlers_pages.go) to decode pending flashes out
  of the `sobs_session` cookie and wire them into `renderPage`,
  `renderPageReq`, and `handleHelpPage`.
- `renderPageFlash` now **merges** any real pending cookie flash with its
  explicit message instead of silently discarding one — the same root-cause
  bug was reachable through a sibling code path (e.g.
  `handleViewTagRules`'s "edit_rule not found" branch), confirmed with a
  deterministic single-request repro during review.
- `consumeSessionFlashes` pops only the `_flashes` key and re-sends the rest
  of the session (e.g. a co-stashed one-time CI-push key from
  `flashRedirectWithCiKey`) instead of wiping the whole cookie.
- `handleViewSettingsRepositories` now decodes the session cookie once and
  derives both the CI-push map and the flashes from it, instead of decoding
  it twice per request.
- `Vary` header merging (`appendVaryHeader`) and the clear-cookie string are
  now shared instead of duplicated raw `.Set()` calls; `renderPage`/
  `renderPageReq` share a new `renderFlashedInto` helper.

## Security: session cookie signing

Fixing the flash bug meant trusting the `sobs_session` cookie's content on
essentially every full page instead of just one (the CI-push-key page). The
cookie was never cryptographically signed (a pre-existing simplification in
this port), so a forged cookie could inject arbitrary attacker-chosen text
into an alert banner on any page.

Added real HMAC-SHA256 signing (`signSessionPayload`/
`verifySessionCookiePayload` in handlers_forms.go), keyed by the
already-present-but-previously-unused `SOBS_SECRET_KEY` config — an
unsigned or tampered cookie is now rejected outright. A startup warning
fires when `SOBS_SECRET_KEY` is left at its insecure default (skipped in
parity mode).

**Parity-safe**: `goldenreplay/normalize.go`'s session-cookie normalizer
already discards everything after the payload segment before comparing, so
a real signature there doesn't affect byte-comparison. Verified by running
the full golden-corpus replay before and after this change:
`GREEN 726 / RED 78` in both cases — the 78 reds are pre-existing and
unrelated (data/seed gaps, not session-cookie related).

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` all clean.
- Added `flash_session_test.go`: the flashRedirect → GET round trip for
  `renderPage`/`renderPageReq`/`handleHelpPage`, the CI-push-key-survives-
  flash-consumption case, `Vary` header merging, cookie-signing tamper
  rejection, and an end-to-end repositories-page test combining the CI key
  and a flash message.
- Ran `CHDB_LIB_PATH=/usr/local/lib/libchdb.so go test -tags chdb
  ./goldenreplay/...` before and after to confirm no parity regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)