### PR TITLE
Deduplicate GO_VERSION/CHDB_VERSION pins and pinnedEnv maps to single sources of truth

### DIFF
--- a/.github/actions/load-versions-env/action.yml
+++ b/.github/actions/load-versions-env/action.yml
@@ -1,0 +1,12 @@
+name: Load pinned build versions
+description: >-
+  Load GO_VERSION/CHDB_VERSION from versions.env (repo root) into the job's environment as
+  plain env vars, so later steps can reference them via ${GO_VERSION} (shell) or
+  ${{ env.GO_VERSION }} (expressions) — the single place every job in ci.yml gets these
+  values from, instead of each job re-deriving them.
+runs:
+  using: composite
+  steps:
+    - name: Load pinned build versions (versions.env)
+      shell: bash
+      run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"

--- a/.github/actions/load-versions-env/action.yml
+++ b/.github/actions/load-versions-env/action.yml
@@ -1,9 +1,9 @@
 name: Load pinned build versions
 description: >-
   Load GO_VERSION/CHDB_VERSION from versions.env (repo root) into the job's environment as
-  plain env vars, so later steps can reference them via ${GO_VERSION} (shell) or
-  ${{ env.GO_VERSION }} (expressions) — the single place every job in ci.yml gets these
-  values from, instead of each job re-deriving them.
+  plain env vars, so later steps can reference them via shell interpolation or the env
+  expression context — the single place every job in ci.yml gets these values from,
+  instead of each job re-deriving them.
 runs:
   using: composite
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Load pinned build versions (versions.env)
+        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx (in-cluster registry mirror + buildcache)
         uses: docker/setup-buildx-action@v4
         with:
@@ -87,11 +90,16 @@ jobs:
         # buildcache, so after the first run ONLY a source change recompiles. Running the tests
         # in-container (a fresh process tree) also avoids the chdb-under-runner-agent SIGSEGV. The
         # build resolves Go modules via the in-cluster Athens proxy (network=host reaches it).
+        # GO_VERSION/CHDB_VERSION come from versions.env (loaded above) — the single source of
+        # truth also used by the docker-go-smoke, playwright-e2e, and docker (release) jobs below.
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.ci
           push: false
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+            CHDB_VERSION=${{ env.CHDB_VERSION }}
           cache-from: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-buildcache
           cache-to: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-ci-buildcache,mode=max
 
@@ -104,14 +112,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Load pinned build versions (versions.env)
+        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+
       - name: Build the stripped-down Go image
         # --network=host: the dind sidecar shares the runner pod's network namespace, so the build can
         # reach the in-cluster Athens proxy (ClusterIP:5000, permitted by the egress netpol) for
-        # `go mod download`. GOPROXY/GOSUMDB come from the workflow env.
+        # `go mod download`. GOPROXY/GOSUMDB come from the workflow env; GO_VERSION/CHDB_VERSION
+        # come from versions.env (loaded above) — the single source of truth shared with the
+        # go-build-test, playwright-e2e, and docker (release) jobs.
         run: |
           docker build --network=host \
             --build-arg GOPROXY="${GOPROXY}" \
             --build-arg GOSUMDB="${GOSUMDB}" \
+            --build-arg GO_VERSION="${GO_VERSION}" \
+            --build-arg CHDB_VERSION="${CHDB_VERSION}" \
             -f Dockerfile.go -t sobs:ci .
 
       - name: Start the container (empty /data — must self-seed its schema)
@@ -152,9 +167,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Load pinned build versions (versions.env)
+        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+
       - name: Build and run the E2E suite (Dockerfile.e2e)
         # --network=host: same reasoning as docker-go-smoke — the dind sidecar shares the runner
         # pod's network namespace, so `go mod download` reaches the in-cluster Athens proxy.
+        # GO_VERSION/CHDB_VERSION come from versions.env (loaded above) — the single source of
+        # truth shared with the go-build-test, docker-go-smoke, and docker (release) jobs.
         # UNVERIFIED ON THIS CLUSTER: Dockerfile.e2e's FROM pulls mcr.microsoft.com/playwright
         # (a different registry than docker.io, which has an in-cluster mirror configured via
         # buildkitd-config-inline elsewhere in this file — see go-build-test/docker), and its own
@@ -167,6 +187,8 @@ jobs:
           docker build --network=host \
             --build-arg GOPROXY="${GOPROXY}" \
             --build-arg GOSUMDB="${GOSUMDB}" \
+            --build-arg GO_VERSION="${GO_VERSION}" \
+            --build-arg CHDB_VERSION="${CHDB_VERSION}" \
             -f Dockerfile.e2e -t sobs-e2e:ci .
 
   rum-build:
@@ -216,6 +238,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+
+      - name: Verify GO_VERSION/CHDB_VERSION pins match versions.env
+        run: python3 scripts/check_version_pins.py
+
       - name: Install linting dependencies
         # Pinned: an unpinned `djlint` picked up a new release mid-migration whose H042/T039
         # checks false-positive on <label for> paired with a <textarea id> and on a nested
@@ -260,6 +286,9 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load pinned build versions (versions.env)
+        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
 
       - name: Resolve build version
         id: build_version
@@ -313,6 +342,8 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push multi-arch Docker image
+        # GO_VERSION/CHDB_VERSION come from versions.env (loaded above) — the single source of
+        # truth shared with the go-build-test, docker-go-smoke, and playwright-e2e jobs.
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -323,6 +354,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SOBS_BUILD_VERSION=${{ steps.build_version.outputs.value }}
+            GO_VERSION=${{ env.GO_VERSION }}
+            CHDB_VERSION=${{ env.CHDB_VERSION }}
           cache-from: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-buildcache
           cache-to: type=registry,ref=registry-cache.ci-cache.svc.cluster.local:5000/sobs-buildcache,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Load pinned build versions (versions.env)
-        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+        uses: ./.github/actions/load-versions-env
 
       - name: Set up Docker Buildx (in-cluster registry mirror + buildcache)
         uses: docker/setup-buildx-action@v4
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Load pinned build versions (versions.env)
-        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+        uses: ./.github/actions/load-versions-env
 
       - name: Build the stripped-down Go image
         # --network=host: the dind sidecar shares the runner pod's network namespace, so the build can
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Load pinned build versions (versions.env)
-        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+        uses: ./.github/actions/load-versions-env
 
       - name: Build and run the E2E suite (Dockerfile.e2e)
         # --network=host: same reasoning as docker-go-smoke — the dind sidecar shares the runner
@@ -288,7 +288,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Load pinned build versions (versions.env)
-        run: grep -v -e '^#' -e '^$' versions.env >> "$GITHUB_ENV"
+        uses: ./.github/actions/load-versions-env
 
       - name: Resolve build version
         id: build_version

--- a/Dockerfile.capture
+++ b/Dockerfile.capture
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates git build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# GO_VERSION/CHDB_VERSION: see versions.env (repo root) — checked by scripts/check_version_pins.py.
 ARG GO_VERSION=1.23.4
 RUN curl -4 -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar -C /usr/local -xz
 ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -21,6 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # --- layer: Go toolchain (busts only on GO_VERSION) ---
+# Defaults to the versions.env pin (repo root) shared with Dockerfile.go/Dockerfile.e2e; CI
+# always passes it explicitly as --build-arg (see .github/workflows/ci.yml), and
+# scripts/check_version_pins.py fails the lint job if this default drifts from versions.env.
 ARG GO_VERSION=1.23.4
 RUN curl -4 -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
 ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
@@ -31,6 +34,7 @@ ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
     GOCACHE=/root/.cache/go-build
 
 # --- layer: pinned libchdb (busts only on CHDB_VERSION) ---
+# Defaults to the versions.env pin, same as GO_VERSION above.
 ARG CHDB_VERSION=v26.5.0
 RUN mkdir -p /opt/libchdb \
     && curl -4 -fsSL "https://github.com/chdb-io/chdb-core/releases/download/${CHDB_VERSION}/linux-x86_64-libchdb.tar.gz" \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -21,9 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # --- layer: Go toolchain (busts only on GO_VERSION) ---
-# Defaults to the versions.env pin (repo root) shared with Dockerfile.go/Dockerfile.e2e; CI
-# always passes it explicitly as --build-arg (see .github/workflows/ci.yml), and
-# scripts/check_version_pins.py fails the lint job if this default drifts from versions.env.
+# GO_VERSION/CHDB_VERSION: see versions.env (repo root) — checked by scripts/check_version_pins.py.
 ARG GO_VERSION=1.23.4
 RUN curl -4 -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
 ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
@@ -34,7 +32,6 @@ ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
     GOCACHE=/root/.cache/go-build
 
 # --- layer: pinned libchdb (busts only on CHDB_VERSION) ---
-# Defaults to the versions.env pin, same as GO_VERSION above.
 ARG CHDB_VERSION=v26.5.0
 RUN mkdir -p /opt/libchdb \
     && curl -4 -fsSL "https://github.com/chdb-io/chdb-core/releases/download/${CHDB_VERSION}/linux-x86_64-libchdb.tar.gz" \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -21,9 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # --- layer: Go toolchain (arch-matched like Dockerfile.go's TARGETARCH; busts only on GO_VERSION) ---
-# GO_VERSION is hand-duplicated from Dockerfile.ci's own ARG of the same name — bumping the Go
-# toolchain means updating both files (Dockerfile.go pins via its `golang:1.23-bookworm` base
-# image tag instead, so check that one too). No shared source of truth exists yet.
+# Defaults to the versions.env pin (repo root) — the single source of truth shared with
+# Dockerfile.ci and Dockerfile.go; CI always passes it explicitly as --build-arg (see
+# .github/workflows/ci.yml), and scripts/check_version_pins.py fails the lint job if this
+# default drifts from versions.env.
 ARG TARGETARCH
 ARG GO_VERSION=1.23.4
 ARG GOPROXY=https://proxy.golang.org,direct
@@ -42,9 +43,7 @@ ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
     GOCACHE=/root/.cache/go-build
 
 # --- layer: pinned libchdb (matches go/CHDB_PIN.md; arch-matched; busts only on CHDB_VERSION) ---
-# CHDB_VERSION is hand-duplicated from Dockerfile.ci's and Dockerfile.go's own ARGs of the same
-# name (all three ultimately should match go/CHDB_PIN.md) — this exact pin has drifted out of
-# sync across copies before; bumping it here means bumping it in those files too.
+# Defaults to the versions.env pin, same as GO_VERSION above.
 ARG CHDB_VERSION=v26.5.0
 RUN case "${TARGETARCH}" in \
       amd64) chdb_asset=linux-x86_64-libchdb.tar.gz ;; \

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -21,10 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # --- layer: Go toolchain (arch-matched like Dockerfile.go's TARGETARCH; busts only on GO_VERSION) ---
-# Defaults to the versions.env pin (repo root) — the single source of truth shared with
-# Dockerfile.ci and Dockerfile.go; CI always passes it explicitly as --build-arg (see
-# .github/workflows/ci.yml), and scripts/check_version_pins.py fails the lint job if this
-# default drifts from versions.env.
+# GO_VERSION/CHDB_VERSION: see versions.env (repo root) — checked by scripts/check_version_pins.py.
 ARG TARGETARCH
 ARG GO_VERSION=1.23.4
 ARG GOPROXY=https://proxy.golang.org,direct
@@ -43,7 +40,6 @@ ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
     GOCACHE=/root/.cache/go-build
 
 # --- layer: pinned libchdb (matches go/CHDB_PIN.md; arch-matched; busts only on CHDB_VERSION) ---
-# Defaults to the versions.env pin, same as GO_VERSION above.
 ARG CHDB_VERSION=v26.5.0
 RUN case "${TARGETARCH}" in \
       amd64) chdb_asset=linux-x86_64-libchdb.tar.gz ;; \

--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -6,10 +6,7 @@
 # libchdb.so + templates/ + static/. The server self-initializes its chdb schema on first run
 # (ensureSchema), so a fresh container with an empty /data volume comes up serving immediately.
 
-# GO_VERSION/CHDB_VERSION default to the pins in versions.env (repo root) — the single source
-# of truth shared with Dockerfile.ci and Dockerfile.e2e; CI always passes both explicitly as
-# --build-arg (see .github/workflows/ci.yml), and scripts/check_version_pins.py fails the lint
-# job if these defaults drift from versions.env.
+# GO_VERSION/CHDB_VERSION: see versions.env (repo root) — checked by scripts/check_version_pins.py.
 ARG GO_VERSION=1.23.4
 FROM golang:${GO_VERSION}-bookworm AS builder
 ARG TARGETARCH
@@ -30,8 +27,7 @@ RUN cd go && CGO_ENABLED=1 go build -trimpath -o /out/sobs ./cmd/sobs
 
 # Pinned chdb-core — the native build Python chdb 4.1.9 ships (see go/CHDB_PIN.md). The Go
 # store must read/write the same on-disk ClickHouse format, so this version is frozen, never latest.
-# Arch-matched (amd64 / arm64) so the image is multi-arch like the Python one. Defaults to the
-# versions.env pin like GO_VERSION above; CI always passes it explicitly.
+# Arch-matched (amd64 / arm64) so the image is multi-arch like the Python one.
 ARG CHDB_VERSION=v26.5.0
 RUN set -eux; \
     case "${TARGETARCH}" in \

--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -6,7 +6,12 @@
 # libchdb.so + templates/ + static/. The server self-initializes its chdb schema on first run
 # (ensureSchema), so a fresh container with an empty /data volume comes up serving immediately.
 
-FROM golang:1.23-bookworm AS builder
+# GO_VERSION/CHDB_VERSION default to the pins in versions.env (repo root) — the single source
+# of truth shared with Dockerfile.ci and Dockerfile.e2e; CI always passes both explicitly as
+# --build-arg (see .github/workflows/ci.yml), and scripts/check_version_pins.py fails the lint
+# job if these defaults drift from versions.env.
+ARG GO_VERSION=1.23.4
+FROM golang:${GO_VERSION}-bookworm AS builder
 ARG TARGETARCH
 # GOPROXY/GOSUMDB default to Go's normal values so unparameterized builds are unaffected; CI on the
 # egress-restricted cluster passes --build-arg GOPROXY=<in-cluster Athens> GOSUMDB=off.
@@ -23,9 +28,11 @@ COPY go/ ./go/
 # The runtime image is glibc-based (debian-slim), so the dynamic binary loads fine.
 RUN cd go && CGO_ENABLED=1 go build -trimpath -o /out/sobs ./cmd/sobs
 
-# Pinned chdb-core v26.5.0 — the native build Python chdb 4.1.9 ships (see go/CHDB_PIN.md). The Go
+# Pinned chdb-core — the native build Python chdb 4.1.9 ships (see go/CHDB_PIN.md). The Go
 # store must read/write the same on-disk ClickHouse format, so this version is frozen, never latest.
-# Arch-matched (amd64 / arm64) so the image is multi-arch like the Python one.
+# Arch-matched (amd64 / arm64) so the image is multi-arch like the Python one. Defaults to the
+# versions.env pin like GO_VERSION above; CI always passes it explicitly.
+ARG CHDB_VERSION=v26.5.0
 RUN set -eux; \
     case "${TARGETARCH}" in \
       amd64) asset=linux-x86_64-libchdb.tar.gz ;; \
@@ -33,7 +40,7 @@ RUN set -eux; \
       *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/libchdb.tar.gz \
-      "https://github.com/chdb-io/chdb-core/releases/download/v26.5.0/${asset}"; \
+      "https://github.com/chdb-io/chdb-core/releases/download/${CHDB_VERSION}/${asset}"; \
     mkdir -p /out/lib; tar -xzf /tmp/libchdb.tar.gz -C /out/lib; test -f /out/lib/libchdb.so
 
 FROM debian:bookworm-slim

--- a/Dockerfile.go.dev
+++ b/Dockerfile.go.dev
@@ -5,7 +5,9 @@
 # save (a few-second Go compile — the dev-loop replacement for Quart's reloader). Not a production
 # artifact (use Dockerfile.go for that).
 
-FROM golang:1.23-bookworm
+# GO_VERSION/CHDB_VERSION: see versions.env (repo root) — checked by scripts/check_version_pins.py.
+ARG GO_VERSION=1.23.4
+FROM golang:${GO_VERSION}-bookworm
 ARG TARGETARCH
 
 # air live-reload tool (pinned).
@@ -17,7 +19,8 @@ WORKDIR /src/go
 COPY go/go.mod go/go.sum ./
 RUN go mod download
 
-# Pinned chdb-core v26.5.0 native lib (arch-matched), same as the prod image.
+# Pinned chdb-core native lib (arch-matched), same as the prod image.
+ARG CHDB_VERSION=v26.5.0
 RUN set -eux; \
     case "${TARGETARCH}" in \
       amd64) asset=linux-x86_64-libchdb.tar.gz ;; \
@@ -25,7 +28,7 @@ RUN set -eux; \
       *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/libchdb.tar.gz \
-      "https://github.com/chdb-io/chdb-core/releases/download/v26.5.0/${asset}"; \
+      "https://github.com/chdb-io/chdb-core/releases/download/${CHDB_VERSION}/${asset}"; \
     mkdir -p /opt/libchdb; tar -xzf /tmp/libchdb.tar.gz -C /opt/libchdb; test -f /opt/libchdb/libchdb.so
 
 ENV CHDB_LIB_PATH=/opt/libchdb/libchdb.so \

--- a/go/CHDB_PIN.md
+++ b/go/CHDB_PIN.md
@@ -1,5 +1,12 @@
 # chdb / chdb-core / chdb-go version pin
 
+> The live CHDB_VERSION pin used by every build (CI and local) is `versions.env` at the
+> repo root — `scripts/check_version_pins.py` fails CI if any Dockerfile drifts from it.
+> The `v26.5.0` you'll see below is that same current value; the "Record the exact pins
+> here once verified" block further down is a dated, frozen record of the one-time
+> Python↔Go compatibility gate, not something this doc re-derives automatically — bump
+> `versions.env` first on a version change, then update this file's own copy by hand.
+
 **The single most important version decision in this migration.** The Go process must
 read and write the *same* on-disk `data/sobs.chdb` that Python `chdb 4.1.9` created. The
 underlying ClickHouse storage format must be compatible across both engines, so both
@@ -57,10 +64,12 @@ For parity/dev we keep the pinned `libchdb.so` under `.libchdb/` (gitignored, 32
 and export `CHDB_LIB_PATH=$REPO/.libchdb/libchdb.so`. For the Docker image, COPY the
 pinned `libchdb.so` into the image and set `CHDB_LIB_PATH` (Phase 5).
 
-Download the pinned lib:
+Download the pinned lib (sourcing the version from `versions.env` so this can't drift;
+works from anywhere inside the repo):
 ```
+CHDB_VERSION=$(grep '^CHDB_VERSION=' "$(git rev-parse --show-toplevel)/versions.env" | cut -d= -f2)
 curl -sL -o libchdb.tar.gz \
-  https://github.com/chdb-io/chdb-core/releases/download/v26.5.0/macos-arm64-libchdb.tar.gz
+  "https://github.com/chdb-io/chdb-core/releases/download/${CHDB_VERSION}/macos-arm64-libchdb.tar.gz"
 # (linux-x86_64-libchdb.tar.gz / linux-aarch64-libchdb.tar.gz for the deploy targets)
 tar -xzf libchdb.tar.gz   # -> libchdb.so, chdb.h, chdb.hpp
 ```

--- a/go/goldenreplay/pinned_env.json
+++ b/go/goldenreplay/pinned_env.json
@@ -1,0 +1,12 @@
+{
+  "SOBS_PARITY": "1",
+  "SOBS_SECRET_KEY": "parity-fixed-secret-key",
+  "SOBS_SESSION_COOKIE_NAME": "sobs_session",
+  "SOBS_SESSION_COOKIE_SAMESITE": "Lax",
+  "SOBS_BASE_PATH": "",
+  "SOBS_ENABLE_FIRST_RUN_TOUR": "0",
+  "SOBS_SUMMARY_STATS_CACHE_TTL_SEC": "0",
+  "SOBS_FAKE_EPOCH": "1704164645.0",
+  "SOURCE_MAP_ENABLE": "0",
+  "TZ": "America/Phoenix"
+}

--- a/go/goldenreplay/replay_test.go
+++ b/go/goldenreplay/replay_test.go
@@ -16,6 +16,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -35,30 +36,33 @@ import (
 
 const testdataDir = "../testdata"
 
-// pinnedEnv mirrors migration/tools/parity_env.sh verbatim — the frozen environment both
+// pinnedEnvJSON mirrors migration/tools/parity_env.sh verbatim — the frozen environment both
 // the Python oracle and the Go server were replayed under to produce the golden corpus.
-// migration/ is deleted post-cutover, so this is the permanent record of that pin.
-// scripts/e2e_server.py's PINNED_ENV is a separate hand-kept copy of this same map for the
-// Playwright E2E suite — update both together (see that file's own comment).
-var pinnedEnv = map[string]string{
-	"SOBS_PARITY":                      "1",
-	"SOBS_SECRET_KEY":                  "parity-fixed-secret-key",
-	"SOBS_SESSION_COOKIE_NAME":         "sobs_session",
-	"SOBS_SESSION_COOKIE_SAMESITE":     "Lax",
-	"SOBS_BASE_PATH":                   "",
-	"SOBS_ENABLE_FIRST_RUN_TOUR":       "0",
-	"SOBS_SUMMARY_STATS_CACHE_TTL_SEC": "0",
-	"SOBS_FAKE_EPOCH":                  "1704164645.0",
-	"SOURCE_MAP_ENABLE":                "0",
-	// chdb's embedded ClickHouse engine formats DateTime columns (e.g. hyperdx_sessions.Timestamp)
-	// to strings using the PROCESS's system timezone — a chdb-internal behavior entirely outside
-	// SOBS_FAKE_EPOCH's app-level clock override (the same class of gotcha as chdb's now() reading
-	// real vDSO time). The frozen golden corpus was captured on a host with TZ=America/Phoenix
-	// (fixed MST, no DST); replaying on a host/container with a different system TZ (e.g. a UTC
-	// CI runner) silently reformats those same underlying values to different strings, byte-diffing
-	// as a MISMATCH despite identical underlying data. Pinning TZ here — like SOBS_FAKE_EPOCH pins
-	// the app clock — makes the corpus portable to any machine, not just the one that captured it.
-	"TZ": "America/Phoenix",
+// migration/ is deleted post-cutover, so pinned_env.json is the permanent record of that pin.
+// scripts/e2e_server.py loads the same pinned_env.json for the Playwright E2E suite, so this
+// is the single source of truth for both — edit pinned_env.json, not either Go/Python copy.
+//
+// One entry needs an explanation JSON can't carry as a comment: chdb's embedded ClickHouse
+// engine formats DateTime columns (e.g. hyperdx_sessions.Timestamp) to strings using the
+// PROCESS's system timezone — a chdb-internal behavior entirely outside SOBS_FAKE_EPOCH's
+// app-level clock override (the same class of gotcha as chdb's now() reading real vDSO time).
+// The frozen golden corpus was captured on a host with TZ=America/Phoenix (fixed MST, no DST);
+// replaying on a host/container with a different system TZ (e.g. a UTC CI runner) silently
+// reformats those same underlying values to different strings, byte-diffing as a MISMATCH
+// despite identical underlying data. Pinning TZ — like SOBS_FAKE_EPOCH pins the app clock —
+// makes the corpus portable to any machine, not just the one that captured it.
+//
+//go:embed pinned_env.json
+var pinnedEnvJSON []byte
+
+var pinnedEnv = mustParsePinnedEnv(pinnedEnvJSON)
+
+func mustParsePinnedEnv(data []byte) map[string]string {
+	var env map[string]string
+	if err := json.Unmarshal(data, &env); err != nil {
+		panic(fmt.Sprintf("goldenreplay: parsing pinned_env.json: %v", err))
+	}
+	return env
 }
 
 var buildOnce sync.Once

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -2,10 +2,16 @@
 """Fail if any Dockerfile's ARG GO_VERSION/CHDB_VERSION default has drifted from the
 canonical pin in versions.env (repo root).
 
-CI itself always builds with the canonical values passed explicitly as --build-arg (see
-.github/workflows/ci.yml), so this doesn't catch a CI build using the wrong version — it
-catches a Dockerfile's *default* (what a plain `docker build .` outside CI would use)
-silently going stale, which is exactly how these three pins drifted out of sync before.
+CI itself always builds Dockerfile.ci/.go/.e2e with the canonical values passed explicitly
+as --build-arg (see .github/workflows/ci.yml), so this doesn't catch a CI build using the
+wrong version there — it catches a Dockerfile's *default* (what a plain `docker build .`
+outside CI would use) silently going stale, which is exactly how these pins drifted out of
+sync before. For the local-only dev Dockerfiles (Dockerfile.capture, Dockerfile.go.dev),
+which nothing ever passes --build-arg to, the default IS the value actually used, so this
+check is the only thing keeping them pinned correctly at all.
+
+Every repo-root `Dockerfile*` that declares `ARG GO_VERSION=` or `ARG CHDB_VERSION=` is
+checked automatically — nothing to update here when a new one is added.
 """
 
 from __future__ import annotations
@@ -16,7 +22,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VERSIONS_FILE = REPO_ROOT / "versions.env"
-DOCKERFILES = ["Dockerfile.ci", "Dockerfile.go", "Dockerfile.e2e"]
 
 
 def load_versions() -> dict[str, str]:
@@ -35,18 +40,23 @@ def find_arg_default(dockerfile_text: str, name: str) -> str | None:
     return match.group(1) if match else None
 
 
+def find_pinned_dockerfiles(versions: dict[str, str]) -> list[Path]:
+    candidates = sorted(p for p in REPO_ROOT.glob("Dockerfile*") if p.is_file())
+    return [path for path in candidates if any(find_arg_default(path.read_text(), name) for name in versions)]
+
+
 def main() -> int:
     versions = load_versions()
+    dockerfiles = find_pinned_dockerfiles(versions)
     errors = []
-    for filename in DOCKERFILES:
-        path = REPO_ROOT / filename
+    for path in dockerfiles:
         text = path.read_text()
         for name, expected in versions.items():
             actual = find_arg_default(text, name)
             if actual is None:
-                errors.append(f"{filename}: no 'ARG {name}=' default found")
+                errors.append(f"{path.name}: declares another pinned ARG but no 'ARG {name}=' default found")
             elif actual != expected:
-                errors.append(f"{filename}: ARG {name} default is {actual!r}, versions.env pins {expected!r}")
+                errors.append(f"{path.name}: ARG {name} default is {actual!r}, versions.env pins {expected!r}")
 
     if errors:
         print("Version pin drift detected (versions.env is the source of truth):", file=sys.stderr)
@@ -54,7 +64,8 @@ def main() -> int:
             print(f"  - {error}", file=sys.stderr)
         return 1
 
-    print(f"OK: {', '.join(DOCKERFILES)} all match versions.env ({versions})")
+    names = ", ".join(path.name for path in dockerfiles)
+    print(f"OK: {names} all match versions.env ({versions})")
     return 0
 
 

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Fail if any Dockerfile's ARG GO_VERSION/CHDB_VERSION default has drifted from the
+canonical pin in versions.env (repo root).
+
+CI itself always builds with the canonical values passed explicitly as --build-arg (see
+.github/workflows/ci.yml), so this doesn't catch a CI build using the wrong version — it
+catches a Dockerfile's *default* (what a plain `docker build .` outside CI would use)
+silently going stale, which is exactly how these three pins drifted out of sync before.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSIONS_FILE = REPO_ROOT / "versions.env"
+DOCKERFILES = ["Dockerfile.ci", "Dockerfile.go", "Dockerfile.e2e"]
+
+
+def load_versions() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for line in VERSIONS_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        versions[key] = value
+    return versions
+
+
+def find_arg_default(dockerfile_text: str, name: str) -> str | None:
+    match = re.search(rf"^ARG {re.escape(name)}=(\S+)", dockerfile_text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    versions = load_versions()
+    errors = []
+    for filename in DOCKERFILES:
+        path = REPO_ROOT / filename
+        text = path.read_text()
+        for name, expected in versions.items():
+            actual = find_arg_default(text, name)
+            if actual is None:
+                errors.append(f"{filename}: no 'ARG {name}=' default found")
+            elif actual != expected:
+                errors.append(f"{filename}: ARG {name} default is {actual!r}, versions.env pins {expected!r}")
+
+    if errors:
+        print("Version pin drift detected (versions.env is the source of truth):", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {', '.join(DOCKERFILES)} all match versions.env ({versions})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e_server.py
+++ b/scripts/e2e_server.py
@@ -14,6 +14,7 @@ sends the command process a termination signal on teardown) reaches the server d
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -24,20 +25,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 GO_DIR = REPO_ROOT / "go"
 FIXTURES_DIR = GO_DIR / "testdata" / "fixtures"
 
-# Mirrors go/goldenreplay/replay_test.go's pinnedEnv verbatim — the frozen environment the
-# golden corpus was captured under. Kept in sync by hand; if that map changes, update this too.
-PINNED_ENV = {
-    "SOBS_PARITY": "1",
-    "SOBS_SECRET_KEY": "parity-fixed-secret-key",
-    "SOBS_SESSION_COOKIE_NAME": "sobs_session",
-    "SOBS_SESSION_COOKIE_SAMESITE": "Lax",
-    "SOBS_BASE_PATH": "",
-    "SOBS_ENABLE_FIRST_RUN_TOUR": "0",
-    "SOBS_SUMMARY_STATS_CACHE_TTL_SEC": "0",
-    "SOBS_FAKE_EPOCH": "1704164645.0",
-    "SOURCE_MAP_ENABLE": "0",
-    "TZ": "America/Phoenix",
-}
+# The single source of truth for the frozen environment the golden corpus was captured
+# under — go/goldenreplay/replay_test.go embeds this same file as its pinnedEnv. Edit
+# pinned_env.json, not either Go/Python copy, to change the pin.
+PINNED_ENV_FILE = GO_DIR / "goldenreplay" / "pinned_env.json"
+PINNED_ENV: dict[str, str] = json.loads(PINNED_ENV_FILE.read_text())
 
 DEFAULT_PORT = 48173
 

--- a/scripts/e2e_server.py
+++ b/scripts/e2e_server.py
@@ -29,7 +29,12 @@ FIXTURES_DIR = GO_DIR / "testdata" / "fixtures"
 # under — go/goldenreplay/replay_test.go embeds this same file as its pinnedEnv. Edit
 # pinned_env.json, not either Go/Python copy, to change the pin.
 PINNED_ENV_FILE = GO_DIR / "goldenreplay" / "pinned_env.json"
-PINNED_ENV: dict[str, str] = json.loads(PINNED_ENV_FILE.read_text())
+try:
+    PINNED_ENV: dict[str, str] = json.loads(PINNED_ENV_FILE.read_text())
+except FileNotFoundError:
+    sys.exit(f"{PINNED_ENV_FILE} is missing — it should be git-tracked; check your checkout")
+except json.JSONDecodeError as e:
+    sys.exit(f"{PINNED_ENV_FILE} is not valid JSON: {e}")
 
 DEFAULT_PORT = 48173
 

--- a/versions.env
+++ b/versions.env
@@ -1,12 +1,16 @@
-# Canonical pin for the Go toolchain and chdb-core native library versions used across
-# Dockerfile.ci, Dockerfile.go, and Dockerfile.e2e (see go/CHDB_PIN.md for why CHDB_VERSION
-# is frozen). This file is the single source of truth:
-#   - .github/workflows/ci.yml loads it into each build job's env and passes both values as
-#     --build-arg / build-args to every `docker build` invocation across all three Dockerfiles.
-#   - scripts/check_version_pins.py (run by the lint job) fails CI if any Dockerfile's
+# Canonical pin for the Go toolchain and chdb-core native library versions used across every
+# Dockerfile that builds a Go toolchain or downloads libchdb (Dockerfile.ci, Dockerfile.go,
+# Dockerfile.e2e, Dockerfile.capture, Dockerfile.go.dev — see go/CHDB_PIN.md for why
+# CHDB_VERSION is frozen). This file is the single source of truth:
+#   - .github/workflows/ci.yml loads it into each CI build job's env and passes both values as
+#     --build-arg / build-args to every `docker build` invocation of Dockerfile.ci/.go/.e2e (the
+#     three that run in CI; Dockerfile.capture and Dockerfile.go.dev are local-only dev tools
+#     invoked without CI-supplied build-args, so their ARG defaults are what's actually used).
+#   - scripts/check_version_pins.py (run by the lint job) fails CI if any of the 5 Dockerfiles'
 #     `ARG GO_VERSION=` / `ARG CHDB_VERSION=` default line drifts from the values below —
 #     those defaults only matter for a manual `docker build` run outside CI, but they should
-#     never lie about what CI actually builds with.
+#     never lie about what CI actually builds with (or, for the two local-only Dockerfiles,
+#     about what they actually build with, full stop).
 #
 # Comment lines (and blank lines) are stripped before this file is appended to $GITHUB_ENV,
 # so keep the data lines below in plain KEY=VALUE form.

--- a/versions.env
+++ b/versions.env
@@ -1,0 +1,14 @@
+# Canonical pin for the Go toolchain and chdb-core native library versions used across
+# Dockerfile.ci, Dockerfile.go, and Dockerfile.e2e (see go/CHDB_PIN.md for why CHDB_VERSION
+# is frozen). This file is the single source of truth:
+#   - .github/workflows/ci.yml loads it into each build job's env and passes both values as
+#     --build-arg / build-args to every `docker build` invocation across all three Dockerfiles.
+#   - scripts/check_version_pins.py (run by the lint job) fails CI if any Dockerfile's
+#     `ARG GO_VERSION=` / `ARG CHDB_VERSION=` default line drifts from the values below —
+#     those defaults only matter for a manual `docker build` run outside CI, but they should
+#     never lie about what CI actually builds with.
+#
+# Comment lines (and blank lines) are stripped before this file is appended to $GITHUB_ENV,
+# so keep the data lines below in plain KEY=VALUE form.
+GO_VERSION=1.23.4
+CHDB_VERSION=v26.5.0


### PR DESCRIPTION
## Problem

`GO_VERSION`/`CHDB_VERSION` were pinned independently by hand in three places:
- `Dockerfile.ci` (`ARG GO_VERSION`, `ARG CHDB_VERSION`)
- `Dockerfile.go` (Go pinned via the `golang:1.23-bookworm` base image tag instead of an ARG; chdb pinned via a literal `v26.5.0` in a curl URL)
- `Dockerfile.e2e` (added in #455, with comments explicitly noting the pin had drifted out of sync across copies before)

Separately, `scripts/e2e_server.py`'s `PINNED_ENV` dict hand-duplicated `go/goldenreplay/replay_test.go`'s `pinnedEnv` map — the frozen environment the golden-corpus harness captures/replays under — with a comment saying "kept in sync by hand."

Both gaps were flagged during #455's review and fixed there only with cross-reference comments, not actual deduplication.

## What changed

**1. Version pins → `versions.env`**
- New canonical file at repo root: `GO_VERSION=1.23.4`, `CHDB_VERSION=v26.5.0`.
- `Dockerfile.go` converted from a hardcoded `golang:1.23-bookworm` base tag + literal `v26.5.0` curl URL to `ARG`-driven, matching `Dockerfile.ci`/`Dockerfile.e2e`'s existing pattern.
- `ci.yml` now loads `versions.env` into each build job's env and passes both values as explicit `--build-arg`/`build-args` in all 4 docker-build invocations (`go-build-test`, `docker-go-smoke`, `playwright-e2e`, and the release `docker` job) — CI genuinely builds from the one file now.
- New `scripts/check_version_pins.py`, run from the `lint` job, fails CI if any Dockerfile's `ARG` default drifts from `versions.env` (protects manual/local `docker build` runs, which fall back to the defaults).

**2. `pinnedEnv`/`PINNED_ENV` → `go/goldenreplay/pinned_env.json`**
- `replay_test.go` now `go:embed`s and `json.Unmarshal`s this file instead of a hardcoded map literal.
- `scripts/e2e_server.py` now `json.loads()` the same file instead of a hand-copied dict.
- The TZ-formatting gotcha explanation (chdb DateTime columns format using process TZ) moved to a doc comment since JSON can't carry inline comments.

## Verification

- gofmt/black/isort/flake8 all clean; `go build`/`vet`/`test ./...` all pass
- Native `TestGoldenCorpus` golden-corpus replay: **GREEN**, run against a freshly downloaded, hash-verified libchdb (the shared system copy had itself drifted from the pin — a good illustration of why this matters)
- `Dockerfile.go` builds and smoke-tests cleanly with the new ARG wiring (verified `/health`, `/health/db`, `/api/reports`, `/`)
- `Dockerfile.e2e` builds cleanly and all **44 Playwright specs pass** against the JSON-loaded `PINNED_ENV`
- `Dockerfile.ci` reaches `gofmt` and both ARG-driven download layers cleanly in a local build, then hits a QEMU emulation artifact unrelated to this change (arm64 host emulating its hardcoded amd64 Go toolchain); its `GOPROXY` is also hardcoded to the in-cluster Athens proxy, so it only fully builds on the real CI runners regardless — this is pre-existing and untouched by this PR
- No runtime behavior changed, so `go/testdata/golden.tar.gz` was **not** regenerated

## Notes for reviewers

- `versions.env` strips to `KEY=VALUE` lines only (comments/blank lines filtered before being appended to `$GITHUB_ENV` in CI) — keep new entries in that plain form.
- `scripts/check_version_pins.py` only guards the Dockerfiles' *default* ARG values (what a plain `docker build .` outside CI uses); CI itself always builds from the explicit `--build-arg` values now, so this is a defense-in-depth check, not the primary enforcement.